### PR TITLE
docs: prioritize Data Engineering in nav, fix faint section headers

### DIFF
--- a/docs/docs/assets/css/extra.css
+++ b/docs/docs/assets/css/extra.css
@@ -1,0 +1,9 @@
+/* Make nav section headers more prominent */
+.md-nav--primary > .md-nav__list > .md-nav__item--section > .md-nav__link {
+  font-weight: 700;
+  color: var(--md-default-fg-color);
+  text-transform: uppercase;
+  font-size: 0.65rem;
+  letter-spacing: 0.05em;
+  opacity: 1;
+}

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -35,6 +35,9 @@ theme:
     - search.highlight
     - content.code.copy
 
+extra_css:
+  - assets/css/extra.css
+
 markdown_extensions:
   - admonition
   - pymdownx.details
@@ -47,6 +50,22 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
+  - Data Engineering:
+      - Agent Modes: data-engineering/agent-modes.md
+      - Tools:
+          - Overview: data-engineering/tools/index.md
+          - SQL Tools: data-engineering/tools/sql-tools.md
+          - Schema Tools: data-engineering/tools/schema-tools.md
+          - FinOps Tools: data-engineering/tools/finops-tools.md
+          - Lineage Tools: data-engineering/tools/lineage-tools.md
+          - dbt Tools: data-engineering/tools/dbt-tools.md
+          - Warehouse Tools: data-engineering/tools/warehouse-tools.md
+      - Guides:
+          - Overview: data-engineering/guides/index.md
+          - Cost Optimization: data-engineering/guides/cost-optimization.md
+          - Migration: data-engineering/guides/migration.md
+          - Using with Claude Code: data-engineering/guides/using-with-claude-code.md
+          - Using with Codex: data-engineering/guides/using-with-codex.md
   - Usage:
       - TUI: usage/tui.md
       - CLI: usage/cli.md
@@ -76,22 +95,6 @@ nav:
           - LSP Servers: configure/lsp.md
           - MCP Servers: configure/mcp-servers.md
           - ACP Support: configure/acp.md
-  - Data Engineering:
-      - Agent Modes: data-engineering/agent-modes.md
-      - Tools:
-          - Overview: data-engineering/tools/index.md
-          - SQL Tools: data-engineering/tools/sql-tools.md
-          - Schema Tools: data-engineering/tools/schema-tools.md
-          - FinOps Tools: data-engineering/tools/finops-tools.md
-          - Lineage Tools: data-engineering/tools/lineage-tools.md
-          - dbt Tools: data-engineering/tools/dbt-tools.md
-          - Warehouse Tools: data-engineering/tools/warehouse-tools.md
-      - Guides:
-          - Overview: data-engineering/guides/index.md
-          - Cost Optimization: data-engineering/guides/cost-optimization.md
-          - Migration: data-engineering/guides/migration.md
-          - Using with Claude Code: data-engineering/guides/using-with-claude-code.md
-          - Using with Codex: data-engineering/guides/using-with-codex.md
   - Develop:
       - SDK: develop/sdk.md
       - Server: develop/server.md


### PR DESCRIPTION
## Summary

Two changes to improve the docs sidebar from a data engineer's perspective:

### 1. Reorder nav to prioritize Data Engineering

**Before:** Getting Started → Usage → Configure → Data Engineering → ...
**After:** Getting Started → **Data Engineering** → Usage → Configure → ...

As a data engineering tool, agent modes, SQL/dbt/FinOps tools, and guides should be the first thing users see — not buried below 20+ configuration items. The new order matches the user journey:

1. **Install** (Getting Started)
2. **Use the data tools** (Data Engineering)
3. **Learn the interfaces** (Usage)
4. **Customize** (Configure)
5. **Extend** (Develop)
6. **Troubleshoot** (Reference)

### 2. Fix faint section headers

Section headers (DATA ENGINEERING, USAGE, CONFIGURE, etc.) were nearly invisible with the `primary: white` theme. Added custom CSS (`assets/css/extra.css`) to make them:

- **Bold** (font-weight: 700)
- **Uppercase** with letter spacing
- **Full contrast** (uses default foreground color instead of faded gray)

## Test plan

- [x] `mkdocs build` — zero errors
- [x] All 44 pages return HTTP 200
- [x] Custom CSS loads correctly
- [x] Nav order: Data Engineering appears before Usage/Configure
- [ ] Visual review of section header styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)