### PR TITLE
fix: resolve all test failures from fork restructure

### DIFF
--- a/packages/opencode/bin/altimate-code
+++ b/packages/opencode/bin/altimate-code
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+
+const childProcess = require("child_process")
+const fs = require("fs")
+const path = require("path")
+const os = require("os")
+
+function run(target) {
+  const result = childProcess.spawnSync(target, process.argv.slice(2), {
+    stdio: "inherit",
+  })
+  if (result.error) {
+    console.error(result.error.message)
+    process.exit(1)
+  }
+  const code = typeof result.status === "number" ? result.status : 0
+  process.exit(code)
+}
+
+const envPath = process.env.ALTIMATE_CODE_BIN_PATH
+if (envPath) {
+  run(envPath)
+}
+
+const scriptPath = fs.realpathSync(__filename)
+const scriptDir = path.dirname(scriptPath)
+
+//
+const cached = path.join(scriptDir, ".altimate-code")
+if (fs.existsSync(cached)) {
+  run(cached)
+}
+
+const platformMap = {
+  darwin: "darwin",
+  linux: "linux",
+  win32: "windows",
+}
+const archMap = {
+  x64: "x64",
+  arm64: "arm64",
+  arm: "arm",
+}
+
+let platform = platformMap[os.platform()]
+if (!platform) {
+  platform = os.platform()
+}
+let arch = archMap[os.arch()]
+if (!arch) {
+  arch = os.arch()
+}
+const scope = "@altimateai"
+const base = "altimate-code-" + platform + "-" + arch
+const binary = platform === "windows" ? "altimate-code.exe" : "altimate-code"
+
+function supportsAvx2() {
+  if (arch !== "x64") return false
+
+  if (platform === "linux") {
+    try {
+      return /(^|\s)avx2(\s|$)/i.test(fs.readFileSync("/proc/cpuinfo", "utf8"))
+    } catch {
+      return false
+    }
+  }
+
+  if (platform === "darwin") {
+    try {
+      const result = childProcess.spawnSync("sysctl", ["-n", "hw.optional.avx2_0"], {
+        encoding: "utf8",
+        timeout: 1500,
+      })
+      if (result.status !== 0) return false
+      return (result.stdout || "").trim() === "1"
+    } catch {
+      return false
+    }
+  }
+
+  if (platform === "windows") {
+    const cmd =
+      '(Add-Type -MemberDefinition "[DllImport(""kernel32.dll"")] public static extern bool IsProcessorFeaturePresent(int ProcessorFeature);" -Name Kernel32 -Namespace Win32 -PassThru)::IsProcessorFeaturePresent(40)'
+
+    for (const exe of ["powershell.exe", "pwsh.exe", "pwsh", "powershell"]) {
+      try {
+        const result = childProcess.spawnSync(exe, ["-NoProfile", "-NonInteractive", "-Command", cmd], {
+          encoding: "utf8",
+          timeout: 3000,
+          windowsHide: true,
+        })
+        if (result.status !== 0) continue
+        const out = (result.stdout || "").trim().toLowerCase()
+        if (out === "true" || out === "1") return true
+        if (out === "false" || out === "0") return false
+      } catch {
+        continue
+      }
+    }
+
+    return false
+  }
+
+  return false
+}
+
+const names = (() => {
+  const avx2 = supportsAvx2()
+  const baseline = arch === "x64" && !avx2
+
+  if (platform === "linux") {
+    const musl = (() => {
+      try {
+        if (fs.existsSync("/etc/alpine-release")) return true
+      } catch {
+        // ignore
+      }
+
+      try {
+        const result = childProcess.spawnSync("ldd", ["--version"], { encoding: "utf8" })
+        const text = ((result.stdout || "") + (result.stderr || "")).toLowerCase()
+        if (text.includes("musl")) return true
+      } catch {
+        // ignore
+      }
+
+      return false
+    })()
+
+    if (musl) {
+      if (arch === "x64") {
+        if (baseline) return [`${base}-baseline-musl`, `${base}-musl`, `${base}-baseline`, base]
+        return [`${base}-musl`, `${base}-baseline-musl`, base, `${base}-baseline`]
+      }
+      return [`${base}-musl`, base]
+    }
+
+    if (arch === "x64") {
+      if (baseline) return [`${base}-baseline`, base, `${base}-baseline-musl`, `${base}-musl`]
+      return [base, `${base}-baseline`, `${base}-musl`, `${base}-baseline-musl`]
+    }
+    return [base, `${base}-musl`]
+  }
+
+  if (arch === "x64") {
+    if (baseline) return [`${base}-baseline`, base]
+    return [base, `${base}-baseline`]
+  }
+  return [base]
+})()
+
+function findBinary(startDir) {
+  let current = startDir
+  for (;;) {
+    const modules = path.join(current, "node_modules")
+    if (fs.existsSync(modules)) {
+      for (const name of names) {
+        const candidate = path.join(modules, scope, name, "bin", binary)
+        if (fs.existsSync(candidate)) return candidate
+      }
+    }
+    const parent = path.dirname(current)
+    if (parent === current) {
+      return
+    }
+    current = parent
+  }
+}
+
+const resolved = findBinary(scriptDir)
+if (!resolved) {
+  console.error(
+    "It seems that your package manager failed to install the right version of the altimate-code CLI for your platform. You can try manually installing " +
+      names.map((n) => `\"${scope}/${n}\"`).join(" or ") +
+      " package",
+  )
+  process.exit(1)
+}
+
+run(resolved)

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -15,7 +15,7 @@
   "bin": {
     "opencode": "./bin/opencode",
     "altimate": "./bin/altimate",
-    "altimate-code": "./bin/altimate"
+    "altimate-code": "./bin/altimate-code"
   },
   "exports": {
     "./*": "./src/*.ts"

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -137,6 +137,7 @@ export namespace ACP {
     private eventAbort = new AbortController()
     private eventStarted = false
     private bashSnapshots = new Map<string, string>()
+    private pendingEmitted = new Set<string>()
     private permissionQueues = new Map<string, Promise<void>>()
     private permissionOptions: PermissionOption[] = [
       { optionId: "once", kind: "allow_once", name: "Allow once" },
@@ -290,6 +291,8 @@ export namespace ACP {
           if (part.type === "tool") {
             switch (part.state.status) {
               case "pending":
+                this.bashSnapshots.delete(part.callID)
+                this.pendingEmitted.add(part.callID)
                 await this.connection
                   .sessionUpdate({
                     sessionId,
@@ -309,6 +312,25 @@ export namespace ACP {
                 return
 
               case "running":
+                if (!this.pendingEmitted.has(part.callID)) {
+                  this.pendingEmitted.add(part.callID)
+                  await this.connection
+                    .sessionUpdate({
+                      sessionId,
+                      update: {
+                        sessionUpdate: "tool_call",
+                        toolCallId: part.callID,
+                        title: part.tool,
+                        kind: toToolKind(part.tool),
+                        status: "pending",
+                        locations: [],
+                        rawInput: {},
+                      },
+                    })
+                    .catch((error) => {
+                      log.error("failed to send synthetic tool pending to ACP", { error })
+                    })
+                }
                 const output = this.bashOutput(part)
                 const content: ToolCallContent[] = []
                 if (output) {
@@ -354,6 +376,7 @@ export namespace ACP {
                       title: part.tool,
                       locations: toLocations(part.tool, part.state.input),
                       rawInput: part.state.input,
+                      ...(content.length > 0 && { content }),
                     },
                   })
                   .catch((error) => {
@@ -838,6 +861,7 @@ export namespace ACP {
         if (part.type === "tool") {
           switch (part.state.status) {
             case "pending":
+              this.pendingEmitted.add(part.callID)
               await this.connection
                 .sessionUpdate({
                   sessionId,
@@ -856,6 +880,25 @@ export namespace ACP {
                 })
               break
             case "running":
+              if (!this.pendingEmitted.has(part.callID)) {
+                this.pendingEmitted.add(part.callID)
+                await this.connection
+                  .sessionUpdate({
+                    sessionId,
+                    update: {
+                      sessionUpdate: "tool_call",
+                      toolCallId: part.callID,
+                      title: part.tool,
+                      kind: toToolKind(part.tool),
+                      status: "pending",
+                      locations: [],
+                      rawInput: {},
+                    },
+                  })
+                  .catch((err) => {
+                    log.error("failed to send synthetic tool pending to ACP", { error: err })
+                  })
+              }
               await this.connection
                 .sessionUpdate({
                   sessionId,

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -20,6 +20,8 @@ export namespace ProviderError {
     /exceeded model token limit/i, // Kimi For Coding, Moonshot
     /context[_ ]length[_ ]exceeded/i, // Generic fallback
     /request entity too large/i, // HTTP 413
+    /the request was too long/i, // Azure OpenAI
+    /maximum tokens for requested operation/i, // Azure OpenAI
   ]
 
   function isOpenAiErrorRetryable(e: APICallError) {

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -18,7 +18,11 @@ test("returns default native agents when no config", async () => {
     fn: async () => {
       const agents = await Agent.list()
       const names = agents.map((a) => a.name)
-      expect(names).toContain("build")
+      expect(names).toContain("builder")
+      expect(names).toContain("analyst")
+      expect(names).toContain("executive")
+      expect(names).toContain("validator")
+      expect(names).toContain("migrator")
       expect(names).toContain("plan")
       expect(names).toContain("general")
       expect(names).toContain("explore")
@@ -34,7 +38,7 @@ test("build agent has correct default properties", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await Agent.get("builder")
       expect(build).toBeDefined()
       expect(build?.mode).toBe("primary")
       expect(build?.native).toBe(true)
@@ -152,7 +156,7 @@ test("custom agent config overrides native agent properties", async () => {
   await using tmp = await tmpdir({
     config: {
       agent: {
-        build: {
+        builder: {
           model: "anthropic/claude-3",
           description: "Custom build agent",
           temperature: 0.7,
@@ -164,7 +168,7 @@ test("custom agent config overrides native agent properties", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await Agent.get("builder")
       expect(build).toBeDefined()
       expect(build?.model?.providerID).toBe("anthropic")
       expect(build?.model?.modelID).toBe("claude-3")
@@ -200,7 +204,7 @@ test("agent permission config merges with defaults", async () => {
   await using tmp = await tmpdir({
     config: {
       agent: {
-        build: {
+        builder: {
           permission: {
             bash: {
               "rm -rf *": "deny",
@@ -213,7 +217,7 @@ test("agent permission config merges with defaults", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await Agent.get("builder")
       expect(build).toBeDefined()
       // Specific pattern is denied
       expect(PermissionNext.evaluate("bash", "rm -rf *", build!.permission).action).toBe("deny")
@@ -234,7 +238,7 @@ test("global permission config applies to all agents", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await Agent.get("builder")
       expect(build).toBeDefined()
       expect(evalPerm(build, "bash")).toBe("deny")
     },
@@ -245,7 +249,7 @@ test("agent steps/maxSteps config sets steps property", async () => {
   await using tmp = await tmpdir({
     config: {
       agent: {
-        build: { steps: 50 },
+        builder: { steps: 50 },
         plan: { maxSteps: 100 },
       },
     },
@@ -253,7 +257,7 @@ test("agent steps/maxSteps config sets steps property", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await Agent.get("builder")
       const plan = await Agent.get("plan")
       expect(build?.steps).toBe(50)
       expect(plan?.steps).toBe(100)
@@ -282,14 +286,14 @@ test("agent name can be overridden", async () => {
   await using tmp = await tmpdir({
     config: {
       agent: {
-        build: { name: "Builder" },
+        builder: { name: "Builder" },
       },
     },
   })
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await Agent.get("builder")
       expect(build?.name).toBe("Builder")
     },
   })
@@ -299,14 +303,14 @@ test("agent prompt can be set from config", async () => {
   await using tmp = await tmpdir({
     config: {
       agent: {
-        build: { prompt: "Custom system prompt" },
+        builder: { prompt: "Custom system prompt" },
       },
     },
   })
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await Agent.get("builder")
       expect(build?.prompt).toBe("Custom system prompt")
     },
   })
@@ -316,7 +320,7 @@ test("unknown agent properties are placed into options", async () => {
   await using tmp = await tmpdir({
     config: {
       agent: {
-        build: {
+        builder: {
           random_property: "hello",
           another_random: 123,
         },
@@ -326,7 +330,7 @@ test("unknown agent properties are placed into options", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await Agent.get("builder")
       expect(build?.options.random_property).toBe("hello")
       expect(build?.options.another_random).toBe(123)
     },
@@ -337,7 +341,7 @@ test("agent options merge correctly", async () => {
   await using tmp = await tmpdir({
     config: {
       agent: {
-        build: {
+        builder: {
           options: {
             custom_option: true,
             another_option: "value",
@@ -349,7 +353,7 @@ test("agent options merge correctly", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await Agent.get("builder")
       expect(build?.options.custom_option).toBe(true)
       expect(build?.options.another_option).toBe("value")
     },
@@ -400,7 +404,7 @@ test("default permission includes doom_loop and external_directory as ask", asyn
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await Agent.get("builder")
       expect(evalPerm(build, "doom_loop")).toBe("ask")
       expect(evalPerm(build, "external_directory")).toBe("ask")
     },
@@ -412,7 +416,7 @@ test("webfetch is allowed by default", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await Agent.get("builder")
       expect(evalPerm(build, "webfetch")).toBe("allow")
     },
   })
@@ -422,7 +426,7 @@ test("legacy tools config converts to permissions", async () => {
   await using tmp = await tmpdir({
     config: {
       agent: {
-        build: {
+        builder: {
           tools: {
             bash: false,
             read: false,
@@ -434,7 +438,7 @@ test("legacy tools config converts to permissions", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await Agent.get("builder")
       expect(evalPerm(build, "bash")).toBe("deny")
       expect(evalPerm(build, "read")).toBe("deny")
     },
@@ -445,7 +449,7 @@ test("legacy tools config maps write/edit/patch/multiedit to edit permission", a
   await using tmp = await tmpdir({
     config: {
       agent: {
-        build: {
+        builder: {
           tools: {
             write: false,
           },
@@ -456,7 +460,7 @@ test("legacy tools config maps write/edit/patch/multiedit to edit permission", a
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await Agent.get("builder")
       expect(evalPerm(build, "edit")).toBe("deny")
     },
   })
@@ -474,7 +478,7 @@ test("Truncate.GLOB is allowed even when user denies external_directory globally
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await Agent.get("builder")
       expect(PermissionNext.evaluate("external_directory", Truncate.GLOB, build!.permission).action).toBe("allow")
       expect(PermissionNext.evaluate("external_directory", Truncate.DIR, build!.permission).action).toBe("deny")
       expect(PermissionNext.evaluate("external_directory", "/some/other/path", build!.permission).action).toBe("deny")
@@ -487,7 +491,7 @@ test("Truncate.GLOB is allowed even when user denies external_directory per-agen
   await using tmp = await tmpdir({
     config: {
       agent: {
-        build: {
+        builder: {
           permission: {
             external_directory: "deny",
           },
@@ -498,7 +502,7 @@ test("Truncate.GLOB is allowed even when user denies external_directory per-agen
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await Agent.get("builder")
       expect(PermissionNext.evaluate("external_directory", Truncate.GLOB, build!.permission).action).toBe("allow")
       expect(PermissionNext.evaluate("external_directory", Truncate.DIR, build!.permission).action).toBe("deny")
       expect(PermissionNext.evaluate("external_directory", "/some/other/path", build!.permission).action).toBe("deny")
@@ -521,7 +525,7 @@ test("explicit Truncate.GLOB deny is respected", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await Agent.get("builder")
       expect(PermissionNext.evaluate("external_directory", Truncate.GLOB, build!.permission).action).toBe("deny")
       expect(PermissionNext.evaluate("external_directory", Truncate.DIR, build!.permission).action).toBe("deny")
     },
@@ -553,7 +557,7 @@ description: Permission skill.
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const build = await Agent.get("build")
+        const build = await Agent.get("builder")
         const skillDir = path.join(tmp.path, ".opencode", "skill", "perm-skill")
         const target = path.join(skillDir, "reference", "notes.md")
         expect(PermissionNext.evaluate("external_directory", target, build!.permission).action).toBe("allow")
@@ -570,7 +574,7 @@ test("defaultAgent returns build when no default_agent config", async () => {
     directory: tmp.path,
     fn: async () => {
       const agent = await Agent.defaultAgent()
-      expect(agent).toBe("build")
+      expect(agent).toBe("builder")
     },
   })
 })
@@ -652,11 +656,11 @@ test("defaultAgent throws when default_agent points to non-existent agent", asyn
   })
 })
 
-test("defaultAgent returns plan when build is disabled and default_agent not set", async () => {
+test("defaultAgent returns analyst when builder is disabled and default_agent not set", async () => {
   await using tmp = await tmpdir({
     config: {
       agent: {
-        build: { disable: true },
+        builder: { disable: true },
       },
     },
   })
@@ -664,8 +668,8 @@ test("defaultAgent returns plan when build is disabled and default_agent not set
     directory: tmp.path,
     fn: async () => {
       const agent = await Agent.defaultAgent()
-      // build is disabled, so it should return plan (next primary agent)
-      expect(agent).toBe("plan")
+      // builder is disabled, so it should return analyst (next primary agent)
+      expect(agent).toBe("analyst")
     },
   })
 })
@@ -674,7 +678,11 @@ test("defaultAgent throws when all primary agents are disabled", async () => {
   await using tmp = await tmpdir({
     config: {
       agent: {
-        build: { disable: true },
+        builder: { disable: true },
+        analyst: { disable: true },
+        executive: { disable: true },
+        validator: { disable: true },
+        migrator: { disable: true },
         plan: { disable: true },
       },
     },
@@ -682,7 +690,7 @@ test("defaultAgent throws when all primary agents are disabled", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      // build and plan are disabled, no primary-capable agents remain
+      // all primary agents are disabled, no primary-capable agents remain
       await expect(Agent.defaultAgent()).rejects.toThrow("no primary visible agent found")
     },
   })

--- a/packages/opencode/test/bridge/client.test.ts
+++ b/packages/opencode/test/bridge/client.test.ts
@@ -16,7 +16,7 @@ let managedPythonPath = "/nonexistent/managed-engine/venv/bin/python"
 // Mock: bridge/engine  (only module we mock — avoids leaking into other tests)
 // ---------------------------------------------------------------------------
 
-mock.module("../../src/bridge/engine", () => ({
+mock.module("../../src/altimate/bridge/engine", () => ({
   ensureEngine: async () => {
     ensureEngineCalls++
   },
@@ -27,7 +27,7 @@ mock.module("../../src/bridge/engine", () => ({
 // Import module under test — AFTER mock.module() calls
 // ---------------------------------------------------------------------------
 
-const { resolvePython } = await import("../../src/bridge/client")
+const { resolvePython } = await import("../../src/altimate/bridge/client")
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -138,7 +138,7 @@ describe("Bridge.start integration", () => {
   })
 
   test("ensureEngine is called when bridge starts", async () => {
-    const { Bridge } = await import("../../src/bridge/client")
+    const { Bridge } = await import("../../src/altimate/bridge/client")
 
     // /bin/echo exists and will spawn successfully but won't respond to
     // the JSON-RPC ping, so start() will eventually fail on verification.

--- a/packages/opencode/test/bridge/engine.test.ts
+++ b/packages/opencode/test/bridge/engine.test.ts
@@ -95,7 +95,7 @@ describe("engine.ts subprocess noise suppression", () => {
     // is actually applied in the production code
     const engineSrc = path.resolve(
       __dirname,
-      "../../src/bridge/engine.ts",
+      "../../src/altimate/bridge/engine.ts",
     )
     const source = await fsp.readFile(engineSrc, "utf-8")
     const lines = source.split("\n")

--- a/packages/opencode/test/install/bin-wrapper.test.ts
+++ b/packages/opencode/test/install/bin-wrapper.test.ts
@@ -47,7 +47,7 @@ describe("bin/altimate-code wrapper", () => {
 
     const wrapperPath = copyBinWrapper(dir)
     const binDir = path.dirname(wrapperPath)
-    createDummyBinary(binDir, ".opencode")
+    createDummyBinary(binDir, ".altimate-code")
 
     const result = runBinWrapper(wrapperPath)
     expect(result.exitCode).toBe(0)
@@ -111,6 +111,6 @@ describe("bin/altimate-code wrapper", () => {
 
     const result = runBinWrapper(wrapperPath)
     expect(result.exitCode).toBe(1)
-    expect(result.stderr).toContain(`@opencode-ai/opencode-${CURRENT_PLATFORM}-${CURRENT_ARCH}`)
+    expect(result.stderr).toContain(`@altimateai/altimate-code-${CURRENT_PLATFORM}-${CURRENT_ARCH}`)
   })
 })

--- a/packages/opencode/test/install/fixture.ts
+++ b/packages/opencode/test/install/fixture.ts
@@ -8,7 +8,7 @@ const ARCH_MAP: Record<string, string> = { x64: "x64", arm64: "arm64", arm: "arm
 
 export const CURRENT_PLATFORM = PLATFORM_MAP[os.platform()] ?? os.platform()
 export const CURRENT_ARCH = ARCH_MAP[os.arch()] ?? os.arch()
-export const CURRENT_PKG_NAME = `@opencode-ai/opencode-${CURRENT_PLATFORM}-${CURRENT_ARCH}`
+export const CURRENT_PKG_NAME = `@altimateai/altimate-code-${CURRENT_PLATFORM}-${CURRENT_ARCH}`
 export const BINARY_NAME = CURRENT_PLATFORM === "windows" ? "altimate-code.exe" : "altimate-code"
 
 const REPO_PKG_DIR = path.resolve(import.meta.dir, "../..")
@@ -37,7 +37,7 @@ export function createMainPackageDir(baseDir: string, opts?: MainPackageOpts) {
 
   fs.writeFileSync(
     path.join(baseDir, "package.json"),
-    JSON.stringify({ name: "@opencode-ai/opencode", version }, null, 2),
+    JSON.stringify({ name: "@altimateai/altimate-code", version }, null, 2),
   )
 
   if (!opts?.noBinDir) {
@@ -54,7 +54,7 @@ interface BinaryPackageOpts {
 export function createBinaryPackage(baseDir: string, opts?: BinaryPackageOpts) {
   const platform = opts?.platform ?? CURRENT_PLATFORM
   const arch = opts?.arch ?? CURRENT_ARCH
-  const pkgName = `@opencode-ai/opencode-${platform}-${arch}`
+  const pkgName = `@altimateai/altimate-code-${platform}-${arch}`
   const binaryName = platform === "windows" ? "altimate-code.exe" : "altimate-code"
 
   const pkgDir = path.join(baseDir, "node_modules", "@altimateai", `altimate-code-${platform}-${arch}`)

--- a/packages/opencode/test/install/integration.test.ts
+++ b/packages/opencode/test/install/integration.test.ts
@@ -31,7 +31,7 @@ describe("install pipeline integration", () => {
     const postResult = runPostinstall(dir)
     expect(postResult.exitCode).toBe(0)
 
-    const cachedBin = path.join(dir, "bin", ".opencode")
+    const cachedBin = path.join(dir, "bin", ".altimate-code")
     expect(fs.existsSync(cachedBin)).toBe(true)
 
     // 3. Place bin wrapper in the same bin/ directory
@@ -57,7 +57,7 @@ describe("install pipeline integration", () => {
     expect(postResult.stderr).toContain("Failed to setup altimate-code binary")
 
     // 2. No cached binary was created
-    expect(fs.existsSync(path.join(dir, "bin", ".opencode"))).toBe(false)
+    expect(fs.existsSync(path.join(dir, "bin", ".altimate-code"))).toBe(false)
 
     // 3. Bin wrapper also fails with helpful error when invoked directly
     const wrapperPkgBin = path.join(dir, "node_modules", "@altimateai", "altimate-code", "bin")

--- a/packages/opencode/test/install/postinstall.test.ts
+++ b/packages/opencode/test/install/postinstall.test.ts
@@ -27,7 +27,7 @@ describe("postinstall.mjs", () => {
     const result = runPostinstall(dir)
     expect(result.exitCode).toBe(0)
 
-    const cachedBinary = path.join(dir, "bin", ".opencode")
+    const cachedBinary = path.join(dir, "bin", ".altimate-code")
     expect(fs.existsSync(cachedBinary)).toBe(true)
     // Verify it's executable
     const stat = fs.statSync(cachedBinary)
@@ -42,7 +42,7 @@ describe("postinstall.mjs", () => {
     createBinaryPackage(dir)
 
     // Create a stale .opencode file
-    const cachedBinary = path.join(dir, "bin", ".opencode")
+    const cachedBinary = path.join(dir, "bin", ".altimate-code")
     fs.writeFileSync(cachedBinary, "stale content")
 
     const result = runPostinstall(dir)
@@ -65,7 +65,7 @@ describe("postinstall.mjs", () => {
     // The current postinstall does not create bin/ — linkSync/copyFileSync fail
     // This test documents current behavior: it fails when bin/ is missing
     if (result.exitCode === 0) {
-      expect(fs.existsSync(path.join(dir, "bin", ".opencode"))).toBe(true)
+      expect(fs.existsSync(path.join(dir, "bin", ".altimate-code"))).toBe(true)
     } else {
       expect(result.exitCode).toBe(1)
       expect(result.stderr).toContain("Failed to setup altimate-code binary")

--- a/packages/opencode/test/install/publish-package.test.ts
+++ b/packages/opencode/test/install/publish-package.test.ts
@@ -12,7 +12,7 @@ describe("publish package validation", () => {
   test("optionalDependencies has all expected platform packages", () => {
     // Validate that all expected platforms produce valid package names
     for (const p of EXPECTED_PLATFORMS) {
-      const pkgName = `@opencode-ai/opencode-${p}`
+      const pkgName = `@altimateai/altimate-code-${p}`
       expect(pkgName).toMatch(PACKAGE_NAME_PATTERN)
     }
   })
@@ -24,7 +24,7 @@ describe("publish package validation", () => {
     const version = "1.0.0"
     const binaries: Record<string, string> = {}
     for (const p of EXPECTED_PLATFORMS) {
-      binaries[`@opencode-ai/opencode-${p}`] = version
+      binaries[`@altimateai/altimate-code-${p}`] = version
     }
     for (const [, ver] of Object.entries(binaries)) {
       expect(ver).not.toMatch(/^v/)
@@ -34,7 +34,7 @@ describe("publish package validation", () => {
 
   test("package names follow naming convention", () => {
     for (const p of EXPECTED_PLATFORMS) {
-      const pkgName = `@opencode-ai/opencode-${p}`
+      const pkgName = `@altimateai/altimate-code-${p}`
       expect(pkgName).toMatch(PACKAGE_NAME_PATTERN)
     }
   })
@@ -66,7 +66,7 @@ describe("publish package validation", () => {
     // postinstall.mjs uses createRequire for resolving platform packages
     const postinstall = fs.readFileSync(path.join(REPO_PKG_DIR, "script/postinstall.mjs"), "utf-8")
     expect(postinstall).toContain("createRequire")
-    expect(postinstall).toContain("@opencode-ai/opencode-")
+    expect(postinstall).toContain("@altimateai/altimate-code-")
 
     // bin wrapper uses @altimateai scope
     const wrapper = fs.readFileSync(path.join(REPO_PKG_DIR, "bin/altimate-code"), "utf-8")

--- a/packages/opencode/test/session/compaction-loop.test.ts
+++ b/packages/opencode/test/session/compaction-loop.test.ts
@@ -496,7 +496,7 @@ describe("session.compaction.isOverflow boundary conditions", () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
         await Bun.write(
-          `${dir}/altimate-code.json`,
+          `${dir}/opencode.json`,
           JSON.stringify({ compaction: { reserved: 50_000 } }),
         )
       },
@@ -517,7 +517,7 @@ describe("session.compaction.isOverflow boundary conditions", () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
         await Bun.write(
-          `${dir}/altimate-code.json`,
+          `${dir}/opencode.json`,
           JSON.stringify({ compaction: { reserved: 50_000 } }),
         )
       },
@@ -565,7 +565,7 @@ describe("session.compaction.isOverflow boundary conditions", () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
         await Bun.write(
-          `${dir}/altimate-code.json`,
+          `${dir}/opencode.json`,
           JSON.stringify({ compaction: { prune: false } }),
         )
       },
@@ -587,7 +587,7 @@ describe("session.compaction.prune with disabled config", () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
         await Bun.write(
-          `${dir}/altimate-code.json`,
+          `${dir}/opencode.json`,
           JSON.stringify({ compaction: { prune: false } }),
         )
       },

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -230,12 +230,12 @@ describe("session.compaction.isOverflow", () => {
 describe("util.token.estimate", () => {
   test("estimates tokens from text (4 chars per token)", () => {
     const text = "x".repeat(4000)
-    expect(Token.estimate(text)).toBe(1000)
+    expect(Token.estimate(text)).toBe(Math.round(4000 / 3.7))
   })
 
   test("estimates tokens from larger text", () => {
     const text = "y".repeat(20_000)
-    expect(Token.estimate(text)).toBe(5000)
+    expect(Token.estimate(text)).toBe(Math.round(20_000 / 3.7))
   })
 
   test("returns 0 for empty string", () => {

--- a/packages/opencode/test/tool/project-scan.test.ts
+++ b/packages/opencode/test/tool/project-scan.test.ts
@@ -17,7 +17,7 @@ import {
   type EnvVarConnection,
   type DataToolInfo,
   type ConfigFileInfo,
-} from "../../src/tool/project-scan"
+} from "../../src/altimate/tools/project-scan"
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -163,7 +163,7 @@ describe("tool.read env file permissions", () => {
     ["environment.ts", false],
   ]
 
-  describe.each(["build", "plan"])("agent=%s", (agentName) => {
+  describe.each(["builder", "plan"])("agent=%s", (agentName) => {
     test.each(cases)("%s asks=%s", async (filename, shouldAsk) => {
       await using tmp = await tmpdir({
         init: (dir) => Bun.write(path.join(dir, filename), "content"),
@@ -172,17 +172,18 @@ describe("tool.read env file permissions", () => {
         directory: tmp.path,
         fn: async () => {
           const agent = await Agent.get(agentName)
+          expect(agent).toBeDefined()
           let askedForEnv = false
           const ctxWithPermissions = {
             ...ctx,
             ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
               for (const pattern of req.patterns) {
-                const rule = PermissionNext.evaluate(req.permission, pattern, agent.permission)
+                const rule = PermissionNext.evaluate(req.permission, pattern, agent!.permission)
                 if (rule.action === "ask" && req.permission === "read") {
                   askedForEnv = true
                 }
                 if (rule.action === "deny") {
-                  throw new PermissionNext.DeniedError(agent.permission)
+                  throw new PermissionNext.DeniedError(agent!.permission)
                 }
               }
             },

--- a/packages/util/src/error.ts
+++ b/packages/util/src/error.ts
@@ -27,7 +27,7 @@ export abstract class NamedError extends Error {
       }
 
       static isInstance(input: any): input is InstanceType<typeof result> {
-        return typeof input === "object" && "name" in input && input.name === name
+        return input !== null && typeof input === "object" && "name" in input && input.name === name
       }
 
       schema() {


### PR DESCRIPTION
## Summary
- Add null guard to `NamedError.isInstance()` preventing `TypeError` on null input
- Add Azure OpenAI overflow detection patterns for context overflow handling
- Fix token estimation tests to use new content-aware ratio (3.7)
- Fix compaction/prune config tests: `altimate-code.json` → `opencode.json`
- Fix install test fixtures: `@opencode-ai/opencode` → `@altimateai/altimate-code`
- Fix `bin/altimate-code` entry in `package.json` to point to dedicated wrapper
- Fix test import paths for relocated modules (`bridge/client`, `bridge/engine`, `tool/project-scan`)
- Add synthetic pending emission + bash output streaming to ACP agent event handler

## Test plan
- [x] All 1561 tests pass (0 failures, 8 skips)
- [x] Verified pre-existing typecheck error in `src/plugin/index.ts` exists on main (not introduced by this PR)