### PR TITLE
test: util — signal, defer, and Color coverage

### DIFF
--- a/packages/opencode/test/util/color.test.ts
+++ b/packages/opencode/test/util/color.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect } from "bun:test"
+import { Color } from "../../src/util/color"
+
+describe("Color: hex validation and conversion", () => {
+  describe("isValidHex", () => {
+    test("accepts valid 6-digit hex with #", () => {
+      expect(Color.isValidHex("#ff0000")).toBe(true)
+      expect(Color.isValidHex("#00FF00")).toBe(true)
+      expect(Color.isValidHex("#1a2b3c")).toBe(true)
+    })
+
+    test("rejects missing hash", () => {
+      expect(Color.isValidHex("ff0000")).toBe(false)
+    })
+
+    test("rejects short hex (3-digit)", () => {
+      expect(Color.isValidHex("#fff")).toBe(false)
+    })
+
+    test("rejects 8-digit hex (with alpha)", () => {
+      expect(Color.isValidHex("#ff000080")).toBe(false)
+    })
+
+    test("rejects undefined and empty", () => {
+      expect(Color.isValidHex(undefined)).toBe(false)
+      expect(Color.isValidHex("")).toBe(false)
+    })
+
+    test("rejects non-hex chars", () => {
+      expect(Color.isValidHex("#gggggg")).toBe(false)
+      expect(Color.isValidHex("#zzzzzz")).toBe(false)
+    })
+  })
+
+  describe("hexToRgb", () => {
+    test("converts pure red", () => {
+      expect(Color.hexToRgb("#ff0000")).toEqual({ r: 255, g: 0, b: 0 })
+    })
+
+    test("converts pure green", () => {
+      expect(Color.hexToRgb("#00ff00")).toEqual({ r: 0, g: 255, b: 0 })
+    })
+
+    test("converts pure blue", () => {
+      expect(Color.hexToRgb("#0000ff")).toEqual({ r: 0, g: 0, b: 255 })
+    })
+
+    test("converts black and white", () => {
+      expect(Color.hexToRgb("#000000")).toEqual({ r: 0, g: 0, b: 0 })
+      expect(Color.hexToRgb("#ffffff")).toEqual({ r: 255, g: 255, b: 255 })
+    })
+
+    test("handles uppercase hex", () => {
+      expect(Color.hexToRgb("#1A2B3C")).toEqual({ r: 26, g: 43, b: 60 })
+    })
+  })
+
+  describe("hexToAnsiBold", () => {
+    test("returns ANSI escape for valid hex", () => {
+      const result = Color.hexToAnsiBold("#ff0000")
+      expect(result).toBe("\x1b[38;2;255;0;0m\x1b[1m")
+    })
+
+    test("returns undefined for invalid hex", () => {
+      expect(Color.hexToAnsiBold("#bad")).toBeUndefined()
+      expect(Color.hexToAnsiBold(undefined)).toBeUndefined()
+    })
+  })
+})

--- a/packages/opencode/test/util/defer.test.ts
+++ b/packages/opencode/test/util/defer.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from "bun:test"
+import { defer } from "../../src/util/defer"
+
+describe("defer: disposal pattern", () => {
+  test("Symbol.dispose invokes the cleanup function", () => {
+    let called = false
+    const d = defer(() => {
+      called = true
+    })
+    expect(called).toBe(false)
+    d[Symbol.dispose]()
+    expect(called).toBe(true)
+  })
+
+  test("Symbol.asyncDispose invokes the cleanup function and returns a Promise", async () => {
+    let called = false
+    const d = defer(() => {
+      called = true
+    })
+    const result = d[Symbol.asyncDispose]()
+    expect(result).toBeInstanceOf(Promise)
+    await result
+    expect(called).toBe(true)
+  })
+
+  test("works with async cleanup functions via asyncDispose", async () => {
+    let called = false
+    const d = defer(async () => {
+      called = true
+    })
+    await d[Symbol.asyncDispose]()
+    expect(called).toBe(true)
+  })
+
+  test("using syntax triggers dispose", () => {
+    let called = false
+    {
+      using _d = defer(() => {
+        called = true
+      })
+      expect(called).toBe(false)
+    }
+    expect(called).toBe(true)
+  })
+})

--- a/packages/opencode/test/util/signal.test.ts
+++ b/packages/opencode/test/util/signal.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from "bun:test"
+import { signal } from "../../src/util/signal"
+
+describe("signal: trigger/wait coordination", () => {
+  test("wait() resolves after trigger() is called", async () => {
+    const s = signal()
+    let resolved = false
+    const p = s.wait().then(() => {
+      resolved = true
+    })
+    expect(resolved).toBe(false)
+    s.trigger()
+    await p
+    expect(resolved).toBe(true)
+  })
+
+  test("trigger() before wait() — promise already resolved", async () => {
+    const s = signal()
+    s.trigger()
+    // wait() returns the same already-resolved promise, so this should not hang
+    const result = await Promise.race([
+      s.wait().then(() => "ok"),
+      new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 200)),
+    ])
+    expect(result).toBe("ok")
+  })
+})


### PR DESCRIPTION
## Summary

Add unit tests for three untested utility modules that power coordination primitives, resource cleanup, and TUI rendering. These modules had zero test coverage despite being used across the codebase.

**1. `signal()` — `src/util/signal.ts`** (2 new tests)

This utility creates a trigger/wait promise pair used for internal coordination (e.g., waiting for initialization). Zero tests existed. A bug here (e.g., `resolve` not assigned before `trigger()`) would silently hang callers. New coverage includes:
- `wait()` resolves after `trigger()` is called
- `trigger()` before `wait()` still resolves (with timeout guard to prevent hangs)

**2. `defer()` — `src/util/defer.ts`** (4 new tests)

This utility creates disposable objects for cleanup via `using`/`await using` syntax. Used throughout the codebase for resource management. Zero tests existed. New coverage includes:
- `Symbol.dispose` invokes the cleanup function (verified via side-effect flag)
- `Symbol.asyncDispose` invokes cleanup and returns a Promise
- Async cleanup functions work correctly
- `using` block syntax triggers dispose on scope exit

**3. `Color` namespace — `src/util/color.ts`** (13 new tests)

This module validates and converts hex colors for TUI rendering (spinner, theme, prompt). Used in `spinner.ts`, `theme.tsx`, and `prompt/index.tsx`. Zero tests existed. A bug in `isValidHex` could crash the TUI or produce garbled ANSI output. New coverage includes:
- `isValidHex`: accepts valid 6-digit hex, rejects short/long/missing-hash/non-hex inputs, handles undefined/empty
- `hexToRgb`: converts pure R/G/B, black/white, uppercase hex correctly
- `hexToAnsiBold`: produces correct ANSI escape sequence, returns undefined for invalid input

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage from automated test discovery

### How did you verify your code works?

```
bun test test/util/signal.test.ts  # 2 pass
bun test test/util/defer.test.ts   # 4 pass
bun test test/util/color.test.ts   # 13 pass
```

All 19 tests pass. No source code was modified.

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01T3MSQnGWmRtoFpyUnQuTf1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for Color utility functions including hex validation, RGB conversion, and ANSI color formatting capabilities
  * Added comprehensive test suite for defer utility disposal patterns, synchronous and asynchronous cleanup operations, and JavaScript using syntax compatibility
  * Implemented full test coverage for signal utility coordination mechanisms between trigger and wait operations to ensure proper synchronization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->