### PR TITLE
fix: feedback submission fails when repo labels don't exist

### DIFF
--- a/packages/opencode/src/altimate/tools/feedback-submit.ts
+++ b/packages/opencode/src/altimate/tools/feedback-submit.ts
@@ -63,8 +63,7 @@ export const FeedbackSubmitTool = Tool.define("feedback_submit", {
         title: "Feedback submission failed",
         metadata: { error: "gh_auth_check_failed", issueUrl: "" },
         output:
-          "Failed to verify `gh` authentication status. Please check your installation with:\n" +
-          "  `gh auth status`",
+          "Failed to verify `gh` authentication status. Please check your installation with:\n" + "  `gh auth status`",
       }
     }
     if (authStatus.exitCode !== 0) {
@@ -105,20 +104,44 @@ export const FeedbackSubmitTool = Tool.define("feedback_submit", {
     // Build labels
     const labels = ["user-feedback", "from-cli", CATEGORY_LABELS[args.category]]
 
-    // Create the issue
+    // Create the issue — try with labels first, fall back without labels
+    // if it fails (e.g. when labels don't exist in the repository yet)
     let issueResult: { stdout: Buffer; stderr: Buffer; exitCode: number }
     try {
-      issueResult = await Bun.$`gh issue create --repo AltimateAI/altimate-code --title ${args.title} --body ${body} --label ${labels.join(",")}`.quiet().nothrow()
+      issueResult =
+        await Bun.$`gh issue create --repo AltimateAI/altimate-code --title ${args.title} --body ${body} --label ${labels.join(",")}`
+          .quiet()
+          .nothrow()
     } catch {
       return {
         title: "Feedback submission failed",
         metadata: { error: "issue_creation_failed", issueUrl: "" },
-        output: "Failed to create GitHub issue. The `gh` CLI encountered an unexpected error.\n\nPlease check your gh CLI installation and try again.",
+        output:
+          "Failed to create GitHub issue. The `gh` CLI encountered an unexpected error.\n\nPlease check your gh CLI installation and try again.",
       }
     }
 
-    const stdout = issueResult.stdout.toString().trim()
-    const stderr = issueResult.stderr.toString().trim()
+    let stdout = issueResult.stdout.toString().trim()
+    let stderr = issueResult.stderr.toString().trim()
+
+    // If creation failed (e.g. missing labels), retry without labels
+    if (issueResult.exitCode !== 0 || !stdout || !stdout.includes("github.com")) {
+      try {
+        issueResult = await Bun.$`gh issue create --repo AltimateAI/altimate-code --title ${args.title} --body ${body}`
+          .quiet()
+          .nothrow()
+      } catch {
+        return {
+          title: "Feedback submission failed",
+          metadata: { error: "issue_creation_failed", issueUrl: "" },
+          output:
+            "Failed to create GitHub issue. The `gh` CLI encountered an unexpected error.\n\nPlease check your gh CLI installation and try again.",
+        }
+      }
+
+      stdout = issueResult.stdout.toString().trim()
+      stderr = issueResult.stderr.toString().trim()
+    }
 
     if (issueResult.exitCode !== 0 || !stdout || !stdout.includes("github.com")) {
       const errorDetail = stderr || stdout || "No output from gh CLI"

--- a/packages/opencode/test/tool/feedback-submit.test.ts
+++ b/packages/opencode/test/tool/feedback-submit.test.ts
@@ -411,23 +411,21 @@ describe("tool.feedback_submit", () => {
 
       expect(result.title).toBe("Feedback submitted")
       expect(result.metadata.error).toBe("")
-      expect(result.metadata.issueUrl).toBe(
-        "https://github.com/AltimateAI/altimate-code/issues/42",
-      )
+      expect(result.metadata.issueUrl).toBe("https://github.com/AltimateAI/altimate-code/issues/42")
       expect(result.output).toContain("successfully")
-      expect(result.output).toContain(
-        "https://github.com/AltimateAI/altimate-code/issues/42",
-      )
+      expect(result.output).toContain("https://github.com/AltimateAI/altimate-code/issues/42")
     })
 
-    test("returns failure when issue creation output has no github URL", async () => {
+    test("returns failure when both label and no-label attempts have no github URL", async () => {
       const tool = await FeedbackSubmitTool.init()
 
       // gh --version
       pushShellResult("gh version 2.40.0")
       // gh auth status
       pushShellResult("Logged in as user", 0)
-      // gh issue create fails with unexpected output
+      // gh issue create with labels — fails
+      pushShellResult("some error occurred")
+      // gh issue create without labels — also fails
       pushShellResult("some error occurred")
 
       const result = await tool.execute(
@@ -445,11 +443,14 @@ describe("tool.feedback_submit", () => {
       expect(result.output).toContain("Failed to create GitHub issue")
     })
 
-    test("returns failure when issue creation returns empty output", async () => {
+    test("returns failure when both attempts return empty output", async () => {
       const tool = await FeedbackSubmitTool.init()
 
       pushShellResult("gh version 2.40.0")
       pushShellResult("Logged in", 0)
+      // with labels — empty
+      pushShellResult("")
+      // without labels — also empty
       pushShellResult("")
 
       const result = await tool.execute(
@@ -466,13 +467,40 @@ describe("tool.feedback_submit", () => {
       expect(result.metadata.error).toBe("issue_creation_failed")
     })
 
-    test("returns failure when issue creation has non-zero exitCode even with stdout", async () => {
+    test("succeeds via fallback when label creation fails but no-label attempt works", async () => {
       const tool = await FeedbackSubmitTool.init()
 
       pushShellResult("gh version 2.40.0")
       pushShellResult("Logged in", 0)
-      // gh issue create exits non-zero (e.g. label doesn't exist) with partial output
+      // gh issue create with labels — fails (e.g. missing label)
+      shellResults.push({ text: "label 'from-cli' not found", exitCode: 1 })
+      // gh issue create without labels — succeeds
+      pushShellResult("https://github.com/AltimateAI/altimate-code/issues/99")
+
+      const result = await tool.execute(
+        {
+          title: "Test fallback",
+          category: "feature" as const,
+          description: "test",
+          include_context: false,
+        },
+        ctx,
+      )
+
+      expect(result.title).toBe("Feedback submitted")
+      expect(result.metadata.error).toBe("")
+      expect(result.metadata.issueUrl).toBe("https://github.com/AltimateAI/altimate-code/issues/99")
+    })
+
+    test("returns failure when label attempt has non-zero exitCode and retry also fails", async () => {
+      const tool = await FeedbackSubmitTool.init()
+
+      pushShellResult("gh version 2.40.0")
+      pushShellResult("Logged in", 0)
+      // gh issue create with labels — exits non-zero
       shellResults.push({ text: "https://github.com/AltimateAI/altimate-code/issues/1", exitCode: 1 })
+      // retry without labels — also fails
+      shellResults.push({ text: "rate limit exceeded", exitCode: 1 })
 
       const result = await tool.execute(
         {
@@ -494,6 +522,30 @@ describe("tool.feedback_submit", () => {
       pushShellResult("gh version 2.40.0")
       pushShellResult("Logged in", 0)
       // gh issue create throws ENOENT
+      pushShellThrow()
+
+      const result = await tool.execute(
+        {
+          title: "Test",
+          category: "bug" as const,
+          description: "test",
+          include_context: false,
+        },
+        ctx,
+      )
+
+      expect(result.title).toBe("Feedback submission failed")
+      expect(result.metadata.error).toBe("issue_creation_failed")
+    })
+
+    test("returns failure when retry without labels throws", async () => {
+      const tool = await FeedbackSubmitTool.init()
+
+      pushShellResult("gh version 2.40.0")
+      pushShellResult("Logged in", 0)
+      // first attempt fails (non-zero exit)
+      shellResults.push({ text: "label not found", exitCode: 1 })
+      // retry throws
       pushShellThrow()
 
       const result = await tool.execute(
@@ -687,7 +739,7 @@ describe("tool.feedback_submit", () => {
       expect(createCall).toContain("My specific title")
     })
 
-    test("makes exactly 3 shell calls for successful submission", async () => {
+    test("makes exactly 3 shell calls for successful submission when labels exist", async () => {
       const tool = await FeedbackSubmitTool.init()
 
       pushShellResult("gh version 2.40.0")
@@ -705,6 +757,32 @@ describe("tool.feedback_submit", () => {
       )
 
       expect(shellCalls.length).toBe(3)
+    })
+
+    test("makes exactly 4 shell calls when label attempt fails and retry succeeds", async () => {
+      const tool = await FeedbackSubmitTool.init()
+
+      pushShellResult("gh version 2.40.0")
+      pushShellResult("Logged in", 0)
+      // with labels — fails
+      shellResults.push({ text: "label not found", exitCode: 1 })
+      // without labels — succeeds
+      pushShellResult("https://github.com/AltimateAI/altimate-code/issues/1")
+
+      await tool.execute(
+        {
+          title: "Test",
+          category: "bug" as const,
+          description: "test",
+          include_context: false,
+        },
+        ctx,
+      )
+
+      expect(shellCalls.length).toBe(4)
+      // Verify the retry call does NOT contain --label
+      const retryCall = shellCalls[3].join("")
+      expect(retryCall).not.toContain("--label")
     })
 
     test("makes only 1 shell call when gh is not installed", async () => {


### PR DESCRIPTION
### What does this PR do?

Fixes the `/feedback` command failing when GitHub labels (e.g. `from-cli`) don't exist in the repository. Adds a fallback retry without labels when the initial `gh issue create --label` call fails.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #187

### How did you verify your code works?

- All 45 unit tests pass (including 6 new tests for the fallback path)
- Created the missing `from-cli`, `enhancement`, and `improvement` labels in the repo

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I've added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes