### PR TITLE
fix: resolve GitlabAuthPlugin type incompatibility

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -19,7 +19,10 @@ export namespace Plugin {
   const BUILTIN = ["opencode-anthropic-auth@0.0.13"]
 
   // Built-in plugins that are directly imported (not installed from npm)
-  const INTERNAL_PLUGINS: PluginInstance[] = [CodexAuthPlugin, CopilotAuthPlugin, GitlabAuthPlugin]
+  // GitlabAuthPlugin uses a different version of @opencode-ai/plugin (from npm)
+  // vs the workspace version, causing a type mismatch on internal HeyApiClient.
+  // The types are structurally compatible at runtime.
+  const INTERNAL_PLUGINS: PluginInstance[] = [CodexAuthPlugin, CopilotAuthPlugin, GitlabAuthPlugin as unknown as PluginInstance]
 
   const state = Instance.state(async () => {
     const client = createOpencodeClient({


### PR DESCRIPTION
## Summary
- Fix TS2322 typecheck error in `src/plugin/index.ts` caused by `@gitlab/opencode-gitlab-auth` depending on `@opencode-ai/plugin@1.2.10` (npm) while workspace has `@1.2.20`
- The `_HeyApiClient` protected property differs between versions, causing type incompatibility
- Cast `GitlabAuthPlugin` to `PluginInstance` since the types are structurally compatible at runtime

## Test plan
- [x] Full turbo typecheck passes (13/13 packages)
- [x] All 1561 tests pass (0 failures)
- [x] Pre-push hook passes without `--no-verify`