### PR TITLE
fix: make cost-report skill warehouse-agnostic

### DIFF
--- a/.altimate-code/skills/cost-report/SKILL.md
+++ b/.altimate-code/skills/cost-report/SKILL.md
@@ -1,116 +1,92 @@
 ---
 name: cost-report
-description: Analyze Snowflake query costs and identify optimization opportunities
+description: Analyze warehouse query costs and identify optimization opportunities. Use when reviewing cloud data warehouse spending, finding expensive queries, or generating cost optimization reports for Snowflake, BigQuery, Databricks, or PostgreSQL.
 ---
 
 # Cost Report
 
 ## Requirements
 **Agent:** any (read-only analysis)
-**Tools used:** sql_execute, sql_analyze, sql_predict_cost, sql_record_feedback
+**Tools used:** `warehouse_list`, `finops_expensive_queries`, `finops_analyze_credits`, `finops_warehouse_advice`, `finops_unused_resources`, `sql_analyze`, `sql_predict_cost`, `sql_record_feedback`, `sql_execute`
 
-Analyze Snowflake warehouse query costs, identify the most expensive queries, detect anti-patterns, and recommend optimizations.
+Generate a cost analysis report for any connected data warehouse. Identifies expensive queries, detects anti-patterns, and recommends optimizations.
 
 ## Workflow
 
-1. **Query SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY** for the top 20 most expensive queries by credits used:
+1. **Detect warehouse** — Call `warehouse_list` to discover connected warehouses. Identify the warehouse type (Snowflake, BigQuery, Databricks, PostgreSQL). If multiple connections exist, ask the user which to analyze.
 
-   ```sql
-   SELECT
-       query_id,
-       query_text,
-       user_name,
-       warehouse_name,
-       query_type,
-       credits_used_cloud_services,
-       bytes_scanned,
-       rows_produced,
-       total_elapsed_time,
-       execution_status,
-       start_time
-   FROM SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY
-   WHERE start_time >= DATEADD('day', -30, CURRENT_TIMESTAMP())
-     AND execution_status = 'SUCCESS'
-     AND credits_used_cloud_services > 0
-   ORDER BY credits_used_cloud_services DESC
-   LIMIT 20;
-   ```
+2. **Gather cost data** — Branch by warehouse type:
 
-   Use `sql_execute` to run this query against the connected Snowflake warehouse.
+   **Snowflake** — Use the built-in FinOps tools (no raw SQL needed):
+   - `finops_expensive_queries` with `days` and `limit` parameters → returns top expensive queries
+   - `finops_analyze_credits` with `days` parameter → returns daily credit breakdown by warehouse, total credits, and recommendations
+   - `finops_warehouse_advice` → returns warehouse sizing and load analysis
+   - `finops_unused_resources` → returns stale tables and idle warehouses
 
-2. **Group and summarize** the results by:
-   - **User**: Which users are driving the most cost?
-   - **Warehouse**: Which warehouses consume the most credits?
-   - **Query type**: SELECT vs INSERT vs CREATE TABLE AS SELECT vs MERGE, etc.
+   **BigQuery, Databricks, PostgreSQL** — Load the appropriate reference file for warehouse-specific queries:
+   - Read [references/bigquery-cost-queries.md](references/bigquery-cost-queries.md) for BigQuery
+   - Read [references/databricks-cost-queries.md](references/databricks-cost-queries.md) for Databricks
+   - Read [references/postgres-cost-queries.md](references/postgres-cost-queries.md) for PostgreSQL
 
-   Present each grouping as a markdown table.
+   Run the queries from the reference file using `sql_execute`.
 
-3. **Analyze the top offenders** - For each of the top 10 most expensive queries:
-   - Run `sql_analyze` on the query text to detect anti-patterns (SELECT *, missing LIMIT, cartesian products, correlated subqueries, etc.)
-   - Run `sql_predict_cost` to get the cost tier prediction based on historical feedback data
-   - Summarize anti-patterns found and their severity
+3. **Analyze top offenders** — For the top 10 most expensive queries from step 2:
+   - Run `sql_analyze` on each query's SQL text (pass the correct `dialect`) to detect anti-patterns
+   - Run `sql_predict_cost` to get cost tier predictions based on historical feedback
 
