### PR TITLE
fix: add missing altimate_change markers for experimental block

### DIFF
--- a/.github/meta/commit.txt
+++ b/.github/meta/commit.txt
@@ -1,3 +1,6 @@
-release: v0.5.2
+fix: add missing `altimate_change` markers for `experimental` block in `opencode.jsonc`
+
+The `experimental` config added in #311 was missing upstream markers,
+causing the Marker Guard CI check to fail on main.
 
 Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -15,7 +15,9 @@
     "github-triage": false,
     "github-pr-search": false,
   },
+  // altimate_change start — disable auto MCP discovery for altimate-code
   "experimental": {
     "auto_mcp_discovery": false,
   },
+  // altimate_change end
 }


### PR DESCRIPTION
### What does this PR do?
Adds missing `altimate_change` markers around the `experimental` config block in `.opencode/opencode.jsonc` to fix the Marker Guard CI failure on main.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR
Closes #343

### How did you verify your code works?
- Verified the diff adds only the two marker comment lines
- The Marker Guard check was the sole CI failure; this directly addresses it

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)