### PR TITLE
fix: suppress Snowflake logger noise in TUI output

### DIFF
--- a/packages/drivers/src/snowflake.ts
+++ b/packages/drivers/src/snowflake.ts
@@ -17,12 +17,15 @@ export async function connect(config: ConnectionConfig): Promise<Connector> {
   }
 
   // Suppress snowflake-sdk's Winston console logging — it writes JSON log
-  // lines to stdout which corrupt the TUI display (see #249).
+  // lines into the interactive TUI output and corrupts the display.
   if (typeof snowflake.configure === "function") {
     try {
-      snowflake.configure({ logLevel: "OFF" })
+      snowflake.configure({
+        logLevel: "OFF",
+        additionalLogToConsole: false,
+      })
     } catch {
-      // Older SDK versions may not support this option; ignore.
+      // Older SDK versions may not support these options; ignore.
     }
   }
 


### PR DESCRIPTION
## Bug
Fixes #300 — Snowflake SDK logger output can leak JSON log lines into the interactive terminal output, which corrupts the TUI display during spend analysis commands.

## Fix
- Keep Snowflake logging disabled with `logLevel: "OFF"`.
- Explicitly set `additionalLogToConsole: false` in `snowflake.configure(...)` so the SDK does not emit logger lines to the terminal stream.

## Testing
- Verified the driver-level configuration path now disables both log level and console mirroring before creating a connection.
- Change is scoped to Snowflake connector initialization only.

Happy to address any feedback.

Greetings, saschabuehrle


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Snowflake driver console logging suppression configuration to more effectively prevent unwanted log output in the interactive terminal environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->