### PR TITLE
chore: migrate test workflow to ARC runners + GitHub-hosted

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         settings:
           - name: linux
-            host: blacksmith-4vcpu-ubuntu-2404
+            host: arc-runner-altimate-code
           - name: windows
-            host: blacksmith-4vcpu-windows-2025
+            host: windows-latest
     runs-on: ${{ matrix.settings.host }}
     defaults:
       run:
@@ -46,10 +46,10 @@ jobs:
       matrix:
         settings:
           - name: linux
-            host: blacksmith-4vcpu-ubuntu-2404
+            host: arc-runner-altimate-code
             playwright: bunx playwright install --with-deps
           - name: windows
-            host: blacksmith-4vcpu-windows-2025
+            host: windows-latest
             playwright: bunx playwright install
     runs-on: ${{ matrix.settings.host }}
     env:
@@ -89,7 +89,7 @@ jobs:
 
   required:
     name: test (linux)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: arc-runner-altimate-code
     needs:
       - unit
       - e2e


### PR DESCRIPTION
## Summary
- Linux unit/e2e/required jobs → `arc-runner-altimate-code` (ARC self-hosted)
- Windows unit/e2e jobs → `windows-latest` (GitHub-hosted)
- Replaces Blacksmith runner labels (`blacksmith-4vcpu-ubuntu-2404`, `blacksmith-4vcpu-windows-2025`)

## Changes
| Job | Before | After |
|-----|--------|-------|
| unit (linux) | `blacksmith-4vcpu-ubuntu-2404` | `arc-runner-altimate-code` |
| unit (windows) | `blacksmith-4vcpu-windows-2025` | `windows-latest` |
| e2e (linux) | `blacksmith-4vcpu-ubuntu-2404` | `arc-runner-altimate-code` |
| e2e (windows) | `blacksmith-4vcpu-windows-2025` | `windows-latest` |
| required | `blacksmith-4vcpu-ubuntu-2404` | `arc-runner-altimate-code` |

## Test plan
- [ ] Verify Linux jobs pick up ARC runners
- [ ] Verify Windows jobs run on GitHub-hosted runners
- [ ] Confirm unit and e2e tests pass on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)