-4. **Classify each query into a cost tier**:
+4. **Record feedback** — For each analyzed query, call `sql_record_feedback` with execution metrics (`bytes_scanned`, `execution_time_ms`, `credits_used`, `warehouse_size`) to improve future predictions.
 
-   | Tier | Credits | Label | Action |
-   |------|---------|-------|--------|
-   | 1 | < $0.01 | Cheap | No action needed |
-   | 2 | $0.01 - $1.00 | Moderate | Review if frequent |
-   | 3 | $1.00 - $100.00 | Expensive | Optimize or review warehouse sizing |
-   | 4 | > $100.00 | Dangerous | Immediate review required |
-
-5. **Record feedback** - For each query analyzed, call `sql_record_feedback` to store the execution metrics so future predictions improve:
-   - Pass `bytes_scanned`, `execution_time_ms`, `credits_used`, and `warehouse_size` from the query history results
-
-6. **Output the final report** as a structured markdown document:
+5. **Output the report** in this standardized format (regardless of warehouse type):
 
    ```
-   # Snowflake Cost Report (Last 30 Days)
+   # Cost Report — {Warehouse Type} (Last {N} Days)
 
    ## Summary
-   - Total credits consumed: X
-   - Number of unique queries: Y
-   - Most expensive query: Z credits
+   - Total cost: {credits or dollars}
+   - Queries analyzed: {count}
+   - Most expensive query: {cost}
+   - Anti-patterns found: {count}
 
-   ## Cost by User
-   | User | Total Credits | Query Count | Avg Credits/Query |
-   |------|--------------|-------------|-------------------|
+   ## Cost by Dimension
+   | {User/Principal} | Total Cost | Query Count | Avg Cost/Query |
+   |------------------|-----------|-------------|----------------|
 
-   ## Cost by Warehouse
-   | Warehouse | Total Credits | Query Count | Avg Credits/Query |
-   |-----------|--------------|-------------|-------------------|
+   | {Warehouse/Project/Cluster} | Total Cost | Query Count | Avg Cost/Query |
+   |-----------------------------|-----------|-------------|----------------|
 
-   ## Cost by Query Type
-   | Query Type | Total Credits | Query Count | Avg Credits/Query |
-   |------------|--------------|-------------|-------------------|
+   ## Top 10 Expensive Queries
 
-   ## Top 10 Expensive Queries (Detailed Analysis)
-
-   ### Query 1 (X credits) - DANGEROUS
-   **User:** user_name | **Warehouse:** wh_name | **Type:** SELECT
+   ### Query 1 — {cost} — {TIER}
+   **User:** {name} | **Warehouse:** {name} | **Type:** {SELECT/INSERT/...}
    **Anti-patterns found:**
-   - SELECT_STAR (warning): Query uses SELECT * ...
-   - MISSING_LIMIT (info): ...
-
+   - {pattern}: {description}
    **Optimization suggestions:**
-   1. Select only needed columns
-   2. Add LIMIT clause
-   3. Consider partitioning strategy
-
-   **Cost prediction:** Tier 1 (fingerprint match, high confidence)
+   1. {suggestion}
+   **Cost prediction:** {tier} ({confidence})
 
    ...
 
    ## Recommendations
-   1. Top priority optimizations
-   2. Warehouse sizing suggestions
-   3. Scheduling recommendations
+   1. {Top priority optimizations}
+   2. {Warehouse/cluster sizing suggestions}
+   3. {Unused resource cleanup opportunities}
    ```
+
+### Cost Tiers
+
+| Tier | Cost | Label | Action |
+|------|------|-------|--------|
+| 1 | Minimal | Cheap | No action needed |
+| 2 | Low–moderate | Moderate | Review if frequent |
+| 3 | High | Expensive | Optimize or review sizing |
+| 4 | Very high | Dangerous | Immediate review required |
+
+Tier thresholds vary by warehouse — Snowflake measures credits, BigQuery measures bytes billed, Databricks measures DBUs, PostgreSQL measures execution time.
 
 ## Usage
 
-The user invokes this skill with:
-- `/cost-report` -- Analyze the last 30 days
-- `/cost-report 7` -- Analyze the last 7 days (adjust the DATEADD interval)
+- `/cost-report` — Analyze the last 30 days on the default warehouse
+- `/cost-report 7` — Analyze the last 7 days
+- `/cost-report my_warehouse 14` — Analyze a specific connection for 14 days
 
