### PR TITLE
fix: add missing async/await to graph children/parents commands

### DIFF
--- a/packages/dbt-tools/src/commands/graph.ts
+++ b/packages/dbt-tools/src/commands/graph.ts
@@ -1,15 +1,15 @@
 import type { DBTProjectIntegrationAdapter } from "@altimateai/dbt-integration"
 
-export function children(adapter: DBTProjectIntegrationAdapter, args: string[]) {
+export async function children(adapter: DBTProjectIntegrationAdapter, args: string[]) {
   const model = flag(args, "model")
   if (!model) return { error: "Missing --model" }
-  return adapter.getChildrenModels({ table: model })
+  return await adapter.getChildrenModels({ table: model })
 }
 
-export function parents(adapter: DBTProjectIntegrationAdapter, args: string[]) {
+export async function parents(adapter: DBTProjectIntegrationAdapter, args: string[]) {
   const model = flag(args, "model")
   if (!model) return { error: "Missing --model" }
-  return adapter.getParentModels({ table: model })
+  return await adapter.getParentModels({ table: model })
 }
 
 function flag(args: string[], name: string): string | undefined {

--- a/packages/dbt-tools/src/index.ts
+++ b/packages/dbt-tools/src/index.ts
@@ -172,10 +172,10 @@ async function main() {
         result = await (await import("./commands/columns")).values(adapter, rest)
         break
       case "children":
-        result = (await import("./commands/graph")).children(adapter, rest)
+        result = await (await import("./commands/graph")).children(adapter, rest)
         break
       case "parents":
-        result = (await import("./commands/graph")).parents(adapter, rest)
+        result = await (await import("./commands/graph")).parents(adapter, rest)
         break
       case "deps":
         result = await (await import("./commands/deps")).deps(adapter)


### PR DESCRIPTION
## Evidence Matrix

| Source | Checked | Data Extracted |
|--------|---------|----------------|
| Sentry | ❌ | N/A — not configured for this repo |
| PostHog | ❌ | N/A — not configured |
| SignOz | ❌ | N/A — not configured |
| Jira | ❌ | N/A |
| Attachments | ❌ | None attached |
| Code Search | ✅ | graph.ts, index.ts — all other switch cases use `await`, only children/parents miss it |
| Existing Tests | ✅ | 11 tests in dbt-tools pass (config + cli tests, no graph-specific tests) |

## Discovery

How I found this: Behavioral analysis of PR #174 (`feat/builder-prompt-and-dbt-skills`).
Both `children()` and `parents()` in `graph.ts` are the only commands missing `async`/`await`.

## Root Cause Analysis

Both `children` and `parents` in `packages/dbt-tools/src/commands/graph.ts` are declared as plain synchronous functions but call async adapter methods (`getChildrenModels`, `getParentModels`) without `await`:

```typescript
// BEFORE — returns Promise, not resolved data
export function children(adapter, args) {
  return adapter.getChildrenModels({ table: model })  // ← no await
}
```

In `index.ts`, the call sites also lack the outer `await`:

```typescript
// BEFORE — result is a Promise object
case "children":
  result = (await import("./commands/graph")).children(adapter, rest)  // ← no await on .children()
```

**Effects:**
1. `result` is a Promise object → `JSON.stringify(Promise)` produces `{}` → empty output
2. The `finally { await adapter.dispose() }` block fires immediately, disposing the Python bridge while the Promise is still pending → crash on the unhandled rejection

**All other switch cases** (compile, test, build-project, execute, columns, deps, etc.) correctly use `result = await (await import(...)).fn(...)`.

## Why This Fix Resolves It

1. **graph.ts**: Added `async` keyword to both function declarations and `await` before adapter calls
2. **index.ts**: Added outer `await` before both `.children()` and `.parents()` calls

This matches the exact pattern used by every other command in the switch block. The adapter methods are confirmed async (same interface as `getColumnsOfModel` which is awaited in `columns.ts`).

## Self-Critique

1. **Root cause confidence:** HIGH — The pattern is unambiguous: every other case uses `await`, these two don't.
2. **What could be wrong:** Nothing — this is a straightforward missing `await` fix.
3. **Edge cases considered:** Early return for missing `--model` flag still works (returns sync `{ error }` before hitting adapter).
4. **Test coverage:** 11 existing dbt-tools tests pass. No graph-specific tests exist in the repo yet.

## Impact

- **Affects:** Both `children` and `parents` dbt graph commands — always produce empty output
- **User impact:** Running graph commands returns `{}` instead of model dependency data
- **Risk:** Low — adding `await` is backward-compatible; matches all other command patterns
- **Files changed:** 2 source files, 0 test files

---
Generated by QA Autopilot | [PR #174](https://github.com/AltimateAI/altimate-code/pull/174)