### PR TITLE
test: util — Color, signal, and defer coverage

### DIFF
--- a/packages/opencode/test/util/color.test.ts
+++ b/packages/opencode/test/util/color.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect } from "bun:test"
+import { Color } from "../../src/util/color"
+
+describe("Color.isValidHex", () => {
+  test("accepts valid 6-digit hex codes", () => {
+    expect(Color.isValidHex("#ff5733")).toBe(true)
+    expect(Color.isValidHex("#000000")).toBe(true)
+    expect(Color.isValidHex("#FFFFFF")).toBe(true)
+    expect(Color.isValidHex("#aAbBcC")).toBe(true)
+  })
+
+  test("rejects 3-digit shorthand hex", () => {
+    // Users coming from CSS might try #FFF — this must be rejected
+    // because hexToRgb assumes 6-digit format
+    expect(Color.isValidHex("#FFF")).toBe(false)
+    expect(Color.isValidHex("#abc")).toBe(false)
+  })
+
+  test("rejects missing hash prefix", () => {
+    expect(Color.isValidHex("ff5733")).toBe(false)
+  })
+
+  test("rejects empty, undefined, and null-ish values", () => {
+    expect(Color.isValidHex("")).toBe(false)
+    expect(Color.isValidHex(undefined)).toBe(false)
+  })
+
+  test("rejects hex with invalid characters", () => {
+    expect(Color.isValidHex("#gggggg")).toBe(false)
+    expect(Color.isValidHex("#12345z")).toBe(false)
+  })
+
+  test("rejects hex with wrong length", () => {
+    expect(Color.isValidHex("#1234567")).toBe(false)
+    expect(Color.isValidHex("#12345")).toBe(false)
+  })
+})
+
+describe("Color.hexToRgb", () => {
+  test("converts standard hex to correct RGB", () => {
+    expect(Color.hexToRgb("#ff0000")).toEqual({ r: 255, g: 0, b: 0 })
+    expect(Color.hexToRgb("#00ff00")).toEqual({ r: 0, g: 255, b: 0 })
+    expect(Color.hexToRgb("#0000ff")).toEqual({ r: 0, g: 0, b: 255 })
+  })
+
+  test("handles boundary values", () => {
+    expect(Color.hexToRgb("#000000")).toEqual({ r: 0, g: 0, b: 0 })
+    expect(Color.hexToRgb("#ffffff")).toEqual({ r: 255, g: 255, b: 255 })
+  })
+
+  test("handles mixed case", () => {
+    expect(Color.hexToRgb("#AaBbCc")).toEqual({ r: 170, g: 187, b: 204 })
+  })
+})
+
+describe("Color.hexToAnsiBold", () => {
+  test("produces correct ANSI escape for valid hex", () => {
+    const result = Color.hexToAnsiBold("#ff0000")
+    expect(result).toBe("\x1b[38;2;255;0;0m\x1b[1m")
+  })
+
+  test("returns undefined for invalid hex, preventing NaN in ANSI sequences", () => {
+    // Key safety test: without isValidHex guard, hexToRgb("#bad") would
+    // produce NaN values in the escape sequence, corrupting terminal output
+    expect(Color.hexToAnsiBold("#bad")).toBeUndefined()
+    expect(Color.hexToAnsiBold("")).toBeUndefined()
+    expect(Color.hexToAnsiBold(undefined)).toBeUndefined()
+  })
+})

--- a/packages/opencode/test/util/defer.test.ts
+++ b/packages/opencode/test/util/defer.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from "bun:test"
+import { defer } from "../../src/util/defer"
+
+describe("defer", () => {
+  test("Symbol.dispose calls the cleanup function", () => {
+    let called = false
+    const d = defer(() => {
+      called = true
+    })
+    d[Symbol.dispose]()
+    expect(called).toBe(true)
+  })
+
+  test("Symbol.asyncDispose calls and awaits the cleanup function", async () => {
+    let called = false
+    const d = defer(async () => {
+      called = true
+    })
+    await d[Symbol.asyncDispose]()
+    expect(called).toBe(true)
+  })
+
+  test("works with using statement for sync cleanup", () => {
+    let cleaned = false
+    {
+      using _ = defer(() => {
+        cleaned = true
+      })
+    }
+    expect(cleaned).toBe(true)
+  })
+
+  test("works with await using statement for async cleanup", async () => {
+    let cleaned = false
+    {
+      await using _ = defer(async () => {
+        cleaned = true
+      })
+    }
+    expect(cleaned).toBe(true)
+  })
+})

