### PR TITLE
fix: dispatcher tests fail in CI due to shared module state

### DIFF
--- a/packages/opencode/test/altimate/schema-finops-dbt.test.ts
+++ b/packages/opencode/test/altimate/schema-finops-dbt.test.ts
@@ -6,14 +6,21 @@ beforeAll(() => { process.env.ALTIMATE_TELEMETRY_DISABLED = "true" })
 afterAll(() => { delete process.env.ALTIMATE_TELEMETRY_DISABLED })
 
 // ---------------------------------------------------------------------------
-// Import modules AFTER env var is set
+// Import registerAll functions — call them explicitly in beforeAll to guard
+// against Dispatcher.reset() in other test files clearing the shared handler map.
 // ---------------------------------------------------------------------------
 
-// These side-effect imports register handlers
-import "../../src/altimate/native/schema/register"
-import "../../src/altimate/native/finops/register"
-import "../../src/altimate/native/dbt/register"
-import "../../src/altimate/native/local/register"
+import { registerAll as registerSchema } from "../../src/altimate/native/schema/register"
+import { registerAll as registerFinops } from "../../src/altimate/native/finops/register"
+import { registerAll as registerDbt } from "../../src/altimate/native/dbt/register"
+import { registerAll as registerLocal } from "../../src/altimate/native/local/register"
+
+beforeAll(() => {
+  registerSchema()
+  registerFinops()
+  registerDbt()
+  registerLocal()
+})
 
 // Import SQL template exports for template generation tests
 import { SQL_TEMPLATES as CreditTemplates } from "../../src/altimate/native/finops/credit-analyzer"


### PR DESCRIPTION
### What does this PR do?

Fixes 11 test failures in CI by replacing side-effect imports with explicit `registerAll()` calls in `beforeAll`. `Dispatcher.reset()` in `dispatcher.test.ts` clears the shared `nativeHandlers` Map, and since Bun shares modules across test files, the one-time side-effect imports never re-register handlers.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #256

### How did you verify your code works?

- Ran both `dispatcher.test.ts` and `schema-finops-dbt.test.ts` together in both orderings — 58/58 pass
- Ran full test suite — 3294 pass, 0 new failures

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)