### PR TITLE
feat: /login command and auto-model selection for Altimate backend

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -9,6 +9,7 @@ import { Installation } from "@/installation"
 import { Flag } from "@/flag/flag"
 import { DialogProvider, useDialog } from "@tui/ui/dialog"
 import { DialogProvider as DialogProviderList } from "@tui/component/dialog-provider"
+import { DialogAltimateLogin } from "@tui/component/dialog-altimate-login"
 import { SDKProvider, useSDK } from "@tui/context/sdk"
 import { SyncProvider, useSync } from "@tui/context/sync"
 import { LocalProvider, useLocal } from "@tui/context/local"
@@ -512,6 +513,17 @@ function App() {
         dialog.replace(() => <DialogProviderList />)
       },
       category: "Provider",
+    },
+    {
+      title: "Login to Altimate",
+      value: "altimate.login",
+      category: "Provider",
+      slash: {
+        name: "login",
+      },
+      onSelect: () => {
+        dialog.replace(() => <DialogAltimateLogin />)
+      },
     },
     {
       title: "View status",

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-altimate-login.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-altimate-login.tsx
@@ -1,0 +1,81 @@
+import { createSignal } from "solid-js"
+import { useDialog } from "@tui/ui/dialog"
+import { useSDK } from "../context/sdk"
+import { useSync } from "@tui/context/sync"
+import { useLocal } from "@tui/context/local"
+import { DialogPrompt } from "../ui/dialog-prompt"
+import { useTheme } from "../context/theme"
+import { AltimateApi } from "@/altimate/api/client"
+import { Filesystem } from "@/util/filesystem"
+
+export function DialogAltimateLogin() {
+  const dialog = useDialog()
+  const sdk = useSDK()
+  const sync = useSync()
+  const local = useLocal()
+  const { theme } = useTheme()
+  const [step, setStep] = createSignal<"url" | "tenant" | "key">("url")
+  const [url, setUrl] = createSignal("https://api.myaltimate.com")
+  const [tenant, setTenant] = createSignal("")
+
+  async function saveAndConnect(apiKey: string) {
+    const creds = {
+      altimateUrl: url(),
+      altimateInstanceName: tenant(),
+      altimateApiKey: apiKey,
+    }
+    await Filesystem.writeJson(AltimateApi.credentialsPath(), creds, 0o600)
+    // Refresh providers to pick up the new altimate-backend
+    await sdk.client.instance.dispose()
+    await sync.bootstrap()
+    // Auto-select the altimate model
+    local.model.set({ providerID: "altimate-backend", modelID: "altimate-default" }, { recent: true })
+    dialog.clear()
+  }
+
+  return (
+    <>
+      {step() === "url" && (
+        <DialogPrompt
+          title="Altimate Backend URL"
+          placeholder="https://api.myaltimate.com"
+          value="https://api.myaltimate.com"
+          description={() => (
+            <text fg={theme.textMuted}>Enter the URL of your Altimate backend server</text>
+          )}
+          onConfirm={(value) => {
+            if (value) setUrl(value)
+            setStep("tenant")
+          }}
+        />
+      )}
+      {step() === "tenant" && (
+        <DialogPrompt
+          title="Instance Name"
+          placeholder="your-tenant"
+          description={() => (
+            <text fg={theme.textMuted}>Enter your Altimate instance (tenant) name</text>
+          )}
+          onConfirm={(value) => {
+            if (!value) return
+            setTenant(value)
+            setStep("key")
+          }}
+        />
+      )}
+      {step() === "key" && (
+        <DialogPrompt
+          title="API Key"
+          placeholder="your-api-key"
+          description={() => (
+            <text fg={theme.textMuted}>Enter your Altimate API key</text>
+          )}
+          onConfirm={async (value) => {
+            if (!value) return
+            await saveAndConnect(value)
+          }}
+        />
+      )}
+    </>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -178,6 +178,18 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           }
         }
 
+        // Prefer altimate-backend when configured
+        const altimateProvider = sync.data.provider.find((x) => x.id === "altimate-backend")
+        if (altimateProvider) {
+          const altimateModel = Object.values(altimateProvider.models)[0]
+          if (altimateModel) {
+            return {
+              providerID: "altimate-backend",
+              modelID: altimateModel.id,
+            }
+          }
+        }
+
         const provider = sync.data.provider[0]
         if (!provider) return undefined
         const defaultModel = sync.data.provider_default[provider.id]

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -18,6 +18,7 @@ import { iife } from "@/util/iife"
 import { Global } from "../global"
 import path from "path"
 import { Filesystem } from "../util/filesystem"
+import { AltimateApi } from "../altimate/api/client"
 
 // Direct imports for bundled providers
 import { createAmazonBedrock, type AmazonBedrockProviderSettings } from "@ai-sdk/amazon-bedrock"
@@ -151,6 +152,28 @@ export namespace Provider {
         options: hasKey ? {} : { apiKey: "public" },
       }
     },
+    // altimate_change start - altimate-backend OpenAI-compatible provider
+    "altimate-backend": async () => {
+      const isConfigured = await AltimateApi.isConfigured()
+      if (!isConfigured) return { autoload: false }
+
+      try {
+        const creds = await AltimateApi.getCredentials()
+        return {
+          autoload: true,
+          options: {
+            baseURL: `${creds.altimateUrl}/agents/v1`,
+            apiKey: creds.altimateApiKey,
+            headers: {
+              "x-tenant": creds.altimateInstanceName,
+            },
+          },
+        }
+      } catch {
+        return { autoload: false }
+      }
+    },
+    // altimate_change end
     openai: async () => {
       return {
         autoload: false,
@@ -794,6 +817,44 @@ export namespace Provider {
         })),
       }
     }
+
+    // altimate_change start - register altimate-backend as an OpenAI-compatible provider
+    if (!database["altimate-backend"]) {
+      const backendModels: Record<string, Model> = {
+        "altimate-default": {
+          id: "altimate-default",
+          providerID: "altimate-backend",
+          name: "Altimate AI",
+          family: "openai",
+          api: { id: "altimate-default", url: "", npm: "@ai-sdk/openai-compatible" },
+          status: "active",
+          headers: {},
+          options: {},
+          cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+          limit: { context: 200000, output: 128000 },
+          capabilities: {
+            temperature: true,
+            reasoning: false,
+            attachment: false,
+            toolcall: true,
+            input: { text: true, audio: false, image: true, video: false, pdf: false },
+            output: { text: true, audio: false, image: false, video: false, pdf: false },
+            interleaved: false,
+          },
+          release_date: "2025-01-01",
+          variants: {},
+        },
+      }
+      database["altimate-backend"] = {
+        id: "altimate-backend",
+        name: "Altimate Backend",
+        source: "custom",
+        env: [],
+        options: {},
+        models: backendModels,
+      }
+    }
+    // altimate_change end
 
     function mergeProvider(providerID: string, provider: Partial<Info>) {
       const existing = providers[providerID]


### PR DESCRIPTION
Closes #112

## Summary

Add `/login` slash command for Altimate credential setup and auto-select the Altimate model when configured, removing the need for manual provider/model selection.

**Changes:**
- New `/login` TUI command — 3-step prompt (URL, tenant, API key) writes `~/.altimate/altimate.json`
- Auto-select `altimate-backend/altimate-default` in fallback model logic when credentials exist
- Single "Altimate AI" model entry replacing 3 separate Claude models (backend handles routing)
- Use `creds.altimateUrl` instead of hardcoded `localhost:8000`

## Test Plan

- `/login` → complete all 3 steps → verify `~/.altimate/altimate.json` written with correct values
- After login, model auto-selects to "Altimate AI" without manual picker
- Fresh launch with existing credentials → skips provider/model dialogs
- Without credentials → existing flow unchanged

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] CHANGELOG updated (if user-facing)