### PR TITLE
fix: Docker E2E tests skip in CI unless explicitly opted in

### DIFF
--- a/packages/opencode/test/altimate/drivers-docker-e2e.test.ts
+++ b/packages/opencode/test/altimate/drivers-docker-e2e.test.ts
@@ -9,8 +9,14 @@ import { createConnection } from "net"
 
 const HAS_CI_SERVICES = !!(process.env.TEST_MYSQL_HOST || process.env.TEST_MSSQL_HOST || process.env.TEST_REDSHIFT_HOST)
 
+// Only run Docker tests when explicitly opted in via DRIVER_E2E_DOCKER=1
+// or when CI services are configured. This prevents the TypeScript CI job
+// (which has Docker but no test databases) from trying to start containers.
+const DOCKER_OPT_IN = process.env.DRIVER_E2E_DOCKER === "1"
+
 function isDockerAvailable(): boolean {
-  if (HAS_CI_SERVICES) return true // CI services replace Docker
+  if (HAS_CI_SERVICES) return true
+  if (!DOCKER_OPT_IN) return false // Skip unless explicitly opted in
   try {
     execSync("docker info", { stdio: "ignore", timeout: 3000 })
     return true

--- a/packages/opencode/test/altimate/drivers-e2e.test.ts
+++ b/packages/opencode/test/altimate/drivers-e2e.test.ts
@@ -34,6 +34,7 @@ function isBetterSqlite3Available(): boolean {
 
 function isDockerAvailable(): boolean {
   if (process.env.TEST_PG_HOST) return true // CI services replace Docker
+  if (!process.env.DRIVER_E2E_DOCKER) return false // Skip unless opted in
   try {
     execSync("docker info", { stdio: "ignore", timeout: 3000 })
     return true


### PR DESCRIPTION
3 tests hang for 60-90s in CI because Docker exists but no test DBs are running. Now requires DRIVER_E2E_DOCKER=1 to run locally.