-Use the tools: `sql_execute`, `sql_analyze`, `sql_predict_cost`, `sql_record_feedback`.
+Use the tools: `warehouse_list`, `finops_expensive_queries`, `finops_analyze_credits`, `finops_warehouse_advice`, `finops_unused_resources`, `sql_analyze`, `sql_predict_cost`, `sql_record_feedback`, `sql_execute`.

--- a/.altimate-code/skills/cost-report/references/bigquery-cost-queries.md
+++ b/.altimate-code/skills/cost-report/references/bigquery-cost-queries.md
@@ -1,0 +1,88 @@
+# BigQuery Cost Queries
+
+Use `sql_execute` to run these queries against the connected BigQuery warehouse. Adjust the region and date range as needed.
+
+## Top Expensive Queries (by bytes billed)
+
+```sql
+SELECT
+    job_id,
+    query,
+    user_email,
+    total_bytes_billed,
+    total_slot_ms,
+    ROUND(total_bytes_billed / POW(1024, 4), 4) AS estimated_tb_billed,
+    ROUND((total_bytes_billed / POW(1024, 4)) * 6.25, 4) AS estimated_cost_usd,
+    statement_type,
+    creation_time,
+    end_time,
+    TIMESTAMP_DIFF(end_time, creation_time, SECOND) AS duration_seconds
+FROM `region-us`.INFORMATION_SCHEMA.JOBS_BY_PROJECT
+WHERE creation_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
+  AND state = 'DONE'
+  AND error_result IS NULL
+  AND statement_type != 'SCRIPT'
+  AND total_bytes_billed > 0
+ORDER BY total_bytes_billed DESC
+LIMIT @limit
+```
+
+Replace `@days` with the number of days (default 30) and `@limit` with the query count (default 20). Change `region-us` to match the dataset region.
+
+## Cost by User
+
+```sql
+SELECT
+    user_email,
+    COUNT(*) AS query_count,
+    SUM(total_bytes_billed) AS total_bytes_billed,
+    ROUND(SUM(total_bytes_billed) / POW(1024, 4) * 6.25, 2) AS total_cost_usd,
+    ROUND(AVG(total_bytes_billed) / POW(1024, 4) * 6.25, 4) AS avg_cost_per_query_usd
+FROM `region-us`.INFORMATION_SCHEMA.JOBS_BY_PROJECT
+WHERE creation_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
+  AND state = 'DONE'
+  AND error_result IS NULL
+  AND total_bytes_billed > 0
+GROUP BY user_email
+ORDER BY total_bytes_billed DESC
+```
+
+## Cost by Dataset
+
+```sql
+SELECT
+    referenced_table.dataset_id AS dataset,
+    COUNT(DISTINCT job_id) AS query_count,
+    SUM(total_bytes_billed) AS total_bytes_billed,
+    ROUND(SUM(total_bytes_billed) / POW(1024, 4) * 6.25, 2) AS total_cost_usd
+FROM `region-us`.INFORMATION_SCHEMA.JOBS_BY_PROJECT,
+UNNEST(referenced_tables) AS referenced_table
+WHERE creation_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
+  AND state = 'DONE'
+  AND error_result IS NULL
+GROUP BY dataset
+ORDER BY total_bytes_billed DESC
+```
+
+## Slot Utilization
+
+```sql
+SELECT
+    TIMESTAMP_TRUNC(period_start, HOUR) AS hour,
+    SUM(period_slot_ms) / 3600000 AS avg_slots_used
+FROM `region-us`.INFORMATION_SCHEMA.JOBS_TIMELINE_BY_PROJECT
+WHERE period_start >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days DAY)
+GROUP BY hour
+ORDER BY hour DESC
+```
+
+## Cost Thresholds
+
+| Tier | Bytes Billed | Est. Cost (on-demand) | Label |
+|------|-------------|----------------------|-------|
+| 1 | < 1 GB | < $0.006 | Cheap |
+| 2 | 1 GB – 100 GB | $0.006 – $0.625 | Moderate |
+| 3 | 100 GB – 10 TB | $0.625 – $62.50 | Expensive |
+| 4 | > 10 TB | > $62.50 | Dangerous |
+
+On-demand pricing: $6.25/TB. Flat-rate/editions pricing varies by commitment.

