### PR TITLE
fix: update altimate.ai/zen URLs to opencode.ai/zen

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -224,7 +224,7 @@ function ApiMethod(props: ApiMethodProps) {
                 key.
               </text>
               <text fg={theme.text}>
-                Go to <span style={{ fg: theme.primary }}>https://altimate.ai/zen</span> to get a key
+                Go to <span style={{ fg: theme.primary }}>https://opencode.ai/zen</span> to get a key
               </text>
             </box>
           ),
@@ -235,7 +235,7 @@ function ApiMethod(props: ApiMethodProps) {
                 with generous usage limits.
               </text>
               <text fg={theme.text}>
-                Go to <span style={{ fg: theme.primary }}>https://altimate.ai/zen</span> and enable Altimate Code Go
+                Go to <span style={{ fg: theme.primary }}>https://opencode.ai/zen</span> and enable Altimate Code Go
               </text>
             </box>
           ),

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -68,7 +68,7 @@ export namespace SessionRetry {
     if (MessageV2.APIError.isInstance(error)) {
       if (!error.data.isRetryable) return undefined
       if (error.data.responseBody?.includes("FreeUsageLimitError"))
-        return `Free usage exceeded, add credits https://altimate.ai/zen`
+        return `Free usage exceeded, add credits https://opencode.ai/zen`
       return error.data.message.includes("Overloaded") ? "Provider is overloaded" : error.data.message
     }
 

--- a/packages/opencode/test/tool/fixtures/models-api.json
+++ b/packages/opencode/test/tool/fixtures/models-api.json
@@ -20977,9 +20977,9 @@
     "id": "opencode",
     "env": ["OPENCODE_API_KEY"],
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://altimate.ai/zen/v1",
+    "api": "https://opencode.ai/zen/v1",
     "name": "Altimate Code Zen",
-    "doc": "https://altimate.ai/docs/zen",
+    "doc": "https://opencode.ai/docs/zen",
     "models": {
       "glm-4.7": {
         "id": "glm-4.7",


### PR DESCRIPTION
## Summary

Replace all references to https://altimate.ai/zen with https://opencode.ai/zen across UI messages, error strings, and test fixtures. 

`https://altimate.ai/zen` link is broken

What changed and why?

## Test Plan
NA

How was this tested?
NA

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] CHANGELOG updated (if user-facing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API provider endpoints and documentation links throughout the application to use the opencode.ai domain. Users will see these updated URLs in API key authentication instructions, provider documentation, and error messages related to account usage limits and credit management features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->