### PR TITLE
ci: switch Windows tests to ARC self-hosted runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           - name: linux
             host: arc-runner-altimate-code
           - name: windows
-            host: windows-latest
+            host: arc-runner-windows-altimate-code
     runs-on: ${{ matrix.settings.host }}
     defaults:
       run:
@@ -49,7 +49,7 @@ jobs:
             host: arc-runner-altimate-code
             playwright: bunx playwright install --with-deps
           - name: windows
-            host: windows-latest
+            host: arc-runner-windows-altimate-code
             playwright: bunx playwright install
     runs-on: ${{ matrix.settings.host }}
     env:


### PR DESCRIPTION
## Summary
- Switch Windows test jobs (unit + e2e) from `windows-latest` to `arc-runner-windows-altimate-code`
- Uses AKS Windows node pool with custom runner image via ARC v2

## Test plan
- [ ] Verify Windows unit tests pass on ARC runner
- [ ] Verify Windows e2e tests pass on ARC runner
- [ ] Confirm Windows nodes scale up when jobs are queued

🤖 Generated with [Claude Code](https://claude.com/claude-code)