### PR TITLE
fix: resolve TUI worker startup crash from circular dependency

### DIFF
--- a/packages/altimate-code/src/cli/cmd/tui/thread.ts
+++ b/packages/altimate-code/src/cli/cmd/tui/thread.ts
@@ -117,7 +117,7 @@ export const TuiThreadCommand = cmd({
         ),
       })
       worker.onerror = (e) => {
-        Log.Default.error(e)
+        Log.Default.error(e.message, { error: e.error?.stack ?? e.error ?? String(e) })
       }
       const client = Rpc.client<typeof rpc>(worker)
       process.on("uncaughtException", (e) => {

--- a/packages/altimate-code/src/provider/models.ts
+++ b/packages/altimate-code/src/provider/models.ts
@@ -122,11 +122,15 @@ export namespace ModelsDev {
 }
 
 if (!Flag.ALTIMATE_CLI_DISABLE_MODELS_FETCH && !process.argv.includes("--get-yargs-completions")) {
-  ModelsDev.refresh()
-  setInterval(
-    async () => {
-      await ModelsDev.refresh()
-    },
-    60 * 1000 * 60,
-  ).unref()
+  // Defer initial refresh to avoid circular dependency — Installation may not
+  // be fully initialized when this module is first evaluated.
+  setTimeout(() => {
+    ModelsDev.refresh()
+    setInterval(
+      async () => {
+        await ModelsDev.refresh()
+      },
+      60 * 1000 * 60,
+    ).unref()
+  }, 0)
 }

--- a/packages/altimate-code/test/cli/tui/worker.test.ts
+++ b/packages/altimate-code/test/cli/tui/worker.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test, afterEach } from "bun:test"
+import { Rpc } from "../../../src/util/rpc"
+import type { rpc } from "../../../src/cli/cmd/tui/worker"
+import path from "path"
+import { fileURLToPath } from "url"
+import { Filesystem } from "../../../src/util/filesystem"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const workerSrc = path.resolve(__dirname, "../../../src/cli/cmd/tui/worker.ts")
+
+describe("tui worker", () => {
+  let worker: Worker | undefined
+
+  afterEach(() => {
+    worker?.terminate()
+    worker = undefined
+  })
+
+  test("starts without errors", async () => {
+    const errors: string[] = []
+
+    worker = new Worker(workerSrc, {
+      env: Object.fromEntries(
+        Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+      ),
+    })
+
+    worker.onerror = (e) => {
+      errors.push(e.message ?? String(e))
+    }
+
+    // Give the worker time to initialize — module loading,
+    // top-level awaits, and side effects all run during this window.
+    await new Promise((r) => setTimeout(r, 3000))
+
+    expect(errors).toEqual([])
+  }, 10_000)
+
+  test("responds to RPC calls after startup", async () => {
+    const errors: string[] = []
+
+    worker = new Worker(workerSrc, {
+      env: Object.fromEntries(
+        Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+      ),
+    })
+
+    worker.onerror = (e) => {
+      errors.push(e.message ?? String(e))
+    }
+
+    // Wait for worker to be ready
+    await new Promise((r) => setTimeout(r, 3000))
+    expect(errors).toEqual([])
+
+    // Verify RPC communication works — the worker exports a `fetch` method
+    const client = Rpc.client<typeof rpc>(worker)
+    const result = await Promise.race([
+      client.call("fetch", {
+        url: "http://altimate-code.internal/health",
+        method: "GET",
+        headers: {},
+      }),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("RPC timeout")), 5000)),
+    ])
+
+    expect(result).toBeDefined()
+    expect(typeof result.status).toBe("number")
+  }, 15_000)
+})


### PR DESCRIPTION
## Summary

- **Fixed empty screen on `npm install -g @altimateai/altimate-code@0.2.2`**: The TUI worker thread crashed on startup due to a circular dependency — `ModelsDev.refresh()` ran at module load time and accessed `Installation.USER_AGENT` before the `Installation` module finished initializing (import chain: `worker.ts` → `config.ts` → `models.ts` → `installation`). Deferred the initial refresh via `setTimeout(…, 0)` so all modules are fully loaded first.
- **Improved worker error logging**: The `worker.onerror` handler now extracts `e.message` and `e.error.stack` instead of logging the raw `ErrorEvent` object (which produced the useless `[object ErrorEvent]`).
- **Added e2e test for worker startup**: Spawns the actual TUI worker and asserts it starts without errors and responds to RPC calls. Verified the test catches this exact bug (fails with the fix reverted).

## Test plan

- [x] `bun test test/cli/tui/worker.test.ts` passes (2 tests)
- [x] Verified test fails when fix is reverted (catches `TypeError: undefined is not an object (evaluating 'Installation.USER_AGENT')`)
- [x] `altimate run "hello"` works correctly
- [x] TUI starts without `[object ErrorEvent]` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)