### PR TITLE
fix: mark driver packages as external in build to prevent 4x binary bloat

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -199,6 +199,13 @@ for (const item of targets) {
     tsconfig: "./tsconfig.json",
     plugins: [solidPlugin],
     sourcemap: "external",
+    // Database drivers are loaded lazily at runtime via dynamic import().
+    // They must NOT be bundled into the binary — users install them on demand.
+    external: [
+      "pg", "snowflake-sdk", "@google-cloud/bigquery", "@databricks/sql",
+      "mysql2", "mssql", "oracledb", "duckdb", "better-sqlite3",
+      "keytar", "ssh2", "dockerode",
+    ],
     compile: {
       autoloadBunfig: false,
       autoloadDotenv: false,


### PR DESCRIPTION
### What does this PR do?

Adds database driver packages to the `external` array in `Bun.build()` config so they're NOT bundled into the compiled binary.

Build artifacts went from 1GB (v0.4.1) to 4GB (v0.4.2+) because driver packages (pg, snowflake-sdk, bigquery, etc.) were being bundled. This caused npm publish to fail with ENOSPC.

### Type of change
- [x] Bug fix

### Issue for this PR
Fixes npm publish ENOSPC failure in v0.4.2/v0.4.3 releases.

### How did you verify your code works?
Typecheck passes. Build config change only — no runtime changes.

### Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code

🤖 Generated with [Claude Code](https://claude.com/claude-code)