### PR TITLE
chore: add missing altimate_change markers for upstream merge safety

### DIFF
--- a/packages/opencode/src/skill/skill.ts
+++ b/packages/opencode/src/skill/skill.ts
@@ -1,7 +1,9 @@
 import z from "zod"
 import path from "path"
 import os from "os"
+// altimate_change start — gray-matter for parsing embedded builtin skill frontmatter
 import matter from "gray-matter"
+// altimate_change end
 import { Config } from "../config/config"
 import { Instance } from "../project/instance"
 import { NamedError } from "@opencode-ai/util/error"
@@ -18,12 +20,11 @@ import { pathToFileURL } from "url"
 import type { Agent } from "@/agent/agent"
 import { PermissionNext } from "@/permission/next"
 
-// Builtin skills embedded at build time — available in ALL distribution channels
-// (npm, Homebrew, AUR, Docker) without relying on postinstall filesystem copies.
-// Falls back to filesystem scan in dev mode when the global is undefined.
+// altimate_change start — builtin skills embedded at build time for all distribution channels
 declare const OPENCODE_BUILTIN_SKILLS:
   | { name: string; content: string }[]
   | undefined
+// altimate_change end
 
 export namespace Skill {
   const log = Log.create({ service: "skill" })
@@ -112,8 +113,7 @@ export namespace Skill {
         })
     }
 
-    // Load builtin skills — prefer filesystem (supports @references), fall back
-    // to binary-embedded data (works without postinstall for Homebrew/AUR/Docker).
+    // altimate_change start — load builtin skills from filesystem or binary-embedded data
     if (!Flag.OPENCODE_DISABLE_EXTERNAL_SKILLS) {
       let loadedFromFs = false
 
@@ -155,6 +155,7 @@ export namespace Skill {
         log.info("loaded embedded builtin skills", { count: OPENCODE_BUILTIN_SKILLS.length })
       }
     }
+    // altimate_change end
 
     // Scan external skill directories (.claude/skills/, .agents/skills/, etc.)
     // Load global (home) first, then project-level (so project-level overwrites)
@@ -259,7 +260,9 @@ export namespace Skill {
           `  <skill>`,
           `    <name>${skill.name}</name>`,
           `    <description>${skill.description}</description>`,
+          // altimate_change start — handle builtin: protocol for embedded skills
           `    <location>${skill.location.startsWith("builtin:") ? skill.location : pathToFileURL(skill.location).href}</location>`,
+          // altimate_change end
           `  </skill>`,
         ]),
         "</available_skills>",

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -165,8 +165,7 @@ export const BashTool = Tool.define("bash", async () => {
         { env: {} },
       )
 
-      // Merge process.env + shell plugin env, then prepend bundled tools dir.
-      // shellEnv.env may contain PATH additions from user's shell profile.
+      // altimate_change start — prepend bundled tools dir (ALTIMATE_BIN_DIR) to PATH
       const mergedEnv: Record<string, string | undefined> = { ...process.env, ...shellEnv.env }
       const binDir = process.env.ALTIMATE_BIN_DIR
       if (binDir) {
@@ -177,6 +176,7 @@ export const BashTool = Tool.define("bash", async () => {
           mergedEnv.PATH = basePath ? `${binDir}${sep}${basePath}` : binDir
         }
       }
+      // altimate_change end
 
       const proc = spawn(params.command, {
         shell,

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -112,6 +112,7 @@ export const SkillTool = Tool.define("skill", async (ctx) => {
         metadata: {},
       })
 
+      // altimate_change start — handle builtin: skills that have no filesystem directory
       const isBuiltin = skill.location.startsWith("builtin:")
       const dir = isBuiltin ? "" : path.dirname(skill.location)
       const base = isBuiltin ? skill.location : pathToFileURL(dir).href
@@ -137,6 +138,7 @@ export const SkillTool = Tool.define("skill", async (ctx) => {
             }
             return arr
           }).then((f) => f.map((file) => `<file>${file}</file>`).join("\n"))
+      // altimate_change end
 
       // altimate_change start — telemetry instrumentation for skill loading
       try {


### PR DESCRIPTION
### What does this PR do?

Adds missing `altimate_change` markers to 3 upstream-shared source files that were modified in #316 without proper markers. This ensures the marker guard CI catches these customizations during future upstream merges and makes conflict resolution easier.

### Type of change

- [x] Chore (non-breaking change that doesn't add functionality)

### Issue for this PR

Closes #321

### How did you verify your code works?

- Verified all markers are balanced (start/end counts match in all 3 files)
- Ran `bun run script/upstream/analyze.ts --markers --base main` — passes clean
- Ran branding guard tests (`test/branding/`) — 153/153 marker-related tests pass
- Typecheck passes (`turbo typecheck`)

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally with my changes

### Files changed

| File | Change |
|------|--------|
| `packages/opencode/src/skill/skill.ts` | Added markers around `gray-matter` import, `OPENCODE_BUILTIN_SKILLS` global declaration, builtin skill loading block, and `builtin:` protocol handling in `fmt()` |
| `packages/opencode/src/tool/bash.ts` | Added markers around `ALTIMATE_BIN_DIR` PATH prepend logic |
| `packages/opencode/src/tool/skill.ts` | Added markers around `isBuiltin` branch for embedded skill file resolution |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for embedded builtin skills with automatic fallback loading.

* **Refactor**
  * Updated skill location handling and XML output formatting for improved path representation.
  * Optimized builtin skill file processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->