### PR TITLE
test: fn() wrapper and skillSource trust classification

### DIFF
--- a/packages/opencode/test/cli/skill.test.ts
+++ b/packages/opencode/test/cli/skill.test.ts
@@ -3,7 +3,8 @@ import { describe, test, expect } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import { tmpdir } from "../fixture/fixture"
-import { detectToolReferences, SHELL_BUILTINS } from "../../src/cli/cmd/skill-helpers"
+import { detectToolReferences, SHELL_BUILTINS, skillSource } from "../../src/cli/cmd/skill-helpers"
+import os from "os"
 
 // ---------------------------------------------------------------------------
 // Unit tests — import production code directly (no duplication)
@@ -453,6 +454,44 @@ describe("skill install — symlink safety", () => {
       .then(() => true)
       .catch(() => false)
     expect(symlinkCopied).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// skillSource trust classification — determines builtin / global / project label
+// ---------------------------------------------------------------------------
+
+describe("skillSource", () => {
+  // Global.Path.home reads process.env.OPENCODE_TEST_HOME || os.homedir()
+  const home = process.env.OPENCODE_TEST_HOME || os.homedir()
+
+  test("builtin: prefix → builtin", () => {
+    expect(skillSource("builtin:dbt-run")).toBe("builtin")
+    expect(skillSource("builtin:")).toBe("builtin")
+  })
+
+  test("~/.altimate/builtin/... → builtin", () => {
+    expect(skillSource(path.join(home, ".altimate", "builtin", "dbt-run", "SKILL.md"))).toBe("builtin")
+  })
+
+  test("~/.claude/skills/... → global", () => {
+    expect(skillSource(path.join(home, ".claude", "skills", "my-skill", "SKILL.md"))).toBe("global")
+  })
+
+  test("~/.agents/skills/... → global", () => {
+    expect(skillSource(path.join(home, ".agents", "skills", "my-skill", "SKILL.md"))).toBe("global")
+  })
+
+  test("~/.altimate-code/skills/... → global", () => {
+    expect(skillSource(path.join(home, ".altimate-code", "skills", "custom", "SKILL.md"))).toBe("global")
+  })
+
+  test("project path → project", () => {
+    expect(skillSource("/home/user/myproject/.opencode/skills/custom/SKILL.md")).toBe("project")
+  })
+
+  test("random path with no skill dir match → project", () => {
+    expect(skillSource("/tmp/something/SKILL.md")).toBe("project")
   })
 })
 

--- a/packages/opencode/test/util/fn.test.ts
+++ b/packages/opencode/test/util/fn.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from "bun:test"
+import { z } from "zod"
+import { fn } from "../../src/util/fn"
+
+describe("fn: zod-validated function wrapper", () => {
+  test("passes validated input to callback", () => {
+    const add = fn(z.object({ a: z.number(), b: z.number() }), ({ a, b }) => a + b)
+    expect(add({ a: 1, b: 2 })).toBe(3)
+  })
+
+  test("throws ZodError on invalid input", () => {
+    const greet = fn(z.object({ name: z.string() }), ({ name }) => `hi ${name}`)
+    expect(() => greet({ name: 42 } as any)).toThrow()
+  })
+
+  test(".force() bypasses validation", () => {
+    const double = fn(z.number().int(), (n) => n * 2)
+    // 1.5 is not an int, but .force skips validation
+    expect(double.force(1.5)).toBe(3)
+  })
+
+  test(".schema exposes the original zod schema", () => {
+    const schema = z.string().email()
+    const validate = fn(schema, (s) => s.toUpperCase())
+    expect(validate.schema).toBe(schema)
+  })
+
+  test("rejects unknown keys with strict schema", () => {
+    const strict = fn(z.object({ id: z.number() }).strict(), ({ id }) => id)
+    expect(() => strict({ id: 1, extra: true } as any)).toThrow()
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Adds 12 new tests across two previously untested modules discovered during automated test-discovery reconnaissance.

**1. `fn()` zod-validated function wrapper — `src/util/fn.ts`** (5 new tests)

This utility wraps functions with zod schema validation and is imported in 10+ core modules including session management, permission evaluation, compaction, and project creation. Zero tests existed despite being a critical path dependency. New coverage includes:
- Normal validated input passthrough
- ZodError thrown on invalid input
- `.force()` bypasses validation (used for internal trusted calls)
- `.schema` exposes the original zod schema for introspection
- Strict schemas reject unknown keys (validates real-world footgun where default zod strips extra keys silently)

**2. `skillSource()` trust classification — `src/cli/cmd/skill-helpers.ts`** (7 new tests)

This function determines whether a skill is classified as "builtin", "global", or "project" — a trust boundary that affects how skills are displayed and whether they receive elevated trust in the CLI. Zero tests existed. New coverage includes:
- `builtin:` prefix correctly returns "builtin"
- `~/.altimate/builtin/` path correctly returns "builtin"
- `~/.claude/skills/`, `~/.agents/skills/`, `~/.altimate-code/skills/` all correctly return "global"
- Arbitrary project paths correctly return "project"
- Random paths with no skill directory match default to "project"

Tests use `process.env.OPENCODE_TEST_HOME || os.homedir()` to match the `Global.Path.home` getter behavior, ensuring deterministic results in both local and CI environments.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage from automated test-discovery

### How did you verify your code works?

```
bun test test/util/fn.test.ts              # 5 pass
bun test test/cli/skill.test.ts -t skillSource  # 7 pass
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01A73k9MRUmXYHgUNzd9oJKk