### PR TITLE
fix: add altimate-core + dbt-integration to build externals

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -199,12 +199,18 @@ for (const item of targets) {
     tsconfig: "./tsconfig.json",
     plugins: [solidPlugin],
     sourcemap: "external",
-    // Database drivers are loaded lazily at runtime via dynamic import().
-    // They must NOT be bundled into the binary — users install them on demand.
+    // Packages that must NOT be bundled into the compiled binary.
+    // They are loaded lazily via dynamic import() at runtime.
     external: [
+      // altimate-core napi binary — ~50MB per platform, loaded on first tool call
+      "@altimateai/altimate-core",
+      // dbt integration — heavy transitive deps (electron, aws-sdk, etc.)
+      "@altimateai/dbt-integration",
+      // Database drivers — users install on demand
       "pg", "snowflake-sdk", "@google-cloud/bigquery", "@databricks/sql",
       "mysql2", "mssql", "oracledb", "duckdb", "better-sqlite3",
-      "keytar", "ssh2", "dockerode",
+      // Optional infra packages
+      "keytar", "ssh2", "dockerode", "yaml",
     ],
     compile: {
       autoloadBunfig: false,


### PR DESCRIPTION
### What does this PR do?
Adds `@altimateai/altimate-core` (napi binary, ~50MB/platform) and `@altimateai/dbt-integration` (heavy transitive deps) to the `external` array in `Bun.build()`. These were being bundled into compiled binaries, causing 4x size bloat (80MB→500MB per platform).

### Type of change
- [x] Bug fix

### How did you verify your code works?
Typecheck passes. Binary size should return to ~80MB per platform (matching v0.4.1).

### Checklist
- [x] My code follows the project's coding standards
