### PR TITLE
fix: exclude 220MB of unused .node binaries from dbt-tools bundle

### DIFF
--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 import { $ } from "bun"
+import fs from "fs"
 import pkg from "../package.json"
 import { Script } from "@opencode-ai/script"
 import { fileURLToPath } from "url"
@@ -56,10 +57,16 @@ async function copyAssets(targetDir: string) {
   await $`cp -r ./bin ${targetDir}/bin`
   await $`cp -r ../../.opencode/skills ${targetDir}/skills`
   await $`cp ./script/postinstall.mjs ${targetDir}/postinstall.mjs`
-  // Bundle dbt-tools: copy its bin wrapper + built dist
+  // Bundle dbt-tools: copy its bin wrapper + only the files it actually needs.
+  // The full dist/ contains ~220 MB of .node native binaries from altimate-core
+  // that bun copies as transitive build artifacts but dbt-tools never loads.
   await $`mkdir -p ${targetDir}/dbt-tools/bin`
   await $`cp ../dbt-tools/bin/altimate-dbt ${targetDir}/dbt-tools/bin/altimate-dbt`
-  await $`cp -r ../dbt-tools/dist ${targetDir}/dbt-tools/dist`
+  await $`mkdir -p ${targetDir}/dbt-tools/dist`
+  await $`cp ../dbt-tools/dist/index.js ${targetDir}/dbt-tools/dist/`
+  if (fs.existsSync("../dbt-tools/dist/altimate_python_packages")) {
+    await $`cp -r ../dbt-tools/dist/altimate_python_packages ${targetDir}/dbt-tools/dist/`
+  }
   await Bun.file(`${targetDir}/LICENSE`).write(await Bun.file("../../LICENSE").text())
   await Bun.file(`${targetDir}/CHANGELOG.md`).write(await Bun.file("../../CHANGELOG.md").text())
 }

--- a/packages/opencode/test/branding/build-integrity.test.ts
+++ b/packages/opencode/test/branding/build-integrity.test.ts
@@ -297,6 +297,15 @@ describe("Bundle Completeness", () => {
     expect(publishScript).toContain("bun run build")
   })
 
+  test("publish.ts copies only needed dbt-tools dist files (not .node binaries)", () => {
+    const publishScript = readFileSync(join(repoRoot, "packages/opencode/script/publish.ts"), "utf-8")
+    // Should copy index.js and altimate_python_packages selectively, not `cp -r dist`
+    expect(publishScript).toContain("dist/index.js")
+    expect(publishScript).toContain("altimate_python_packages")
+    // Should NOT do a blanket `cp -r ../dbt-tools/dist` (would include ~220MB of .node files)
+    expect(publishScript).not.toMatch(/cp -r \.\.\/dbt-tools\/dist [^/]/)
+  })
+
   test("postinstall.mjs sets up dbt-tools symlink", () => {
     const postinstall = readFileSync(join(repoRoot, "packages/opencode/script/postinstall.mjs"), "utf-8")
     expect(postinstall).toContain("setupDbtTools")


### PR DESCRIPTION
### What does this PR do?

Fixes dbt-tools bundle copying 220MB of unnecessary `@altimateai/altimate-core` `.node` native binaries that `bun build` produces as transitive artifacts but dbt-tools never loads at runtime.

Selectively copies only `index.js` (860KB) and `altimate_python_packages/` (2.2MB) instead of the entire `dist/` directory — **223MB → 3MB**.

Credit: @suryaiyer95 ([#316 comment](https://github.com/AltimateAI/altimate-code/pull/316#issuecomment-3137408893))

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #319

### How did you verify your code works?

- 376 release-critical tests pass (including new test verifying selective copy)
- Typecheck clean
- Verified `publish.ts` no longer does blanket `cp -r ../dbt-tools/dist`

### Checklist

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [ ] CHANGELOG updated (if user-facing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)