--- a/.altimate-code/skills/cost-report/references/databricks-cost-queries.md
+++ b/.altimate-code/skills/cost-report/references/databricks-cost-queries.md
@@ -1,0 +1,88 @@
+# Databricks Cost Queries
+
+Use `sql_execute` to run these queries against the connected Databricks warehouse. Requires access to the `system` catalog.
+
+## Top Expensive Queries (by read bytes)
+
+```sql
+SELECT
+    statement_id,
+    statement_text,
+    executed_by,
+    read_bytes,
+    ROUND(read_bytes / POW(1024, 3), 2) AS read_gb,
+    total_duration_ms,
+    ROUND(total_duration_ms / 1000.0, 1) AS duration_seconds,
+    warehouse_id,
+    compute_resources_dbus AS dbus_consumed,
+    status,
+    start_time,
+    end_time
+FROM system.query.history
+WHERE start_time >= DATEADD(DAY, -@days, CURRENT_TIMESTAMP())
+  AND status = 'FINISHED'
+  AND read_bytes > 0
+ORDER BY read_bytes DESC
+LIMIT @limit
+```
+
+Replace `@days` with the number of days (default 30) and `@limit` with the query count (default 20).
+
+## Cost by User
+
+```sql
+SELECT
+    executed_by,
+    COUNT(*) AS query_count,
+    SUM(read_bytes) AS total_read_bytes,
+    ROUND(SUM(read_bytes) / POW(1024, 3), 2) AS total_read_gb,
+    SUM(compute_resources_dbus) AS total_dbus,
+    ROUND(AVG(total_duration_ms) / 1000.0, 1) AS avg_duration_seconds
+FROM system.query.history
+WHERE start_time >= DATEADD(DAY, -@days, CURRENT_TIMESTAMP())
+  AND status = 'FINISHED'
+GROUP BY executed_by
+ORDER BY total_read_bytes DESC
+```
+
+## Cost by Warehouse
+
+```sql
+SELECT
+    warehouse_id,
+    COUNT(*) AS query_count,
+    SUM(read_bytes) AS total_read_bytes,
+    ROUND(SUM(read_bytes) / POW(1024, 3), 2) AS total_read_gb,
+    SUM(compute_resources_dbus) AS total_dbus,
+    ROUND(AVG(total_duration_ms) / 1000.0, 1) AS avg_duration_seconds
+FROM system.query.history
+WHERE start_time >= DATEADD(DAY, -@days, CURRENT_TIMESTAMP())
+  AND status = 'FINISHED'
+GROUP BY warehouse_id
+ORDER BY total_read_bytes DESC
+```
+
+## DBU Usage Over Time
+
+```sql
+SELECT
+    DATE_TRUNC('DAY', start_time) AS day,
+    SUM(compute_resources_dbus) AS total_dbus,
+    COUNT(*) AS query_count
+FROM system.query.history
+WHERE start_time >= DATEADD(DAY, -@days, CURRENT_TIMESTAMP())
+  AND status = 'FINISHED'
+GROUP BY day
+ORDER BY day DESC
+```
+
+## Cost Thresholds
+
+| Tier | DBUs | Label |
+|------|------|-------|
+| 1 | < 0.1 | Cheap |
+| 2 | 0.1 – 10 | Moderate |
+| 3 | 10 – 100 | Expensive |
+| 4 | > 100 | Dangerous |
+
+Actual cost depends on DBU pricing for your workspace tier (Standard, Premium, Enterprise) and compute type (SQL Serverless, Pro, Classic).

