### PR TITLE
fix: address multi-model code review findings for recent merges

### DIFF
--- a/.github/meta/commit.txt
+++ b/.github/meta/commit.txt
@@ -1,26 +1,18 @@
-fix: harden auth field handling for all warehouse drivers (#267)
+fix: address multi-model code review findings for recent merges
 
-Add config field name normalization so LLM-generated, dbt, and SDK
-field names all resolve to canonical snake_case before reaching drivers.
-
-- Add `normalizeConfig()` in `@altimateai/drivers` with per-driver alias
-  maps (Snowflake, BigQuery, Databricks, Redshift, PostgreSQL, MySQL,
-  SQL Server, Oracle) and common aliases (`username` → `user`,
-  `dbname` → `database`)
-- Call `normalizeConfig()` before both `resolveConfig()` and
-  `saveConnection()` in registry so credential store uses canonical names
-- Add Snowflake inline PEM support via `config.private_key`
-- Add BigQuery `credentials_json` (inline JSON) support
-- Add MySQL SSL construction from top-level `ssl_ca`/`ssl_cert`/`ssl_key`
-  fields at connection time (not during normalization, to preserve
-  credential store detection)
-- Expand `SENSITIVE_FIELDS` with `private_key`, `token`,
-  `credentials_json`, `keyfile_json`, `ssl_key`, `ssl_cert`, `ssl_ca`
-- Update `sensitiveKeys` in `project-scan.ts` to match
-- Fix `detectAuthMethod()` to recognize inline `private_key`
-- Update `warehouse_add` tool description with per-warehouse field docs
-- Add 72 unit tests for normalization logic
-
-Closes #267
+- Fix TUI trace dialog ignoring custom `tracing.dir` config — plumb
+  config dir through `DialogTraceList`, `getTraceViewerUrl`, and
+  `openTraceInBrowser` so custom trace directories work in the TUI
+- Fix WebFetch `clearTimeout` leak — move both `fetch` calls inside the
+  `try` block so the `finally` clause always clears the timer, even on
+  DNS failures or `AbortError`
+- Fix `cleanTitle` empty string fallback — add `"(Untitled)"` as final
+  fallback when all parsing yields empty
+- Add error logging to `openTraceInBrowser` — log actual error before
+  showing toast so failures are debuggable
+- Add `altimate_change` markers around `HONEST_UA` branding constant in
+  `webfetch.ts` for upstream merge compatibility
+- Update tracing docs for new `/trace` dialog behavior
+- Update TUI docs to include `/trace` in slash command examples
 
 Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

--- a/docs/docs/configure/tracing.md
+++ b/docs/docs/configure/tracing.md
@@ -144,7 +144,9 @@ The `--live` flag adds a green "LIVE" indicator and polls for updates every 2 se
 
 ### From the TUI
 
-Type `/trace` in the TUI to open the trace viewer for the current session in your browser. The viewer launches in live mode automatically, so you can watch spans appear as the agent works.
+Type `/trace` in the TUI to open a trace history dialog listing all recent sessions. Select any trace to open it in your browser with the interactive viewer. The current session appears at the top, and traces are grouped by date with duration and timestamp info.
+
+The viewer launches in live mode automatically for in-progress sessions, so you can watch spans appear as the agent works.
 
 ## Remote Exporters
 

--- a/docs/docs/usage/tui.md
+++ b/docs/docs/usage/tui.md
@@ -20,7 +20,7 @@ The TUI has three main areas:
 |--------|--------|---------|
 | `@` | Reference a file | `@src/models/user.sql explain this model` |
 | `!` | Run a shell command | `!dbt run --select my_model` |
-| `/` | Slash command | `/discover`, `/connect`, `/review`, `/models`, `/theme` |
+| `/` | Slash command | `/discover`, `/connect`, `/review`, `/models`, `/theme`, `/trace` |
 
 ## Leader Key
 

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -35,9 +35,10 @@ import fsAsync from "fs/promises"
 
 // altimate_change start - shared trace viewer server
 let traceViewerServer: ReturnType<typeof Bun.serve> | undefined
-function getTraceViewerUrl(sessionID: string): string {
+let traceViewerTracesDir: string | undefined
+function getTraceViewerUrl(sessionID: string, tracesDir?: string): string {
   if (!traceViewerServer) {
-    const tracesDir = Tracer.getTracesDir()
+    traceViewerTracesDir = Tracer.getTracesDir(tracesDir)
     traceViewerServer = Bun.serve({
       port: 0, // random available port
       hostname: "127.0.0.1",
@@ -56,7 +57,7 @@ function getTraceViewerUrl(sessionID: string): string {
         }
 
         const safeId = sid.replace(/[/\\.:]/g, "_")
-        const traceFile = `${tracesDir}/${safeId}.json`
+        const traceFile = `${traceViewerTracesDir}/${safeId}.json`
 
         if (action === "api") {
           try {
@@ -273,21 +274,34 @@ function App() {
   const promptRef = usePromptRef()
 
   // altimate_change start - shared trace viewer helper
+  // Load custom tracing dir from config (same as worker.ts and trace.ts)
+  const [tracesDir, setTracesDir] = createSignal<string | undefined>(undefined)
+  onMount(async () => {
+    try {
+      const { Config } = await import("@/config/config")
+      const cfg = await Config.get()
+      setTracesDir(cfg.tracing?.dir)
+    } catch {
+      // Config failure should not prevent TUI from working
+    }
+  })
+
   async function openTraceInBrowser(sessionID: string) {
     try {
       // Check if trace file exists on disk before opening browser
       const safeId = sessionID.replace(/[/\\.:]/g, "_")
-      const traceFile = `${Tracer.getTracesDir()}/${safeId}.json`
+      const traceFile = `${Tracer.getTracesDir(tracesDir())}/${safeId}.json`
       const exists = await fsAsync.access(traceFile).then(() => true).catch(() => false)
       if (!exists) {
         toast.show({ variant: "warning", message: "Trace not available yet — send a prompt first", duration: 4000 })
         return
       }
-      const url = getTraceViewerUrl(sessionID)
+      const url = getTraceViewerUrl(sessionID, tracesDir())
       await open(url)
       toast.show({ variant: "info", message: `Trace viewer: ${url}`, duration: 6000 })
-    } catch {
-      toast.show({ variant: "warning", message: `Failed to open browser. Trace files: ${Tracer.getTracesDir()}`, duration: 8000 })
+    } catch (err) {
+      Log.Default.error(`Failed to open trace viewer: ${err}`)
+      toast.show({ variant: "warning", message: `Failed to open browser. Trace files: ${Tracer.getTracesDir(tracesDir())}`, duration: 8000 })
     }
   }
   // altimate_change end
@@ -683,6 +697,7 @@ function App() {
         dialog.replace(() => (
           <DialogTraceList
             currentSessionID={currentSessionID}
+            tracesDir={tracesDir()}
             onSelect={openTraceInBrowser}
           />
         ))

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-trace-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-trace-list.tsx
@@ -10,7 +10,7 @@ function cleanTitle(raw: unknown): string {
   // Strip quotes, markdown headings, and take first non-empty line
   const stripped = raw.replace(/^["'`]+|["'`]+$/g, "").trim()
   const lines = stripped.split("\n").map((l) => l.replace(/^#+\s*/, "").trim()).filter(Boolean)
-  return lines.find((l) => l.length > 5) || lines[0] || stripped
+  return lines.find((l) => l.length > 5) || lines[0] || stripped || "(Untitled)"
 }
 
 function formatDuration(ms: number): string {
@@ -23,12 +23,13 @@ function formatDuration(ms: number): string {
 
 export function DialogTraceList(props: {
   currentSessionID?: string
+  tracesDir?: string
   onSelect: (sessionID: string) => void
 }) {
   const dialog = useDialog()
 
   const [traces] = createResource(async () => {
-    return Tracer.listTraces()
+    return Tracer.listTraces(props.tracesDir)
   })
 
   const options = createMemo(() => {
@@ -37,7 +38,7 @@ export function DialogTraceList(props: {
         {
           title: "Failed to load traces",
           value: "__error__",
-          description: `Check ${Tracer.getTracesDir()}`,
+          description: `Check ${Tracer.getTracesDir(props.tracesDir)}`,
         },
       ]
     }

--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -7,7 +7,9 @@ import { abortAfterAny } from "../util/abort"
 const MAX_RESPONSE_SIZE = 5 * 1024 * 1024 // 5MB
 const DEFAULT_TIMEOUT = 30 * 1000 // 30 seconds
 const MAX_TIMEOUT = 120 * 1000 // 2 minutes
+// altimate_change start — branding: honest bot UA
 const HONEST_UA = "altimate-code/1.0 (+https://github.com/AltimateAI/altimate-code)"
+// altimate_change end
 const BROWSER_UA =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
 // Status codes that warrant a retry with a different User-Agent
@@ -70,16 +72,17 @@ export const WebFetchTool = Tool.define("webfetch", {
     const honestHeaders = { ...baseHeaders, "User-Agent": HONEST_UA }
     const browserHeaders = { ...baseHeaders, "User-Agent": BROWSER_UA }
 
-    let response = await fetch(params.url, { signal, headers: honestHeaders })
-
-    // Retry with browser UA if the honest UA was rejected
-    if (!response.ok && RETRYABLE_STATUSES.has(response.status)) {
-      await response.body?.cancel().catch(() => {})
-      response = await fetch(params.url, { signal, headers: browserHeaders })
-    }
-
     let arrayBuffer: ArrayBuffer
+    let response: Response
     try {
+      response = await fetch(params.url, { signal, headers: honestHeaders })
+
+      // Retry with browser UA if the honest UA was rejected
+      if (!response.ok && RETRYABLE_STATUSES.has(response.status)) {
+        await response.body?.cancel().catch(() => {})
+        response = await fetch(params.url, { signal, headers: browserHeaders })
+      }
+
       if (!response.ok) {
         throw new Error(`Request failed with status code: ${response.status}`)
       }


### PR DESCRIPTION
### What does this PR do?

Addresses findings from a 6-model consensus code review (Claude, GPT 5.2 Codex, Gemini 3.1 Pro, Kimi K2.5, MiniMax M2.5, GLM-5) of the recent merges (#297, #301, #303, #305):

- **Fix TUI trace dialog ignoring custom `tracing.dir` config** — plumb config dir through `DialogTraceList`, `getTraceViewerUrl`, and `openTraceInBrowser` so custom trace directories work in the TUI (found by GPT 5.2 Codex)
- **Fix WebFetch `clearTimeout` leak** — move both `fetch` calls inside the `try` block so the `finally` clause always clears the timer, even on DNS failures or `AbortError` (found by Gemini 3.1 Pro)
- **Fix `cleanTitle` empty string fallback** — add `"(Untitled)"` as final fallback when all parsing yields empty (found by Claude, GLM-5)
- **Add error logging to `openTraceInBrowser`** — log actual error before showing toast so failures are debuggable (found by Kimi K2.5, GLM-5)
- **Add `altimate_change` markers** around `HONEST_UA` branding constant in `webfetch.ts` for upstream merge compatibility
- **Update tracing docs** for new `/trace` dialog behavior
- **Update TUI docs** to include `/trace` in slash command examples

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #306

### How did you verify your code works?

- Typecheck: 5/5 packages pass
- WebFetch tests: 8/8 pass
- Tracing persistence tests: 6/6 pass
- Branding tests: 269/269 pass
- Snowflake E2E tests: 45/45 pass (live account)
- Marker guard: clean
- Full test suite: 3776 pass (33 pre-existing failures, 243 skip)

### Checklist

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TUI trace dialog now honors custom trace directory configuration end-to-end.

* **Bug Fixes**
  * Fixed timeout leak in web fetch operations.
  * Improved title parsing fallback to display "(Untitled)" for traces without titles.
  * Enhanced error visibility in trace browser with detailed logging.

* **Documentation**
  * Updated trace and TUI documentation to reflect trace dialog behavior and slash commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->