### PR TITLE
fix: trace system prompt only once per session

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -728,14 +728,19 @@ export namespace SessionPrompt {
         system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
       }
 
-      // altimate_change start - trace system prompt
-      Tracer.active?.logSpan({
-        name: "system-prompt",
-        startTime: Date.now(),
-        endTime: Date.now(),
-        input: { agent: agent.name, step },
-        output: { parts: system.length, content: system.join("\n\n") },
-      })
+      // altimate_change start - trace system prompt once per loop() call.
+      // The system prompt is functionally identical across steps within a single
+      // loop() invocation (same agent, same environment). Agent switches re-enter
+      // loop() with step reset to 0, so each agent's prompt is traced separately.
+      if (step === 1) {
+        Tracer.active?.logSpan({
+          name: "system-prompt",
+          startTime: Date.now(),
+          endTime: Date.now(),
+          input: { agent: agent.name, step },
+          output: { parts: system.length, content: system.join("\n\n") },
+        })
+      }
       // altimate_change end
 
       const result = await processor.process({


### PR DESCRIPTION
## Summary
- The `system-prompt` tracing span was inside the `while(true)` loop, firing on every LLM generation step. A session with N tool-calling rounds produced N identical spans.
- Added `step === 1` guard so the system prompt is traced once per `loop()` call.
- Agent switches re-enter `loop()` with step reset, so each agent's prompt is still captured.

## Changes
- Guard `logSpan("system-prompt")` with `if (step === 1)` to avoid duplication
- Document the static-prompt assumption in comments
- Keep `step` in span input for debugging context

## Test plan
- [ ] Verify traces contain exactly 1 `system-prompt` span per session
- [ ] Verify agent switches still produce separate `system-prompt` spans
- [ ] Verify no regression in tracing output format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Reviewed by 7 AI models (Claude, Codex, Kimi, Grok, MiniMax, GLM-5, Qwen). Unanimous APPROVE after 1 convergence round.*