### PR TITLE
fix: npm publish glob and PyPI skip-existing for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/altimate-engine/dist/
+          skip-existing: true
 
   github-release:
     name: Create GitHub Release

--- a/packages/altimate-code/script/publish.ts
+++ b/packages/altimate-code/script/publish.ts
@@ -8,7 +8,7 @@ const dir = fileURLToPath(new URL("..", import.meta.url))
 process.chdir(dir)
 
 const binaries: Record<string, string> = {}
-for (const filepath of new Bun.Glob("*/package.json").scanSync({ cwd: "./dist" })) {
+for (const filepath of new Bun.Glob("**/package.json").scanSync({ cwd: "./dist" })) {
   const pkg = await Bun.file(`./dist/${filepath}`).json()
   binaries[pkg.name] = pkg.version
 }


### PR DESCRIPTION
## Summary

- **npm publish fix**: Change glob in `publish.ts` from `*/package.json` to `**/package.json` to find scoped package directories (`@altimate/cli-*`) which create nested paths 2 levels deep under `dist/`
- **PyPI skip-existing**: Add `skip-existing: true` to the PyPI publish action so releases don't fail when the engine version hasn't changed

Both issues caused v0.1.6 release to fail at the publish stage.

## Test plan

- [ ] Merge and re-tag v0.1.7 to verify both publish steps pass
- [ ] Verify `binaries` object is populated (not `{}`) in npm publish logs
- [ ] Verify PyPI step shows "skipping" instead of 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)