### PR TITLE
fix: correct TEAM_MEMBERS ref from 'dev' to 'main' in pr-standards workflow

### DIFF
--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -32,7 +32,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               path: '.github/TEAM_MEMBERS',
-              ref: 'dev'
+              ref: 'main'
             });
             const members = Buffer.from(file.content, 'base64').toString().split('\n').map(l => l.trim()).filter(Boolean);
             if (members.includes(login)) {
@@ -179,7 +179,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               path: '.github/TEAM_MEMBERS',
-              ref: 'dev'
+              ref: 'main'
             });
             const members = Buffer.from(file.content, 'base64').toString().split('\n').map(l => l.trim()).filter(Boolean);
             if (members.includes(login)) {


### PR DESCRIPTION
What does this PR do?

Fixes a broken pr-standards workflow that was causing both check-standards and check-compliance jobs to always fail with a 404 error.

Both jobs fetch .github/TEAM_MEMBERS to check if a PR author is a team member (and skip checks accordingly). The ref was hardcoded to 'dev', but this repository uses main as its default branch — the dev branch does not
exist, so every run crashed with:

HttpError: No commit found for the ref dev
GET .github/TEAM_MEMBERS?ref=dev → 404

Changed ref: 'dev' → ref: 'main' in both the check-standards and check-compliance jobs.

Type of change

Bug fix
How did you verify your code works?

Confirmed the dev branch does not exist in this repo and that .github/TEAM_MEMBERS exists on main. The fix is a two-line change — both jobs will now successfully resolve the file and proceed with their checks.

Checklist

Tested locally end-to-end
No unrelated changes included
Issue for this PR

fix: no issue required (infrastructure bug fix)