### PR TITLE
feat: route telemetry directly to Azure Application Insights

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "altimate-code",

--- a/packages/altimate-code/src/config/config.ts
+++ b/packages/altimate-code/src/config/config.ts
@@ -1184,6 +1184,12 @@ export namespace Config {
             .describe("Token buffer for compaction. Leaves enough window to avoid overflow during compaction."),
         })
         .optional(),
+      telemetry: z
+        .object({
+          disabled: z.boolean().optional().describe("Disable usage telemetry (default: false)"),
+        })
+        .optional()
+        .describe("Telemetry settings"),
       experimental: z
         .object({
           disable_paste_summary: z.boolean().optional(),

--- a/packages/altimate-code/src/id/id.ts
+++ b/packages/altimate-code/src/id/id.ts
@@ -1,5 +1,7 @@
 import z from "zod"
-import { randomBytes } from "crypto"
+import { monotonicFactory, decodeTime } from "ulid"
+
+const ulid = monotonicFactory()
 
 export namespace Identifier {
   const prefixes = {
@@ -13,71 +15,51 @@ export namespace Identifier {
     tool: "tool",
   } as const
 
+  // Crockford base32 alphabet used by ULID
+  const CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+  // Invert each character within the Crockford alphabet so the ID sorts in reverse chronological order
+  function invert(id: string): string {
+    return id
+      .split("")
+      .map((c) => {
+        const idx = CROCKFORD.indexOf(c.toUpperCase())
+        return idx === -1 ? c : CROCKFORD[31 - idx]
+      })
+      .join("")
+  }
+
   export function schema(prefix: keyof typeof prefixes) {
     return z.string().startsWith(prefixes[prefix])
   }
 
-  const LENGTH = 26
-
-  // State for monotonic ID generation
-  let lastTimestamp = 0
-  let counter = 0
-
-  export function ascending(prefix: keyof typeof prefixes, given?: string) {
-    return generateID(prefix, false, given)
+  export function ascending(prefix: keyof typeof prefixes, given?: string): string {
+    if (given) {
+      if (!given.startsWith(prefixes[prefix])) throw new Error(`ID ${given} does not start with ${prefixes[prefix]}`)
+      return given
+    }
+    return prefixes[prefix] + "_" + ulid()
   }
 
-  export function descending(prefix: keyof typeof prefixes, given?: string) {
-    return generateID(prefix, true, given)
+  export function descending(prefix: keyof typeof prefixes, given?: string): string {
+    if (given) {
+      if (!given.startsWith(prefixes[prefix])) throw new Error(`ID ${given} does not start with ${prefixes[prefix]}`)
+      return given
+    }
+    return prefixes[prefix] + "_" + invert(ulid())
   }
 
-  function generateID(prefix: keyof typeof prefixes, descending: boolean, given?: string): string {
-    if (!given) {
-      return create(prefix, descending)
-    }
-
-    if (!given.startsWith(prefixes[prefix])) {
-      throw new Error(`ID ${given} does not start with ${prefixes[prefix]}`)
-    }
-    return given
-  }
-
-  function randomBase62(length: number): string {
-    const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-    let result = ""
-    const bytes = randomBytes(length)
-    for (let i = 0; i < length; i++) {
-      result += chars[bytes[i] % 62]
-    }
-    return result
-  }
-
-  export function create(prefix: keyof typeof prefixes, descending: boolean, timestamp?: number): string {
-    const currentTimestamp = timestamp ?? Date.now()
-
-    if (currentTimestamp !== lastTimestamp) {
-      lastTimestamp = currentTimestamp
-      counter = 0
-    }
-    counter++
-
-    let now = BigInt(currentTimestamp) * BigInt(0x1000) + BigInt(counter)
-
-    now = descending ? ~now : now
-
-    const timeBytes = Buffer.alloc(6)
-    for (let i = 0; i < 6; i++) {
-      timeBytes[i] = Number((now >> BigInt(40 - 8 * i)) & BigInt(0xff))
-    }
-
-    return prefixes[prefix] + "_" + timeBytes.toString("hex") + randomBase62(LENGTH - 12)
+  export function create(prefix: keyof typeof prefixes, desc: boolean, timestamp?: number): string {
+    const id = ulid(timestamp)
+    return prefixes[prefix] + "_" + (desc ? invert(id) : id)
   }
 
   /** Extract timestamp from an ascending ID. Does not work with descending IDs. */
   export function timestamp(id: string): number {
-    const prefix = id.split("_")[0]
-    const hex = id.slice(prefix.length + 1, prefix.length + 13)
-    const encoded = BigInt("0x" + hex)
-    return Number(encoded / BigInt(0x1000))
+    const ulidPart = id.slice(id.indexOf("_") + 1)
+    if (ulidPart.charCodeAt(0) > "9".charCodeAt(0)) {
+      throw new Error("timestamp() does not work with descending IDs")
+    }
+    return decodeTime(ulidPart)
   }
 }

--- a/packages/altimate-code/src/telemetry/index.ts
+++ b/packages/altimate-code/src/telemetry/index.ts
@@ -1,4 +1,5 @@
 import { Control } from "@/control"
+import { Config } from "@/config/config"
 import { Installation } from "@/installation"
 import { Log } from "@/util/log"
 
@@ -108,56 +109,106 @@ export namespace Telemetry {
         tokens_pruned: number
       }
 
-  type Batch = {
-    session_id: string
-    cli_version: string
-    user_email: string
-    project_id: string
-    timestamp: number
-    events: Event[]
+  type AppInsightsConfig = {
+    iKey: string
+    endpoint: string // e.g. https://xxx.applicationinsights.azure.com/v2/track
   }
 
   let enabled = false
-  let authenticated = false
   let buffer: Event[] = []
   let flushTimer: ReturnType<typeof setInterval> | undefined
-  let accountUrl = ""
-  let cachedToken = ""
   let userEmail = ""
   let sessionId = ""
   let projectId = ""
+  let appInsights: AppInsightsConfig | undefined
+
+  function parseConnectionString(cs: string): AppInsightsConfig | undefined {
+    const parts: Record<string, string> = {}
+    for (const segment of cs.split(";")) {
+      const idx = segment.indexOf("=")
+      if (idx === -1) continue
+      parts[segment.slice(0, idx).trim()] = segment.slice(idx + 1).trim()
+    }
+    const iKey = parts["InstrumentationKey"]
+    const ingestionEndpoint = parts["IngestionEndpoint"]
+    if (!iKey || !ingestionEndpoint) return undefined
+    const base = ingestionEndpoint.endsWith("/") ? ingestionEndpoint : ingestionEndpoint + "/"
+    return { iKey, endpoint: `${base}v2/track` }
+  }
+
+  function toAppInsightsEnvelopes(events: Event[], cfg: AppInsightsConfig): object[] {
+    return events.map((event) => {
+      const { type, timestamp, ...fields } = event as any
+      const sid: string = fields.session_id ?? sessionId
+
+      const properties: Record<string, string> = {
+        cli_version: Installation.VERSION,
+        project_id: fields.project_id ?? projectId,
+      }
+      const measurements: Record<string, number> = {}
+
+      // Flatten all fields — nested `tokens` object gets prefixed keys
+      for (const [k, v] of Object.entries(fields)) {
+        if (k === "session_id" || k === "project_id") continue
+        if (k === "tokens" && typeof v === "object" && v !== null) {
+          for (const [tk, tv] of Object.entries(v as Record<string, unknown>)) {
+            if (typeof tv === "number") measurements[`tokens_${tk}`] = tv
+          }
+        } else if (typeof v === "number") {
+          measurements[k] = v
+        } else if (v !== undefined && v !== null) {
+          properties[k] = typeof v === "object" ? JSON.stringify(v) : String(v)
+        }
+      }
+
+      return {
+        name: `Microsoft.ApplicationInsights.${cfg.iKey}.Event`,
+        time: new Date(timestamp).toISOString(),
+        iKey: cfg.iKey,
+        tags: {
+          "ai.session.id": sid,
+          "ai.user.id": userEmail,
+          "ai.cloud.role": "altimate-code",
+          "ai.application.ver": Installation.VERSION,
+        },
+        data: {
+          baseType: "EventData",
+          baseData: {
+            ver: 2,
+            name: type,
+            properties,
+            measurements,
+          },
+        },
+      }
+    })
+  }
+
+  // Instrumentation key is intentionally public — safe to hardcode in client-side tooling.
+  // Override with APPLICATIONINSIGHTS_CONNECTION_STRING env var for local dev / testing.
+  const DEFAULT_CONNECTION_STRING =
+    "InstrumentationKey=5095f5e6-477e-4262-b7ae-2118de18550d;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=6564474f-329b-4b7d-849e-e70cb4181294"
 
   export async function init() {
     if (enabled || flushTimer) return
+    const userConfig = await Config.get()
+    if (userConfig.telemetry?.disabled) return
     try {
+      // App Insights: env var overrides default (for dev/testing), otherwise use the baked-in key
+      const connectionString = process.env.APPLICATIONINSIGHTS_CONNECTION_STRING ?? DEFAULT_CONNECTION_STRING
+      const cfg = parseConnectionString(connectionString)
+      if (!cfg) {
+        enabled = false
+        return
+      }
+      appInsights = cfg
       const account = Control.account()
-      if (account) {
-        const token = await Control.token()
-        if (token) {
-          accountUrl = account.url
-          cachedToken = token
-          userEmail = account.email
-          authenticated = true
-        }
-      }
-
-      // Fall back to env var for anonymous users
-      if (!accountUrl) {
-        const envUrl = process.env.ALTIMATE_TELEMETRY_URL
-        if (!envUrl) {
-          enabled = false
-          return
-        }
-        accountUrl = envUrl
-      }
-
+      if (account) userEmail = account.email
       enabled = true
-
+      log.info("telemetry initialized", { mode: "appinsights" })
       const timer = setInterval(flush, FLUSH_INTERVAL_MS)
       if (typeof timer === "object" && timer && "unref" in timer) (timer as any).unref()
       flushTimer = timer
-
-      log.info("telemetry initialized", { authenticated })
     } catch {
       enabled = false
     }
@@ -181,54 +232,26 @@ export namespace Telemetry {
   }
 
   export async function flush() {
-    if (!enabled || buffer.length === 0) return
+    if (!enabled || buffer.length === 0 || !appInsights) return
 
     const events = buffer.splice(0, buffer.length)
-    const batch: Batch = {
-      session_id: sessionId,
-      cli_version: Installation.VERSION,
-      user_email: userEmail,
-      project_id: projectId,
-      timestamp: Date.now(),
-      events,
-    }
 
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
     try {
-      const headers: Record<string, string> = { "Content-Type": "application/json" }
-      if (authenticated && cachedToken) {
-        headers["Authorization"] = `Bearer ${cachedToken}`
-      }
-
-      const controller = new AbortController()
-      const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
-
-      const response = await fetch(`${accountUrl}/api/observability/ingest`, {
+      const response = await fetch(appInsights.endpoint, {
         method: "POST",
-        headers,
-        body: JSON.stringify(batch),
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(toAppInsightsEnvelopes(events, appInsights)),
         signal: controller.signal,
       })
-      clearTimeout(timeout)
-
-      if (authenticated && response.status === 401) {
-        const newToken = await Control.token()
-        if (!newToken) return
-        cachedToken = newToken
-        const retryController = new AbortController()
-        const retryTimeout = setTimeout(() => retryController.abort(), REQUEST_TIMEOUT_MS)
-        await fetch(`${accountUrl}/api/observability/ingest`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${cachedToken}`,
-          },
-          body: JSON.stringify(batch),
-          signal: retryController.signal,
-        })
-        clearTimeout(retryTimeout)
+      if (!response.ok) {
+        log.debug("telemetry flush failed", { status: response.status })
       }
     } catch {
       // Silently drop on failure — telemetry must never break the CLI
+    } finally {
+      clearTimeout(timeout)
     }
   }
 
@@ -239,7 +262,7 @@ export namespace Telemetry {
     }
     await flush()
     enabled = false
-    authenticated = false
+    appInsights = undefined
     buffer = []
     sessionId = ""
     projectId = ""


### PR DESCRIPTION
## Summary

- **Telemetry**: Migrates from posting batches to `altimate-backend /api/observability/ingest` to posting directly to Azure Application Insights (`/v2/track`), eliminating backend dependency and auth complexity
- **ID module**: Replaces hand-rolled timestamp+base62 generator with the `ulid` npm package, using `monotonicFactory()` to preserve same-millisecond ordering guarantees

## Code Review Fixes (8-model review)

- **`id.ts`**: Use `monotonicFactory()` instead of plain `ulid()` — fixes non-deterministic ordering of IDs generated within the same millisecond
- **`id.ts`**: `timestamp()` now throws a clear error on descending IDs instead of a cryptic `DEC_TIME_MALFORMED` library error
- **`telemetry/index.ts`**: `clearTimeout` moved to `finally` block to prevent timer leak
- **`telemetry/index.ts`**: Log `log.debug` on non-2xx HTTP responses for debuggability
- **`telemetry/index.ts`**: Use `JSON.stringify` for object values instead of `String(v)` to prevent `[object Object]` in `customDimensions`
- **`config.ts`**: Add `telemetry.disabled` config field — opt-out via `~/.config/altimate-code/config.json` (`"telemetry": { "disabled": true }`)

## Test Plan

- [x] Built binary and ran `altimate-code run "say hello in one sentence"`
- [x] Queried Azure App Insights `customEvents` — `session_start`, `generation`, `session_end` all landed with correct `customDimensions` and `customMeasurements`
- [x] Verified `session_Id` standard column populated correctly from `ai.session.id` tag