--- a/packages/opencode/test/util/signal.test.ts
+++ b/packages/opencode/test/util/signal.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from "bun:test"
+import { signal } from "../../src/util/signal"
+
+describe("signal", () => {
+  test("wait() resolves after trigger()", async () => {
+    const s = signal()
+    let resolved = false
+    const waiting = s.wait().then(() => {
+      resolved = true
+    })
+    expect(resolved).toBe(false)
+    s.trigger()
+    await waiting
+    expect(resolved).toBe(true)
+  })
+
+  test("trigger() before wait() still resolves immediately", async () => {
+    // Race condition guard: trigger fires before anyone awaits
+    const s = signal()
+    s.trigger()
+    let resolved = false
+    await s.wait().then(() => {
+      resolved = true
+    })
+    expect(resolved).toBe(true)
+  })
+
+  test("multiple wait() calls on same signal all resolve", async () => {
+    const s = signal()
+    let count = 0
+    const waiters = [
+      s.wait().then(() => count++),
+      s.wait().then(() => count++),
+      s.wait().then(() => count++),
+    ]
+    s.trigger()
+    await Promise.all(waiters)
+    expect(count).toBe(3)
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Adds unit tests for three previously untested utility modules in `packages/opencode/src/util/`. These utilities are foundational — they power TUI rendering, async event coordination, and resource cleanup across the codebase. Zero tests existed for any of them.

**1. `Color` — `src/util/color.ts`** (11 new tests)

This namespace provides hex color validation and ANSI escape generation for the TUI (agent colors, theming). Zero tests existed. The key risk: `hexToRgb()` has no input validation of its own — it blindly calls `parseInt` on string slices. If `isValidHex()` ever loses its guard, callers get silent `NaN` values embedded in ANSI escape sequences, producing corrupted terminal output. Coverage includes:
- Valid 6-digit hex acceptance (mixed case, boundaries)
- Rejection of CSS 3-digit shorthand (`#FFF`) which would produce wrong RGB values
- Rejection of missing hash prefix, empty/undefined input, invalid characters, wrong lengths
- `hexToRgb` conversion correctness for primary colors and boundary values
- `hexToAnsiBold` integration: valid hex produces correct escape, invalid hex returns `undefined` (NaN guard)

**2. `signal()` — `src/util/signal.ts`** (3 new tests)

This one-shot promise signal is used for async coordination (e.g., session event synchronization). The critical risk: if `trigger()` fires before `wait()` is called, the promise must still resolve — otherwise consumers silently hang. Coverage includes:
- Normal flow: `wait()` resolves after `trigger()`
- Race condition: `trigger()` before `wait()` still resolves immediately
- Fan-out: multiple `wait()` calls on the same signal all resolve

**3. `defer()` — `src/util/defer.ts`** (4 new tests)

This utility creates TC39 Explicit Resource Management disposables for `using`/`await using` patterns. It's used throughout tests (via `tmpdir`) and in production for file handle cleanup. If the dispose symbols malfunction, resources leak silently. Coverage includes:
- Direct `Symbol.dispose` call triggers cleanup function
- Direct `Symbol.asyncDispose` call triggers and awaits async cleanup
- `using` statement invokes sync cleanup via TC39 machinery
- `await using` statement invokes async cleanup via TC39 machinery

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage via `/test-discovery`

### How did you verify your code works?

```
bun test test/util/color.test.ts    # 11 pass, 23 assertions
bun test test/util/signal.test.ts   #  3 pass, 4 assertions
bun test test/util/defer.test.ts    #  4 pass, 4 assertions
```

All 18 tests pass. No source code modified — tests only.

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_0154uqXBVVoY4G5HcLzFfGRY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for color utilities including hex validation, RGB conversion, and ANSI formatting
  * Added test suite for defer utility covering synchronous and asynchronous cleanup behaviors
  * Added test suite for signal utility validating async wait/trigger patterns with concurrent operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->