--- a/.altimate-code/skills/cost-report/references/postgres-cost-queries.md
+++ b/.altimate-code/skills/cost-report/references/postgres-cost-queries.md
@@ -1,0 +1,102 @@
+# PostgreSQL Cost Queries
+
+Use `sql_execute` to run these queries against the connected PostgreSQL warehouse. Requires the `pg_stat_statements` extension to be enabled.
+
+## Check pg_stat_statements is Available
+
+```sql
+SELECT * FROM pg_available_extensions WHERE name = 'pg_stat_statements';
+```
+
+If not enabled, the DBA must run `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;` and restart the server.
+
+## Top Expensive Queries (by execution time)
+
+```sql
+SELECT
+    queryid,
+    LEFT(query, 500) AS query_text,
+    calls,
+    ROUND(total_exec_time::numeric, 2) AS total_exec_time_ms,
+    ROUND(mean_exec_time::numeric, 2) AS mean_exec_time_ms,
+    ROUND((shared_blks_hit + shared_blks_read)::numeric * 8 / 1024, 2) AS total_mb_processed,
+    shared_blks_hit,
+    shared_blks_read,
+    CASE
+        WHEN shared_blks_hit + shared_blks_read > 0
+        THEN ROUND(shared_blks_hit::numeric / (shared_blks_hit + shared_blks_read) * 100, 1)
+        ELSE 0
+    END AS cache_hit_pct,
+    rows
+FROM pg_stat_statements
+ORDER BY total_exec_time DESC
+LIMIT @limit
+```
+
+Replace `@limit` with the query count (default 20). PostgreSQL does not have a built-in date filter on `pg_stat_statements` — statistics are cumulative since the last reset. Use `pg_stat_statements_reset()` to reset counters.
+
+## Cost by Query Pattern
+
+```sql
+SELECT
+    queryid,
+    LEFT(query, 200) AS query_pattern,
+    calls,
+    ROUND(total_exec_time::numeric / 1000, 2) AS total_exec_seconds,
+    ROUND(mean_exec_time::numeric, 2) AS mean_exec_time_ms,
+    rows AS total_rows_returned,
+    ROUND(rows::numeric / NULLIF(calls, 0), 0) AS avg_rows_per_call
+FROM pg_stat_statements
+WHERE calls > 1
+ORDER BY total_exec_time DESC
+LIMIT 50
+```
+
+## Table I/O Statistics
+
+```sql
+SELECT
+    schemaname,
+    relname AS table_name,
+    seq_scan,
+    seq_tup_read,
+    idx_scan,
+    idx_tup_fetch,
+    n_tup_ins + n_tup_upd + n_tup_del AS total_writes,
+    pg_size_pretty(pg_total_relation_size(relid)) AS total_size
+FROM pg_stat_user_tables
+ORDER BY seq_tup_read DESC
+LIMIT 20
+```
+
+## Index Usage
+
+```sql
+SELECT
+    schemaname,
+    relname AS table_name,
+    indexrelname AS index_name,
+    idx_scan,
+    idx_tup_read,
+    idx_tup_fetch,
+    pg_size_pretty(pg_relation_size(indexrelid)) AS index_size
+FROM pg_stat_user_indexes
+WHERE idx_scan = 0
+ORDER BY pg_relation_size(indexrelid) DESC
+LIMIT 20
+```
+
+This query finds **unused indexes** — indexes that consume storage but are never scanned.
+
+## Cost Thresholds
+
+PostgreSQL has no direct cost metric like credits or bytes billed. Use execution time as a proxy:
+
+| Tier | Total Exec Time | Label |
+|------|----------------|-------|
+| 1 | < 100 ms | Cheap |
+| 2 | 100 ms – 10 s | Moderate |
+| 3 | 10 s – 5 min | Expensive |
+| 4 | > 5 min | Dangerous |
+
+For RDS/Aurora, cross-reference with CloudWatch metrics (ReadIOPS, WriteIOPS, CPUUtilization) and the AWS Cost Explorer for actual dollar costs.


### PR DESCRIPTION
## Summary
- Remove hardcoded Snowflake `ACCOUNT_USAGE.QUERY_HISTORY` SQL from `cost-report` skill
- Use existing FinOps tools (`finops_expensive_queries`, `finops_analyze_credits`, `finops_warehouse_advice`, `finops_unused_resources`) for the Snowflake path
- Add `references/` directory with warehouse-specific cost queries for BigQuery, Databricks, and PostgreSQL
- Add `warehouse_list` detection as the first workflow step
- Add "Use when" trigger phrasing to description for better LLM auto-activation

## Test plan
- [ ] Verify skill loads correctly and `references/` files are discoverable
- [ ] Test Snowflake path uses FinOps tools (no raw SQL)
- [ ] Test BigQuery/Databricks/Postgres paths load correct reference file

🤖 Generated with [Claude Code](https://claude.com/claude-code)