### PR TITLE
fix: CI test failures for TypeScript and Python jobs

### DIFF
--- a/packages/altimate-code/test/fixture/fixture.ts
+++ b/packages/altimate-code/test/fixture/fixture.ts
@@ -24,9 +24,9 @@ export async function tmpdir<T>(options?: TmpDirOptions<T>) {
   }
   if (options?.config) {
     await Bun.write(
-      path.join(dirpath, "opencode.json"),
+      path.join(dirpath, "altimate-code.json"),
       JSON.stringify({
-        $schema: "https://opencode.ai/config.json",
+        $schema: "https://altimate-code.dev/config.json",
         ...options.config,
       }),
     )

--- a/packages/altimate-engine/pyproject.toml
+++ b/packages/altimate-engine/pyproject.toml
@@ -28,6 +28,7 @@ warehouses = [
 security = ["keyring>=24.0"]
 docker = ["docker>=7.0"]
 tunneling = ["sshtunnel>=0.4", "paramiko>=3.0"]
+dev = ["pytest>=7.0", "ruff>=0.1"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/altimate_engine"]


### PR DESCRIPTION
## Summary

- **TypeScript tests:** Test fixture was writing config to `opencode.json` but the config loader (after the rename) only looks for `altimate-code.json`. Updated the fixture to write to the correct filename.
- **Python tests:** `pytest: command not found` because `pyproject.toml` had no `dev` optional dependency group. Added `dev = ["pytest>=7.0", "ruff>=0.1"]` so `pip install -e ".[dev]"` works.

## Test plan

- [x] `bun test test/permission-task.test.ts` — all 21 tests pass locally
- [ ] CI should pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)