### PR TITLE
feat: add non-interactive mode to mcp add command

### DIFF
--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -453,6 +453,11 @@ export const McpAddCommand = cmd({
       async fn() {
         // Non-interactive mode: all required args provided via flags
         if (args.name && args.type) {
+          if (!args.name.trim()) {
+            console.error("MCP server name cannot be empty")
+            process.exit(1)
+          }
+
           const useGlobal = args.global || Instance.project.vcs !== "git"
           const configPath = await resolveConfigPath(
             useGlobal ? Global.Path.config : Instance.worktree,
@@ -462,17 +467,21 @@ export const McpAddCommand = cmd({
           let mcpConfig: Config.Mcp
 
           if (args.type === "local") {
-            if (!args.command) {
+            if (!args.command?.trim()) {
               console.error("--command is required for local type")
               process.exit(1)
             }
             mcpConfig = {
               type: "local",
-              command: args.command.split(" "),
+              command: args.command.trim().split(/\s+/).filter(Boolean),
             }
           } else {
             if (!args.url) {
               console.error("--url is required for remote type")
+              process.exit(1)
+            }
+            if (!URL.canParse(args.url)) {
+              console.error(`Invalid URL: ${args.url}`)
               process.exit(1)
             }
 


### PR DESCRIPTION
## Summary

- Add non-interactive mode to `mcp add` command with flags: `--name`, `--type`, `--url`, `--command`, `--header`, `--no-oauth`, `--global`
- Add `mcp remove` (alias `rm`) command to remove MCP servers by name
- Fix `--no-oauth` by using yargs built-in `--no-` negation instead of a custom option
- Fall back to global config when not in a git repo (prevents EROFS errors when running from `~`)

## Test plan

- [ ] Run `altimate-code mcp add --name "test" --type remote --url "https://example.com/sse" --header "Authorization=Bearer token" --no-oauth --global` and verify config is written
- [ ] Run `altimate-code mcp remove test --global` and verify config entry is removed
- [ ] Run `mcp add` from a non-git directory (e.g. `~`) without `--global` and verify it falls back to global config
- [ ] Run `mcp remove` for a server that doesn't exist and verify error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)