### PR TITLE
fix: show welcome box on first CLI run, not during postinstall

### DIFF
--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -143,11 +143,7 @@ async function main() {
     if (os.platform() === "win32") {
       // On Windows, the .exe is already included in the package and bin field points to it
       // No postinstall setup needed
-      console.log("Windows detected: binary setup not needed (using packaged .exe)")
-      if (version) {
-        writeUpgradeMarker(version)
-        printWelcome(version)
-      }
+      if (version) writeUpgradeMarker(version)
       return
     }
 
@@ -162,10 +158,9 @@ async function main() {
       fs.copyFileSync(binaryPath, target)
     }
     fs.chmodSync(target, 0o755)
-    if (version) {
-      writeUpgradeMarker(version)
-      printWelcome(version)
-    }
+    // Write marker only — npm v7+ suppresses all postinstall output.
+    // The CLI picks up the marker and shows the welcome box on first run.
+    if (version) writeUpgradeMarker(version)
   } catch (error) {
     console.error("Failed to setup altimate-code binary:", error.message)
     process.exit(1)

--- a/packages/opencode/src/cli/welcome.ts
+++ b/packages/opencode/src/cli/welcome.ts
@@ -15,11 +15,12 @@ function getDataDir(): string {
 
 /**
  * Check for a post-install/upgrade marker written by postinstall.mjs.
- * If found, display a brief upgrade confirmation on stderr, then remove the marker.
+ * If found, display a welcome box on stderr, then remove the marker.
  *
- * The postinstall script shows the full welcome box (with get-started hints).
- * This function handles the case where postinstall output was silenced (npm v7+)
- * or the install method didn't run postinstall at all (brew, curl).
+ * npm v7+ silences ALL postinstall output (stdout AND stderr), so
+ * the postinstall script only writes a marker file. This function
+ * picks it up on first CLI run and shows the welcome box before
+ * the TUI launches.
  */
 export function showWelcomeBannerIfNeeded(): void {
   try {
@@ -40,16 +41,36 @@ export function showWelcomeBannerIfNeeded(): void {
 
     if (!isUpgrade) return
 
-    // Show a brief confirmation — the full welcome box is in postinstall.mjs
     const tty = process.stderr.isTTY
     if (!tty) return
 
+    // Show the welcome box that postinstall couldn't display
     const orange = "\x1b[38;5;214m"
     const reset = "\x1b[0m"
     const bold = "\x1b[1m"
 
+    const v = `altimate-code v${currentVersion} installed`
+    const lines = [
+      "",
+      "  Get started:",
+      "    altimate              Open the TUI",
+      '    altimate run "hello"  Run a quick task',
+      "    altimate --help       See all commands",
+      "",
+    ]
+    const contentWidth = Math.max(v.length, ...lines.map((l) => l.length)) + 2
+    const pad = (s: string) => s + " ".repeat(contentWidth - s.length)
+    const top = `  ${orange}╭${"─".repeat(contentWidth + 2)}╮${reset}`
+    const bot = `  ${orange}╰${"─".repeat(contentWidth + 2)}╯${reset}`
+    const empty = `  ${orange}│${reset} ${" ".repeat(contentWidth)} ${orange}│${reset}`
+    const row = (s: string) => `  ${orange}│${reset} ${pad(s)} ${orange}│${reset}`
+
     process.stderr.write(EOL)
-    process.stderr.write(`  ${orange}${bold}altimate-code v${currentVersion}${reset} installed successfully!${EOL}`)
+    process.stderr.write(top + EOL)
+    process.stderr.write(empty + EOL)
+    process.stderr.write(row(` ${bold}${v}${reset}`) + EOL)
+    for (const line of lines) process.stderr.write(row(line) + EOL)
+    process.stderr.write(bot + EOL)
     process.stderr.write(EOL)
   } catch {
     // Non-fatal — never let banner display break the CLI

--- a/packages/opencode/test/install/postinstall.test.ts
+++ b/packages/opencode/test/install/postinstall.test.ts
@@ -78,7 +78,7 @@ describe("postinstall.mjs", () => {
     }
   })
 
-  test("prints welcome banner with correct version", () => {
+  test("does not print banner (npm v7+ suppresses all postinstall output)", () => {
     const { dir, cleanup: c } = installTmpdir()
     cleanup = c
 
@@ -88,23 +88,9 @@ describe("postinstall.mjs", () => {
     const dataDir = path.join(dir, "xdg-data")
     const result = runPostinstall(dir, { XDG_DATA_HOME: dataDir })
     expect(result.exitCode).toBe(0)
-    // Banner is written to stderr (npm v7+ silences postinstall stdout)
-    expect(result.stderr).toContain("altimate-code v2.5.0 installed")
-  })
-
-  test("does not produce double-v when version already has v prefix", () => {
-    const { dir, cleanup: c } = installTmpdir()
-    cleanup = c
-
-    createMainPackageDir(dir, { version: "v2.5.0" })
-    createBinaryPackage(dir)
-
-    const dataDir = path.join(dir, "xdg-data")
-    const result = runPostinstall(dir, { XDG_DATA_HOME: dataDir })
-    expect(result.exitCode).toBe(0)
-    // Banner is written to stderr (npm v7+ silences postinstall stdout)
-    expect(result.stderr).toContain("altimate-code v2.5.0 installed")
-    expect(result.stderr).not.toContain("vv2.5.0")
+    // Postinstall only writes the marker — banner is shown by the CLI on first run
+    expect(result.stdout).not.toContain("altimate-code")
+    expect(result.stderr).not.toContain("altimate-code")
   })
 
   test("writes upgrade marker file to XDG_DATA_HOME", () => {


### PR DESCRIPTION
### What does this PR do?

Fixes the install banner timing. npm v7+ suppresses ALL postinstall output (stdout AND stderr), so the welcome box was never visible after `npm install`. Users only saw "added 2 packages".

**Before:** postinstall tries to print banner → npm suppresses it → marker written → CLI shows "installed successfully!" inside TUI session (wrong place)

**After:** postinstall only writes marker → first `altimate` run shows the full welcome box with get-started hints → marker deleted → subsequent runs are clean

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #160

### How did you verify your code works?

- Verified npm 10.x suppresses all postinstall output (stdout + stderr)
- Postinstall test updated: confirms no banner output from postinstall
- Welcome test: 7 pass, marker read/delete flow verified
- Full test suite: 2451 pass, 0 fail

### Checklist

- [x] My code follows the code style of this project
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes