### PR TITLE
fix: surface project context in system prompt for connection discovery

### DIFF
--- a/packages/opencode/src/altimate/fingerprint/index.ts
+++ b/packages/opencode/src/altimate/fingerprint/index.ts
@@ -6,6 +6,12 @@ import path from "path"
 
 const log = Log.create({ service: "fingerprint" })
 
+/** Canonical list of warehouse adapter identifiers, shared with system prompt builder. */
+export const ADAPTER_TAGS = [
+  "snowflake", "bigquery", "redshift", "databricks", "postgres",
+  "mysql", "sqlite", "duckdb", "trino", "spark", "clickhouse",
+] as const
+
 export namespace Fingerprint {
   export interface Result {
     tags: string[]
@@ -102,7 +108,7 @@ export namespace Fingerprint {
       try {
         const content = await Filesystem.readText(path.join(dir, "profiles.yml"))
         const adapterMatch = content.match(
-          /type:\s*(snowflake|bigquery|redshift|databricks|postgres|mysql|sqlite|duckdb|trino|spark|clickhouse)/i,
+          new RegExp(`type:\\s*(${ADAPTER_TAGS.join("|")})`, "i"),
         )
         if (adapterMatch) {
           tags.push(adapterMatch[1]!.toLowerCase())

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -14,7 +14,7 @@ import type { Agent } from "@/agent/agent"
 import { PermissionNext } from "@/permission/next"
 import { Skill } from "@/skill"
 // altimate_change start - import for env-based skill selection
-import { Fingerprint } from "../altimate/fingerprint"
+import { Fingerprint, ADAPTER_TAGS } from "../altimate/fingerprint"
 import { Config } from "../config/config"
 import { selectSkillsWithLLM } from "../altimate/skill-selector"
 // altimate_change end
@@ -61,32 +61,36 @@ export namespace SystemPrompt {
     ]
 
     // altimate_change start - inject project context to guide connection discovery
-    const fingerprint = Fingerprint.get() ?? await Fingerprint.detect(Instance.directory, Instance.worktree)
-    if (fingerprint.tags.length > 0) {
-      const isDbt = fingerprint.tags.includes("dbt")
-      const adapterTags = ["snowflake", "bigquery", "redshift", "databricks", "postgres", "mysql", "duckdb", "trino", "spark", "clickhouse"]
-      const detectedAdapter = fingerprint.tags.find(t => adapterTags.includes(t))
+    try {
+      // detect() caches per-cwd, so calling it directly is both correct and cheap
+      const fingerprint = await Fingerprint.detect(Instance.directory, Instance.worktree)
+      if (fingerprint.tags.length > 0) {
+        const isDbt = fingerprint.tags.includes("dbt")
+        const detectedAdapter = fingerprint.tags.find(t => (ADAPTER_TAGS as readonly string[]).includes(t))
 
-      parts.push(
-        [
-          `<project-context>`,
-          `  Detected project tags: ${fingerprint.tags.join(", ")}`,
-          ...(isDbt ? [
-            ``,
-            `  This workspace contains a dbt project. When executing SQL queries:`,
-            `  1. Attempt to use the dbt connection first (configured via profiles.yml${detectedAdapter ? `, adapter: ${detectedAdapter}` : ""}).`,
-            `  2. If the dbt connection is unavailable or fails, fall back to a configured warehouse connection.`,
-            `  3. If neither works, ask the user for the credentials needed to connect${detectedAdapter ? ` to ${detectedAdapter}` : ""}.`,
-            `  Do not assume the dbt connection will always succeed — be prepared to ask for credentials.`,
-          ] : [
-            ``,
-            `  No dbt project detected. When SQL execution is needed:`,
-            `  1. Check if a warehouse connection is already configured.`,
-            `  2. If not, ask the user for the connection credentials appropriate to this project${detectedAdapter ? ` (detected: ${detectedAdapter})` : ""}.`,
-          ]),
-          `</project-context>`,
-        ].join("\n"),
-      )
+        parts.push(
+          [
+            `<project-context>`,
+            `  Detected project tags: ${fingerprint.tags.join(", ")}`,
+            ...(isDbt ? [
+              ``,
+              `  This workspace contains a dbt project. When executing SQL queries:`,
+              `  1. Attempt to use the dbt connection first (configured via profiles.yml${detectedAdapter ? `, adapter: ${detectedAdapter}` : ""}).`,
+              `  2. If the dbt connection is unavailable or fails, fall back to a configured warehouse connection.`,
+              `  3. If neither works, ask the user for the credentials needed to connect${detectedAdapter ? ` to ${detectedAdapter}` : ""}.`,
+              `  Do not assume the dbt connection will always succeed — be prepared to ask for credentials.`,
+            ] : [
+              ``,
+              `  No dbt project detected. When SQL execution is needed:`,
+              `  1. Check if a warehouse connection is already configured.`,
+              `  2. If not, ask the user for the connection credentials appropriate to this project${detectedAdapter ? ` (detected: ${detectedAdapter})` : ""}.`,
+            ]),
+            `</project-context>`,
+          ].join("\n"),
+        )
+      }
+    } catch {
+      // fingerprint detection is best-effort — never block session startup
     }
     // altimate_change end
 


### PR DESCRIPTION
## Summary

- Injects a `<project-context>` block into the system prompt based on workspace fingerprint detection
- **dbt project open**: instructs the LLM to try dbt connection first (via `profiles.yml`), fall back to a configured warehouse connection, and ask the user for credentials (scoped to the detected adapter) if both fail
- **No dbt project**: instructs the LLM to check for an existing warehouse connection and ask the user for adapter-appropriate credentials if none is configured
- Detected warehouse adapter (e.g. `snowflake`, `bigquery`) is surfaced in both paths so credential prompts are specific, not generic

## Motivation

Previously the agent had no awareness of the open project's connection context. It would either silently fail or ask for generic credentials. This change makes the agent behave like it understands the environment — trying the right path first and asking the right questions when things don't work.

## Test plan

- [ ] Open a dbt project with a valid `profiles.yml` — agent should use dbt connection without asking for credentials
- [ ] Open a dbt project where dbt connection fails — agent should fall back to warehouse connection or ask for credentials with the correct adapter type
- [ ] Open a non-dbt project with a detected adapter (e.g. `.sqlfluff` + snowflake) — agent should ask for warehouse credentials scoped to that adapter
- [ ] Open a project with no detectable tags — `<project-context>` block should be omitted entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)