### PR TITLE
test: util — Rpc client protocol and abortAfter/abortAfterAny coverage

### DIFF
--- a/packages/opencode/test/util/abort.test.ts
+++ b/packages/opencode/test/util/abort.test.ts
@@ -1,0 +1,60 @@
+import { describe, test, expect } from "bun:test"
+import { abortAfter, abortAfterAny } from "../../src/util/abort"
+
+describe("abortAfter: timeout-based abort", () => {
+  test("signal is not aborted immediately", () => {
+    const { signal, clearTimeout } = abortAfter(5000)
+    expect(signal.aborted).toBe(false)
+    clearTimeout()
+  })
+
+  test("signal aborts after timeout", async () => {
+    const { signal } = abortAfter(10)
+    // Event-driven: wait for the abort event instead of guessing a wall-clock delay
+    await Promise.race([
+      new Promise<void>((r) => signal.addEventListener("abort", () => r())),
+      new Promise<void>((_, reject) => setTimeout(() => reject(new Error("abort did not fire within 500ms")), 500)),
+    ])
+    expect(signal.aborted).toBe(true)
+  })
+
+  test("clearTimeout prevents abort", async () => {
+    // Use a very short timeout so waiting longer than it proves clearTimeout worked
+    const { signal, clearTimeout: clear } = abortAfter(10)
+    clear()
+    // Wait well beyond the original timeout
+    await new Promise((r) => setTimeout(r, 200))
+    expect(signal.aborted).toBe(false)
+  })
+})
+
+describe("abortAfterAny: composite signal", () => {
+  test("aborts when external signal fires before timeout", () => {
+    const ext = new AbortController()
+    const { signal, clearTimeout } = abortAfterAny(5000, ext.signal)
+    expect(signal.aborted).toBe(false)
+    ext.abort()
+    expect(signal.aborted).toBe(true)
+    clearTimeout()
+  })
+
+  test("aborts on timeout when external signal is silent", async () => {
+    const ext = new AbortController()
+    const { signal } = abortAfterAny(10, ext.signal)
+    // Event-driven: wait for the abort event
+    await Promise.race([
+      new Promise<void>((r) => signal.addEventListener("abort", () => r())),
+      new Promise<void>((_, reject) => setTimeout(() => reject(new Error("abort did not fire within 500ms")), 500)),
+    ])
+    expect(signal.aborted).toBe(true)
+  })
+
+  test("combines multiple external signals", () => {
+    const a = new AbortController()
+    const b = new AbortController()
+    const { signal, clearTimeout } = abortAfterAny(5000, a.signal, b.signal)
+    b.abort()
+    expect(signal.aborted).toBe(true)
+    clearTimeout()
+  })
+})

