### PR TITLE
docs: add MCP auto-discovery section to security FAQ

### DIFF
--- a/docs/docs/reference/security-faq.md
+++ b/docs/docs/reference/security-faq.md
@@ -152,6 +152,39 @@ MCP (Model Context Protocol) servers extend Altimate Code with additional tools.
 !!! warning
     Third-party MCP servers are not reviewed or audited by Altimate. Treat them like any other third-party dependency: review the source, check for updates, and limit their access.
 
+## What is MCP auto-discovery?
+
+Altimate Code can automatically discover MCP server definitions from other AI tools installed on your machine. This saves you from manually re-configuring servers you already use elsewhere. Sources include:
+
+| Source | Config file | Scope |
+|--------|------------|-------|
+| VS Code | `.vscode/mcp.json` | Project |
+| Cursor | `.cursor/mcp.json` | Project |
+| GitHub Copilot | `.github/copilot/mcp.json` | Project |
+| Claude Code | `.mcp.json` | Project + Home |
+| Gemini CLI | `.gemini/settings.json` | Project + Home |
+| Claude Desktop | `~/.claude.json` | Home |
+
+**Security model:**
+
+- **Home-directory configs** (your personal machine config) are treated as trusted and auto-enabled, since you installed them.
+- **Project-scoped configs** (checked into a repo) are discovered but **disabled by default**. You must explicitly approve them via the `/discover-and-add-mcps` tool before they run.
+- **Sensitive details are redacted** in discovery notifications. Server commands and URLs are only shown when you explicitly inspect them.
+- **Prototype pollution, command injection, and path traversal** are hardened against with input validation and `Object.create(null)` result objects.
+
+**To disable auto-discovery entirely:**
+
+```json
+{
+  "experimental": {
+    "auto_mcp_discovery": false
+  }
+}
+```
+
+!!! tip
+    If your project repository contains `.vscode/mcp.json` or similar config files from other contributors, auto-discovery will find them but **will not start them** until you approve. Always review discovered servers before enabling them.
+
 ## How does the SQL analysis engine work?
 
 As of v0.4.2, all 73 tool methods run natively in TypeScript via `@altimateai/altimate-core` (Rust napi-rs bindings). There is no Python dependency. The engine executes in-process with no subprocess, no network port, and no external service.


### PR DESCRIPTION
### What does this PR do?
Adds a new "What is MCP auto-discovery?" section to the security FAQ documenting the feature introduced in #311. Covers:
- Table of all 6 supported external config sources (VS Code, Cursor, Copilot, Claude, Gemini)
- Trust model: home-directory configs auto-enabled vs project-scoped disabled by default
- Security hardening (prototype pollution, command injection, path traversal)
- How to disable the feature via `auto_mcp_discovery: false`

### Type of change
- [x] Documentation update

### How did you verify your code works?
- Reviewed the auto-discovery implementation in `src/mcp/discover.ts` and adversarial tests to ensure accuracy of documented security controls
- Verified markdown renders correctly with admonitions and table formatting

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FAQ section explaining MCP auto-discovery functionality for discovering MCP server definitions from other installed AI tools.
  * Documented the security model including trust levels, approval processes, and security hardening measures.
  * Added instructions on disabling auto-discovery and clarified that discovered servers require explicit approval before starting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->