### PR TITLE
fix: prevent upstream tags from polluting origin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Add upstream remote
         run: |
           git remote add upstream https://github.com/anomalyco/opencode.git || true
-          git fetch upstream --quiet
+          git fetch upstream --quiet --no-tags
 
       - name: Install merge tooling deps
         run: bun install

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,7 +69,7 @@ Add a new section at the top of `CHANGELOG.md`:
 git add -A
 git commit -m "release: v0.2.0"
 git tag v0.2.0
-git push origin main --tags
+git push origin main v0.2.0
 ```
 
 ### 4. What happens automatically
@@ -111,7 +111,7 @@ bun run packages/altimate-code/script/bump-version.ts --engine 0.2.1
 git add -A
 git commit -m "release: engine-v0.2.1"
 git tag engine-v0.2.1
-git push origin main --tags
+git push origin main engine-v0.2.1
 ```
 
 This triggers `.github/workflows/publish-engine.yml` which publishes only to PyPI.

--- a/github/script/release
+++ b/github/script/release
@@ -10,7 +10,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 # Get the latest Git tag
-git fetch --force --tags
+git fetch origin --force --tags
 latest_tag=$(git tag --sort=committerdate | grep -E '^github-v[0-9]+\.[0-9]+\.[0-9]+$' | tail -1)
 if [ -z "$latest_tag" ]; then
     echo "No tags found"
@@ -38,4 +38,4 @@ echo "New version: $new_version"
 
 # Tag
 git tag $new_version
-git push --tags
+git push origin "$new_version"

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -63,7 +63,7 @@ if (Script.release) {
     await $`git tag v${Script.version}`
     await $`git fetch origin`
     await $`git cherry-pick HEAD..origin/dev`.nothrow()
-    await $`git push origin HEAD --tags --no-verify --force-with-lease`
+    await $`git push origin HEAD v${Script.version} --no-verify --force-with-lease`
     await new Promise((resolve) => setTimeout(resolve, 5_000))
   }
 

--- a/script/upstream/README.md
+++ b/script/upstream/README.md
@@ -283,7 +283,7 @@ Run `bun run script/upstream/analyze.ts --branding --verbose` to see details. Co
 
 ```bash
 git remote add upstream https://github.com/anomalyco/opencode.git
-git fetch upstream --tags
+git fetch upstream --no-tags
 ```
 
 ### Aborting a merge

--- a/sdks/vscode/script/release
+++ b/sdks/vscode/script/release
@@ -10,7 +10,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 # Get the latest Git tag
-git fetch --force --tags
+git fetch origin --force --tags
 latest_tag=$(git tag --sort=committerdate | grep -E '^vscode-v[0-9]+\.[0-9]+\.[0-9]+$' | tail -1)
 if [ -z "$latest_tag" ]; then
     echo "No tags found"
@@ -38,4 +38,4 @@ echo "New version: $new_version"
 
 # Tag
 git tag $new_version
-git push --tags
+git push origin "$new_version"


### PR DESCRIPTION
### What does this PR do?

Prevents ~900 upstream OpenCode tags from leaking into our origin remote by scoping all `git fetch` and `git push` tag operations.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #164

### How did you verify your code works?

- Deleted 945 stale tags from both local and origin (952 → 7 remaining)
- Verified all 6 changed files use explicit remote targeting and `--no-tags` where appropriate
- Confirmed remaining tags are only Altimate releases: `v0.1.0(-beta*)`, `v0.2.0`, `v0.3.0`, `v0.3.1`

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

---

**Changes across 6 files:**

| File | Problem | Fix |
|---|---|---|
| `.github/workflows/ci.yml` | `git fetch upstream` auto-follows tags | Added `--no-tags` |
| `sdks/vscode/script/release` | `git fetch --force --tags` + `git push --tags` | Explicit `origin`; push only new tag |
| `github/script/release` | Same as above | Same fix |
| `script/publish.ts` | `git push origin HEAD --tags` | Push only `v${version}` |
| `RELEASING.md` | Docs use `--tags` | Push only specific tag |
| `script/upstream/README.md` | Docs use `git fetch upstream --tags` | Changed to `--no-tags` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)