### PR TITLE
fix: address 4 issues found in post-v0.2.2 commits

### DIFF
--- a/docs/docs/security-faq.md
+++ b/docs/docs/security-faq.md
@@ -150,7 +150,12 @@ The engine is not exposed on any network port — it only communicates through s
 
 ## Does Altimate Code store conversation history?
 
-Conversation context lives in memory during your session. Altimate Code does not persist conversation history to disk or send it to any service. When you end a session, the context is gone.
+Yes. Altimate Code persists session data locally on your machine:
+
+- **Session messages** are stored in a local SQLite database so you can resume, review, and revert conversations.
+- **Prompt history** (your recent inputs) is saved to `~/.state/prompt-history.jsonl` for command-line recall.
+
+This data **never** leaves your machine — it is not sent to any service or included in telemetry. You can delete it at any time by removing the local database and history files.
 
 !!! note
     Your LLM provider may have its own data retention policies. Check your provider's terms to understand how they handle API requests.

--- a/packages/altimate-code/script/build.ts
+++ b/packages/altimate-code/script/build.ts
@@ -217,6 +217,7 @@ for (const item of targets) {
       ALTIMATE_CLI_VERSION: `'${Script.version}'`,
       ALTIMATE_CLI_CHANNEL: `'${Script.channel}'`,
       ALTIMATE_ENGINE_VERSION: `'${engineVersion}'`,
+      ALTIMATE_CLI_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "undefined",
       ALTIMATE_CLI_MIGRATIONS: JSON.stringify(migrations),
       ALTIMATE_CLI_CHANGELOG: JSON.stringify(changelog),
       OTUI_TREE_SITTER_WORKER_PATH: bunfsRoot + workerRelativePath,

--- a/packages/altimate-code/src/session/prompt.ts
+++ b/packages/altimate-code/src/session/prompt.ts
@@ -838,15 +838,17 @@ export namespace SessionPrompt {
         compactions: totalCompactions,
         outcome,
       })
-      Telemetry.track({
-        type: "session_end",
-        timestamp: Date.now(),
-        session_id: sessionID,
-        total_cost: sessionTotalCost,
-        total_tokens: sessionTotalTokens,
-        tool_call_count: toolCallCount,
-        duration_ms: Date.now() - sessionStartTime,
-      })
+      if (!emergencySessionEndFired) {
+        Telemetry.track({
+          type: "session_end",
+          timestamp: Date.now(),
+          session_id: sessionID,
+          total_cost: sessionTotalCost,
+          total_tokens: sessionTotalTokens,
+          tool_call_count: toolCallCount,
+          duration_ms: Date.now() - sessionStartTime,
+        })
+      }
       await Telemetry.shutdown()
     }
     for await (const item of MessageV2.stream(sessionID)) {

--- a/packages/altimate-code/test/cli/tui/worker.test.ts
+++ b/packages/altimate-code/test/cli/tui/worker.test.ts
@@ -3,7 +3,6 @@ import { Rpc } from "../../../src/util/rpc"
 import type { rpc } from "../../../src/cli/cmd/tui/worker"
 import path from "path"
 import { fileURLToPath } from "url"
-import { Filesystem } from "../../../src/util/filesystem"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const workerSrc = path.resolve(__dirname, "../../../src/cli/cmd/tui/worker.ts")


### PR DESCRIPTION
## Summary

Deep analysis of all 7 commits since v0.2.2 revealed 4 issues across build, docs, telemetry, and tests:

- **Restore missing `ALTIMATE_CLI_LIBC` build define** — `OPENCODE_LIBC` was removed in commit 04d5941 without being replaced. `watcher.ts` uses this constant to select the correct `@parcel/watcher` binding on Linux; without it, musl-based systems (Alpine, etc.) silently fall back to glibc and file watching breaks.
- **Correct security FAQ on session persistence** — The FAQ claimed "Altimate Code does not persist conversation history to disk," which is factually incorrect. Sessions are stored in SQLite (`session.sql.ts`) and prompt history is saved to `~/.state/prompt-history.jsonl`. Rewrote to accurately describe local persistence while emphasizing data never leaves the machine.
- **Guard duplicate `session_end` telemetry** — The emergency `session_end` handler (for `beforeExit`/`exit`) sets a dedup flag, but the `finally` block fired `session_end` again unconditionally. In normal session completion both paths run, producing duplicate events. Added the missing dedup check.
- **Remove unused `Filesystem` import** in `worker.test.ts`.

## Test plan

- [ ] Verify build succeeds with `bun run script/build.ts --single`
- [ ] Confirm `ALTIMATE_CLI_LIBC` appears in Linux build output (check define block)
- [ ] Review security FAQ reads accurately at `docs/docs/security-faq.md`
- [ ] Run `bun test test/cli/tui/worker.test.ts` to confirm no import errors
- [ ] Verify telemetry logs show exactly one `session_end` event per session

🤖 Generated with [Claude Code](https://claude.com/claude-code)