### PR TITLE
chore:remove brew from docs and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,7 @@ into CI pipelines and orchestration DAGs. Precision data tooling for any LLM.
 ## Install
 
 ```bash
-# npm (recommended)
 npm install -g altimate-code
-
-# Homebrew
-brew install AltimateAI/tap/altimate-code
 ```
 
 Then — in order:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -64,9 +64,8 @@ The `v*` tag triggers `.github/workflows/release.yml` which:
 1. **Builds** all platform binaries (linux/darwin/windows, x64/arm64)
 2. **Publishes to npm** — platform-specific binary packages + wrapper package
 3. **Creates GitHub Release** — with auto-generated release notes and binary attachments
-4. **Updates Homebrew tap** — pushes formula update to `AltimateAI/homebrew-tap`
-5. **Updates AUR** — pushes PKGBUILD update to `altimate-code-bin`
-6. **Publishes Docker image** — to `ghcr.io/altimateai/altimate-code`
+4. **Updates AUR** — pushes PKGBUILD update to `altimate-code-bin`
+5. **Publishes Docker image** — to `ghcr.io/altimateai/altimate-code`
 
 ### 4. Verify
 
@@ -75,9 +74,6 @@ After the workflow completes:
 ```bash
 # npm
 npm info @altimateai/altimate-code version
-
-# Homebrew
-brew update && brew info altimate/tap/altimate-code
 
 # Docker
 docker pull ghcr.io/altimateai/altimate-code:0.5.0
@@ -100,10 +96,6 @@ Before your first release, set up:
 ### GitHub
 - `GITHUB_TOKEN` is automatically provided by GitHub Actions
 - Enable GitHub Packages for Docker image publishing
-
-### Homebrew
-- Create `AltimateAI/homebrew-tap` repository
-- The `GITHUB_TOKEN` needs write access to this repo
 
 ### AUR (optional)
 - Register the `altimate-code-bin` package on AUR

--- a/docs/docs/getting-started/quickstart-new.md
+++ b/docs/docs/getting-started/quickstart-new.md
@@ -12,8 +12,6 @@ description: "Get value from Altimate Code in 10 minutes. For data engineers who
 npm install -g altimate-code
 ```
 
-Or via Homebrew: `brew install AltimateAI/tap/altimate-code`
-
 ---
 
 ## Step 2: Connect Your LLM

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -4,18 +4,14 @@ description: "Install altimate-code, connect your warehouse and LLM, configure a
 
 # Setup
 
-> **You need:** npm 8+ or Homebrew. An API key for any supported LLM provider.
+> **You need:** npm 8+. An API key for any supported LLM provider.
 
 ---
 
 ## Step 1: Install
 
 ```bash
-# npm (recommended)
 npm install -g altimate-code
-
-# Homebrew
-brew install AltimateAI/tap/altimate-code
 ```
 
 > **Zero additional setup.** One command install.

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -4,18 +4,14 @@ description: "Install altimate-code and run your first SQL analysis. The open-so
 
 # Quickstart
 
-> **You need:** npm 8+ or Homebrew. An API key for any supported LLM provider.
+> **You need:** npm 8+. An API key for any supported LLM provider.
 
 ---
 
 ## Step 1: Install
 
 ```bash
-# npm (recommended)
 npm install -g altimate-code
-
-# Homebrew
-brew install AltimateAI/tap/altimate-code
 ```
 
 > **Zero additional setup.** One command install.


### PR DESCRIPTION
Removed Homebrew

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Homebrew installation instructions from all installation guides.
  * Updated prerequisites to require only npm 8+ (previously npm 8+ or Homebrew).
  * Simplified installation documentation to feature npm as the sole installation method.
  * Removed related release workflow documentation for Homebrew tap publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->