### PR TITLE
chore: migrate CI/release to ARC self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,15 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   typescript:
     name: TypeScript
-    runs-on: arc-runner-altimate-code
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'arc-runner-altimate-code' }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -39,7 +44,8 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: arc-runner-altimate-code
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'arc-runner-altimate-code' }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -56,7 +62,8 @@ jobs:
 
   python:
     name: Python ${{ matrix.python-version }}
-    runs-on: arc-runner-altimate-code
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'arc-runner-altimate-code' }}
+    timeout-minutes: 60
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
   build:
     name: Build (${{ matrix.os }})
     runs-on: arc-runner-altimate-code
+    timeout-minutes: 60
     permissions:
       contents: read
     strategy:
@@ -59,6 +60,7 @@ jobs:
     name: Publish to npm
     needs: build
     runs-on: arc-runner-altimate-code
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -87,7 +89,7 @@ jobs:
           merge-multiple: true
 
       - name: Configure npm auth
-        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "$RUNNER_TEMP/.npmrc"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -115,6 +117,7 @@ jobs:
           OPENCODE_RELEASE: "1"
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/.npmrc
           GH_REPO: ${{ env.GH_REPO }}
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
@@ -123,6 +126,7 @@ jobs:
   publish-engine:
     name: Publish engine to PyPI
     runs-on: arc-runner-altimate-code
+    timeout-minutes: 60
     environment: pypi
     permissions:
       contents: read
@@ -153,6 +157,7 @@ jobs:
     name: Create GitHub Release
     needs: [build, publish-npm]
     runs-on: arc-runner-altimate-code
+    timeout-minutes: 60
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary
- Update `ci.yml` to use `arc-runner-altimate-code` instead of `ubuntu-latest`
- Update `release.yml` to use `arc-runner-altimate-code` instead of `ubuntu-latest`

ARC v2 (runner scale sets) has been deployed on AKS cluster `altimate-arc` in Azure East US. Runners scale to zero when idle.

## Test plan
- [ ] Verify CI workflow triggers and completes on ARC runner
- [ ] Verify release workflow jobs pick up the new runner label

Generated with [Claude Code](https://claude.com/claude-code)