### PR TITLE
chore: update install commands to use unscoped `altimate-code`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Teach your AI teammate project-specific patterns, naming conventions, and best p
 
 ```bash
 # npm (recommended)
-npm install -g @altimateai/altimate-code
+npm install -g altimate-code
 
 # Homebrew
 brew install AltimateAI/tap/altimate-code

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,6 +9,7 @@ The monorepo produces two publishable packages:
 | Package | Registry | Trigger |
 |---------|----------|---------|
 | `@altimateai/altimate-code` | npm | `v*` tag (e.g., `v0.3.0`) |
+| `altimate-code` | npm | Same `v*` tag (unscoped alias) |
 | `altimate-engine` | PyPI | Same `v*` tag (published alongside CLI) |
 
 Both packages are versioned and released together. The CLI embeds the expected engine version at build time and auto-installs it on end-user machines.
@@ -77,7 +78,7 @@ git push origin main v0.2.0
 The `v*` tag triggers `.github/workflows/release.yml` which:
 
 1. **Builds** all platform binaries (linux/darwin/windows, x64/arm64)
-2. **Publishes to npm** — platform-specific binary packages + wrapper package `altimate-code-ai`
+2. **Publishes to npm** — platform-specific binary packages + scoped wrapper `@altimateai/altimate-code` + unscoped wrapper `altimate-code`
 3. **Publishes to PyPI** — `altimate-engine` via OIDC trusted publishing
 4. **Creates GitHub Release** — with auto-generated release notes and binary attachments
 5. **Updates Homebrew tap** — pushes formula update to `AltimateAI/homebrew-tap`
@@ -89,8 +90,9 @@ The `v*` tag triggers `.github/workflows/release.yml` which:
 After the workflow completes:
 
 ```bash
-# npm
+# npm (both scoped and unscoped should show same version)
 npm info @altimateai/altimate-code version
+npm info altimate-code version
 
 # PyPI
 pip install altimate-engine==0.2.0

--- a/docs/docs/data-engineering/guides/using-with-claude-code.md
+++ b/docs/docs/data-engineering/guides/using-with-claude-code.md
@@ -75,7 +75,7 @@ altimate:
 
 ## Setup
 
-1. Install altimate globally: `npm install -g @altimateai/altimate-code`
+1. Install altimate globally: `npm install -g altimate-code`
 2. Configure warehouse connections in your project
 3. Claude Code automatically discovers altimate's tools when the `/data` skill is invoked
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -17,7 +17,7 @@ Unlike general-purpose coding agents, altimate is built for data teams:
 ## Installation
 
 ```bash
-npm install -g @altimateai/altimate-code
+npm install -g altimate-code
 ```
 
 After install, you'll see a welcome banner with quick-start commands. On upgrades, the banner also shows what changed since your previous version.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -31,7 +31,7 @@ hide:
 <div class="hero-install" markdown>
 
 ```bash
-npm install -g @altimateai/altimate-code
+npm install -g altimate-code
 ```
 
 </div>

--- a/docs/docs/usage/github.md
+++ b/docs/docs/usage/github.md
@@ -31,7 +31,7 @@ jobs:
         with:
           node-version: "22"
       - name: Install altimate
-        run: npm install -g @altimateai/altimate-code
+        run: npm install -g altimate-code
       - name: Run agent
         run: altimate github
         env:

--- a/docs/docs/usage/gitlab.md
+++ b/docs/docs/usage/gitlab.md
@@ -15,7 +15,7 @@ altimate-review:
   image: node:22
   stage: review
   script:
-    - npm install -g @altimateai/altimate-code
+    - npm install -g altimate-code
     - altimate github  # Uses GitHub-compatible interface
   variables:
     ANTHROPIC_API_KEY: $ANTHROPIC_API_KEY

--- a/docs/docs/usage/ide.md
+++ b/docs/docs/usage/ide.md
@@ -12,7 +12,7 @@ altimate integrates with VS Code and Cursor as an AI assistant.
 1. Install the altimate extension from the marketplace
 2. Ensure `altimate` is installed globally:
    ```bash
-   npm install -g @altimateai/altimate-code
+   npm install -g altimate-code
    ```
 3. The extension will auto-detect the CLI
 

--- a/docs/docs/windows-wsl.md
+++ b/docs/docs/windows-wsl.md
@@ -17,7 +17,7 @@ altimate is supported on Windows through WSL (Windows Subsystem for Linux).
 
 3. Install altimate:
    ```bash
-   npm install -g @altimateai/altimate-code
+   npm install -g altimate-code
    ```
 
 4. Launch:

--- a/script/upstream/README.md
+++ b/script/upstream/README.md
@@ -191,7 +191,7 @@ Ordered most-specific-first to prevent partial matches. Categories:
 | App IDs | `ai.opencode.desktop` -> `ai.altimate.code.desktop` |
 | Social | `x.com/altaborodin` -> `x.com/Altimateinc` |
 | Product name | `OpenCode` -> `Altimate Code` |
-| Install commands | `npm i -g opencode-ai` -> `npm i -g @altimateai/altimate-code` |
+| Install commands | `npm i -g opencode-ai` -> `npm i -g altimate-code` |
 | Homebrew | `anomalyco/tap/opencode` -> `AltimateAI/tap/altimate-code` |
 
 ### Adding a new branding rule

--- a/script/upstream/utils/config.ts
+++ b/script/upstream/utils/config.ts
@@ -199,22 +199,22 @@ const productNameRules: StringReplacement[] = [
 const npmInstallRules: StringReplacement[] = [
   {
     pattern: /bun i -g opencode-ai/g,
-    replacement: "bun i -g @altimateai/altimate-code",
+    replacement: "bun i -g altimate-code",
     description: "bun global install",
   },
   {
     pattern: /npm install -g opencode-ai/g,
-    replacement: "npm install -g @altimateai/altimate-code",
+    replacement: "npm install -g altimate-code",
     description: "npm global install",
   },
   {
     pattern: /npm i -g opencode-ai/g,
-    replacement: "npm i -g @altimateai/altimate-code",
+    replacement: "npm i -g altimate-code",
     description: "npm short global install",
   },
   {
     pattern: /npx opencode-ai/g,
-    replacement: "npx @altimateai/altimate-code",
+    replacement: "npx altimate-code",
     description: "npx invocation",
   },
 ]


### PR DESCRIPTION
### What does this PR do?

Updates all user-facing install commands from `npm install -g @altimateai/altimate-code` to the simpler `npm install -g altimate-code`, now that the unscoped package is published (#229).

Also updates the upstream merge branding rules so future merges produce the correct unscoped install commands.

### Type of change

- [x] Chore (docs, config, non-code change)

### Issue for this PR

Closes #233

### How did you verify your code works?

- Verified all 10 changed files have correct replacement
- CI release notes kept scoped (version-pinned installs work better with scoped names)
- Typecheck passes

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)