### PR TITLE
fix: address Sentry review findings from PR #144

### DIFF
--- a/packages/opencode/src/altimate/enhance-prompt.ts
+++ b/packages/opencode/src/altimate/enhance-prompt.ts
@@ -5,12 +5,10 @@ import { Agent } from "@/agent/agent"
 import { Config } from "@/config/config"
 import { Log } from "@/util/log"
 import { MessageV2 } from "@/session/message-v2"
+import { MessageID, SessionID } from "@/session/schema"
 
 const ENHANCE_NAME = "enhance-prompt"
 const ENHANCE_TIMEOUT_MS = 15_000
-// MessageV2.User requires branded MessageID/SessionID types, but this is a
-// synthetic message that never enters the session store — cast is safe here.
-const ENHANCE_ID = ENHANCE_NAME as any
 
 const log = Log.create({ service: ENHANCE_NAME })
 
@@ -105,8 +103,8 @@ export async function enhancePrompt(text: string): Promise<string> {
     }
 
     const user: MessageV2.User = {
-      id: ENHANCE_ID,
-      sessionID: ENHANCE_ID,
+      id: MessageID.ascending(),
+      sessionID: SessionID.descending(),
       role: "user",
       time: { created: Date.now() },
       agent: ENHANCE_NAME,
@@ -124,7 +122,7 @@ export async function enhancePrompt(text: string): Promise<string> {
       tools: {},
       model,
       abort: controller.signal,
-      sessionID: ENHANCE_ID,
+      sessionID: user.sessionID,
       retries: 2,
       messages: [
         {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -207,8 +207,10 @@ export function Prompt(props: PromptProps) {
         enabled: !!store.prompt.input,
         onSelect: async (dialog) => {
           if (!store.prompt.input.trim()) return
+          if (enhancingInProgress) return
           dialog.clear()
           const original = store.prompt.input
+          enhancingInProgress = true
           toast.show({
             message: "Enhancing prompt...",
             variant: "info",
@@ -241,6 +243,8 @@ export function Prompt(props: PromptProps) {
               variant: "error",
               duration: 3000,
             })
+          } finally {
+            enhancingInProgress = false
           }
         },
       },
@@ -625,9 +629,11 @@ export function Prompt(props: PromptProps) {
           enhancingInProgress = true
           toast.show({ message: "Enhancing prompt...", variant: "info", duration: 2000 })
           const enhanced = await enhancePrompt(inputText)
-          // Discard if user changed the prompt during enhancement
-          if (store.prompt.input !== inputText) return
-          if (enhanced !== inputText) {
+          // If user changed the prompt during enhancement, skip enhancement
+          // but continue submission with the original text (don't abandon it)
+          if (store.prompt.input !== inputText) {
+            inputText = store.prompt.input
+          } else if (enhanced !== inputText) {
             inputText = enhanced
             setStore("prompt", "input", enhanced)
           }

--- a/packages/opencode/test/altimate/enhance-prompt.test.ts
+++ b/packages/opencode/test/altimate/enhance-prompt.test.ts
@@ -60,6 +60,16 @@ mock.module("@/session/message-v2", () => ({
   MessageV2: {},
 }))
 
+let idCounter = 0
+mock.module("@/session/schema", () => ({
+  MessageID: {
+    ascending: () => `msg-${++idCounter}`,
+  },
+  SessionID: {
+    descending: () => `session-${++idCounter}`,
+  },
+}))
+
 // Import after mocking
 const { enhancePrompt, isAutoEnhanceEnabled } = await import("../../src/altimate/enhance-prompt")
 


### PR DESCRIPTION
### What does this PR do?

Fixes 3 valid Sentry bot findings from PR #144 (AI-powered prompt enhancement):

- **Hardcoded IDs** → Use unique `MessageID.ascending()` / `SessionID.descending()` instead of hardcoded `"enhance-prompt"` string for synthetic LLM calls
- **Missing concurrency guard** → Add `enhancingInProgress` flag + `finally` cleanup to manual enhance handler, preventing race with auto-enhance on submit
- **Orphaned session on early return** → When user edits prompt during auto-enhance, use their latest text and continue submission instead of silently returning (which left an orphaned session)

3 other Sentry findings were **false positives** (stream already consumed at L139-141, compaction circuit breaker already exists in `compaction.ts`).

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #17639

### How did you verify your code works?

- All 48 enhance-prompt unit tests pass (`bun test test/altimate/enhance-prompt.test.ts`)
- All 62 altimate test suite tests pass
- TypeScript type checks pass (`turbo typecheck`)

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)