--- a/packages/opencode/test/util/rpc.test.ts
+++ b/packages/opencode/test/util/rpc.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect, afterEach } from "bun:test"
+import { Rpc } from "../../src/util/rpc"
+
+describe("Rpc: client protocol", () => {
+  test("single call returns correct result via mock channel", async () => {
+    // Create a target that simulates a server: when a request arrives,
+    // compute the result and send it back through onmessage.
+    const target: any = {
+      onmessage: null,
+      postMessage: (data: string) => {
+        const parsed = JSON.parse(data)
+        if (parsed.type === "rpc.request" && parsed.method === "add") {
+          const result = parsed.input.a + parsed.input.b
+          // Respond asynchronously (microtask) to mirror real Worker timing
+          Promise.resolve().then(() => {
+            target.onmessage!({
+              data: JSON.stringify({ type: "rpc.result", result, id: parsed.id }),
+            } as MessageEvent)
+          })
+        }
+      },
+    }
+
+    const rpc = Rpc.client<{ add: (input: { a: number; b: number }) => number }>(target)
+    const result = await rpc.call("add", { a: 3, b: 4 })
+    expect(result).toBe(7)
+  })
+
+  test("concurrent calls resolve to their own results (synchronous out-of-order)", async () => {
+    // Accumulate requests and respond in reverse order synchronously
+    const pending: Array<{ method: string; input: any; id: number }> = []
+    const target: any = {
+      onmessage: null,
+      postMessage: (data: string) => {
+        const parsed = JSON.parse(data)
+        if (parsed.type === "rpc.request") {
+          pending.push({ method: parsed.method, input: parsed.input, id: parsed.id })
+          // After both requests arrive, respond in reverse order
+          if (pending.length === 2) {
+            // Second request resolves first, then first — no timers
+            for (const req of [...pending].reverse()) {
+              target.onmessage!({
+                data: JSON.stringify({ type: "rpc.result", result: req.input, id: req.id }),
+              } as MessageEvent)
+            }
+          }
+        }
+      },
+    }
+
+    const rpc = Rpc.client<{ echo: (input: string) => string }>(target)
+    const [r1, r2] = await Promise.all([rpc.call("echo", "first"), rpc.call("echo", "second")])
+    expect(r1).toBe("first")
+    expect(r2).toBe("second")
+  })
+
+  test("event subscription delivers data and unsubscribe works", () => {
+    const target: any = { onmessage: null, postMessage: () => {} }
+    const rpc = Rpc.client(target)
+
+    const received: string[] = []
+    const unsub = rpc.on<string>("status", (data) => received.push(data))
+
+    // Simulate two events
+    target.onmessage!({ data: JSON.stringify({ type: "rpc.event", event: "status", data: "ok" }) } as MessageEvent)
+    target.onmessage!({ data: JSON.stringify({ type: "rpc.event", event: "status", data: "done" }) } as MessageEvent)
+
+    expect(received).toEqual(["ok", "done"])
+
+    // Unsubscribe and send another event — should be ignored
+    unsub()
+    target.onmessage!({
+      data: JSON.stringify({ type: "rpc.event", event: "status", data: "ignored" }),
+    } as MessageEvent)
+    expect(received).toEqual(["ok", "done"])
+  })
+
+  test("unmatched result id is silently ignored", () => {
+    const target: any = { onmessage: null, postMessage: () => {} }
+    Rpc.client(target)
+
+    // Stale/duplicate result IDs must not throw
+    expect(() => {
+      target.onmessage!({
+        data: JSON.stringify({ type: "rpc.result", result: "stale", id: 99999 }),
+      } as MessageEvent)
+    }).not.toThrow()
+  })
+
+  test("multiple event listeners on the same event", () => {
+    const target: any = { onmessage: null, postMessage: () => {} }
+    const rpc = Rpc.client(target)
+
+    const a: number[] = []
+    const b: number[] = []
+    rpc.on<number>("tick", (v) => a.push(v))
+    const unsub = rpc.on<number>("tick", (v) => b.push(v))
+
+    target.onmessage!({ data: JSON.stringify({ type: "rpc.event", event: "tick", data: 1 }) } as MessageEvent)
+    unsub()
+    target.onmessage!({ data: JSON.stringify({ type: "rpc.event", event: "tick", data: 2 }) } as MessageEvent)
+
+    expect(a).toEqual([1, 2])
+    expect(b).toEqual([1])
+  })
+})


### PR DESCRIPTION
## Summary

Add 11 new tests covering two previously untested utility modules that power TUI communication and tool timeout enforcement.

**1. `Rpc` client protocol — `src/util/rpc.ts`** (5 new tests)

The RPC module handles message passing between the main thread and Web Workers for TUI rendering. The only existing test (`test/cli/tui/worker.test.ts`) checks that the TUI worker boots without errors — it never tests the RPC protocol itself. A bug in request/response ID matching would cause concurrent TUI calls to return wrong results, silently corrupting the interface. New coverage includes:

- Single request/response round-trip with mock channel (microtask-async, mirroring real Worker timing)
- **Concurrent calls resolve to their own results** — requests are responded to in reverse order (synchronously, no timers) to prove that request ID matching works correctly even when responses arrive out-of-order
- Event subscription delivery and unsubscribe cleanup — verifies that `on()` delivers data and the returned unsubscribe function stops delivery
- Stale/duplicate result IDs are silently ignored (defensive contract)
- Multiple listeners on the same event with independent unsubscribe

**2. `abortAfter` / `abortAfterAny` — `src/util/abort.ts`** (6 new tests)

These utilities enforce timeouts for network tools (codesearch, webfetch) and compose multiple abort signals. Zero tests existed. If the timeout doesn't fire or `clearTimeout` doesn't prevent it, tools either hang indefinitely (blocking the session) or abort prematurely. The `bind()` trick on line 13 is a documented GC optimization — a regression would cause memory leaks in long-running sessions. New coverage includes:

- Signal starts unaborted (sanity baseline)
- Signal fires after timeout (event-driven assertion, not wall-clock polling — CI-safe)
- `clearTimeout()` prevents the abort from ever firing (waits 20x the timeout duration)
- External signal aborts composite before timeout fires
- Timeout fires when external signal stays silent
- Multiple external signals composed via `AbortSignal.any()`

### Quality assurance

All tests were reviewed by a critic agent before committing:
- Rejected a timer-based concurrent calls test (flaky on CI) and rewrote with synchronous out-of-order responses
- Revised all timeout assertions to be event-driven instead of wall-clock polling
- Increased timeout headroom ratios for the `clearTimeout` test

## Test plan

- [x] `bun test test/util/rpc.test.ts` — 5 pass
- [x] `bun test test/util/abort.test.ts` — 6 pass
- [x] Marker analysis passes (no upstream source files modified)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Issue for this PR
N/A — proactive test coverage

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01SEi5D6EC94jD3x9bpJdyQJ