### PR TITLE
chore(ci): remove self-hosted runners from public repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   typescript:
     name: TypeScript
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'arc-runner-altimate-code' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -44,7 +44,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'arc-runner-altimate-code' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -62,7 +62,7 @@ jobs:
 
   python:
     name: Python ${{ matrix.python-version }}
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'arc-runner-altimate-code' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build:
     name: Build (${{ matrix.os }})
-    runs-on: arc-runner-altimate-code
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: read
@@ -59,7 +59,7 @@ jobs:
   publish-npm:
     name: Publish to npm
     needs: build
-    runs-on: arc-runner-altimate-code
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: read
@@ -125,7 +125,7 @@ jobs:
   # doesn't need CLI binary artifacts. This allows it to run in parallel.
   publish-engine:
     name: Publish engine to PyPI
-    runs-on: arc-runner-altimate-code
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: pypi
     permissions:
@@ -156,7 +156,7 @@ jobs:
   github-release:
     name: Create GitHub Release
     needs: [build, publish-npm]
-    runs-on: arc-runner-altimate-code
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         settings:
           - name: linux
-            host: arc-runner-altimate-code
+            host: ubuntu-latest
           - name: windows
             host: windows-latest
     runs-on: ${{ matrix.settings.host }}
@@ -46,7 +46,7 @@ jobs:
       matrix:
         settings:
           - name: linux
-            host: arc-runner-altimate-code
+            host: ubuntu-latest
             playwright: bunx playwright install --with-deps
           - name: windows
             host: windows-latest
@@ -89,7 +89,7 @@ jobs:
 
   required:
     name: test (linux)
-    runs-on: arc-runner-altimate-code
+    runs-on: ubuntu-latest
     needs:
       - unit
       - e2e


### PR DESCRIPTION
### What does this PR do?

Remove self-hosted ARC runners (`arc-runner-altimate-code`) from all workflows and replace with `ubuntu-latest`. Self-hosted runners on public repos are a security risk — any fork can submit a PR that runs arbitrary code on our infrastructure.

Fixes #109

**Files changed:**
- `.github/workflows/ci.yml` — 3 jobs (typescript, lint, python)
- `.github/workflows/test.yml` — 3 jobs (unit, e2e, required)
- `.github/workflows/release.yml` — 4 jobs (build, publish-npm, publish-engine, github-release)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / code improvement
- [x] CI/CD or infrastructure change

### Issue for this PR

Fixes #109

### How did you verify your code works?

- All workflows use standard GitHub-hosted runner actions (setup-bun, setup-python, etc.) that are fully compatible with ubuntu-latest
- CI on this PR validates the change directly

### Checklist

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [ ] CHANGELOG updated (if user-facing)