### PR TITLE
test: config — ConfigPaths.parseText substitution and JSONC parsing

### DIFF
--- a/packages/opencode/test/config/paths.test.ts
+++ b/packages/opencode/test/config/paths.test.ts
@@ -1,0 +1,167 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+import fs from "fs/promises"
+import { ConfigPaths } from "../../src/config/paths"
+
+describe("ConfigPaths.parseText: {env:VAR} substitution", () => {
+  const saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    saved.TEST_DB_HOST = process.env.TEST_DB_HOST
+    saved.TEST_EMPTY_VAR = process.env.TEST_EMPTY_VAR
+  })
+
+  afterEach(() => {
+    for (const [key, val] of Object.entries(saved)) {
+      if (val === undefined) delete process.env[key]
+      else process.env[key] = val
+    }
+  })
+
+  test("replaces {env:VAR} with environment variable value", async () => {
+    process.env.TEST_DB_HOST = "localhost"
+    const result = await ConfigPaths.parseText(
+      '{ "host": "{env:TEST_DB_HOST}" }',
+      "/fake/config.json",
+    )
+    expect(result).toEqual({ host: "localhost" })
+  })
+
+  test("missing env var resolves to empty string", async () => {
+    delete process.env.TEST_EMPTY_VAR
+    const result = await ConfigPaths.parseText(
+      '{ "key": "{env:TEST_EMPTY_VAR}" }',
+      "/fake/config.json",
+    )
+    expect(result).toEqual({ key: "" })
+  })
+})
+
+describe("ConfigPaths.parseText: {file:path} substitution", () => {
+  test("inlines content from a relative file path", async () => {
+    await using tmp = await tmpdir()
+    const secretFile = path.join(tmp.path, "secret.txt")
+    await fs.writeFile(secretFile, "my-api-key-123")
+    const configPath = path.join(tmp.path, "opencode.json")
+
+    const result = await ConfigPaths.parseText(
+      '{ "apiKey": "{file:secret.txt}" }',
+      configPath,
+    )
+    expect(result).toEqual({ apiKey: "my-api-key-123" })
+  })
+
+  test("inlines content from an absolute file path", async () => {
+    await using tmp = await tmpdir()
+    const secretFile = path.join(tmp.path, "abs-secret.txt")
+    await fs.writeFile(secretFile, "absolute-key")
+
+    const result = await ConfigPaths.parseText(
+      `{ "apiKey": "{file:${secretFile}}" }`,
+      "/fake/config.json",
+    )
+    expect(result).toEqual({ apiKey: "absolute-key" })
+  })
+
+  test("trims whitespace from file content", async () => {
+    await using tmp = await tmpdir()
+    const secretFile = path.join(tmp.path, "padded.txt")
+    await fs.writeFile(secretFile, "  trimmed-value  \n")
+    const configPath = path.join(tmp.path, "opencode.json")
+
+    const result = await ConfigPaths.parseText(
+      '{ "val": "{file:padded.txt}" }',
+      configPath,
+    )
+    expect(result).toEqual({ val: "trimmed-value" })
+  })
+
+  test("throws ConfigInvalidError when referenced file does not exist", async () => {
+    await using tmp = await tmpdir()
+    const configPath = path.join(tmp.path, "opencode.json")
+
+    try {
+      await ConfigPaths.parseText(
+        '{ "apiKey": "{file:nonexistent.txt}" }',
+        configPath,
+      )
+      expect.unreachable("should have thrown")
+    } catch (err: any) {
+      expect(err.name).toBe("ConfigInvalidError")
+      expect(err.data.message).toContain("does not exist")
+    }
+  })
+
+  test("missing file with mode 'empty' resolves to empty string", async () => {
+    await using tmp = await tmpdir()
+    const configPath = path.join(tmp.path, "opencode.json")
+
+    const result = await ConfigPaths.parseText(
+      '{ "apiKey": "{file:nonexistent.txt}" }',
+      configPath,
+      "empty",
+    )
+    expect(result).toEqual({ apiKey: "" })
+  })
+
+  test("skips {file:...} inside JSONC comments", async () => {
+    await using tmp = await tmpdir()
+    const configPath = path.join(tmp.path, "opencode.json")
+
+    // The {file:...} on a commented line should be left as-is and not cause an error
+    const text = [
+      "{",
+      '  // {file:does-not-exist.txt}',
+      '  "name": "test"',
+      "}",
+    ].join("\n")
+
+    const result = await ConfigPaths.parseText(text, configPath)
+    expect(result).toEqual({ name: "test" })
+  })
+})
+
+describe("ConfigPaths.parseText: JSONC parsing", () => {
+  test("parses valid JSONC with comments and trailing commas", async () => {
+    const text = [
+      "{",
+      '  // This is a comment',
+      '  "name": "test",',
+      '  "count": 42,',
+      "}",
+    ].join("\n")
+
+    const result = await ConfigPaths.parseText(text, "/fake/config.json")
+    expect(result).toEqual({ name: "test", count: 42 })
+  })
+
+  test("throws ConfigJsonError with line/column on syntax error", async () => {
+    const text = '{ "name": "test", "bad": }'
+
+    try {
+      await ConfigPaths.parseText(text, "/fake/bad.json")
+      expect.unreachable("should have thrown")
+    } catch (err: any) {
+      expect(err.name).toBe("ConfigJsonError")
+      expect(err.data.path).toBe("/fake/bad.json")
+      // Error message should contain line and column info
+      expect(err.data.message).toContain("line")
+      expect(err.data.message).toContain("column")
+    }
+  })
+
+  test("error message includes the problematic JSONC input", async () => {
+    const text = '{ invalid json }'
+
+    try {
+      await ConfigPaths.parseText(text, "/fake/bad.json")
+      expect.unreachable("should have thrown")
+    } catch (err: any) {
+      expect(err.name).toBe("ConfigJsonError")
+      // The error message should include the input for debugging
+      expect(err.data.message).toContain("JSONC Input")
+      expect(err.data.message).toContain("invalid json")
+    }
+  })
+})


### PR DESCRIPTION
### What does this PR do?\n\n**1. `ConfigPaths.parseText` and `ConfigPaths.substitute` — `src/config/paths.ts`** (11 new tests)\n\nThis module handles all config file loading: `{env:VAR}` token substitution, `{file:path}` file inclusion, and JSONC parsing with error reporting. **Zero tests existed.** This is the core config loading path — any bug here crashes the application or silently produces wrong config values for every user.\n\nNew coverage includes:\n\n**`{env:VAR}` substitution (2 tests):**\n- Happy path: environment variable value is correctly interpolated into config\n- Missing env var: silently resolves to empty string (documents surprising behavior — a typo in var name produces no error)\n\n**`{file:path}` substitution (5 tests):**\n- Relative path resolution: `{file:secret.txt}` resolves relative to the config file's directory, not CWD\n- Absolute path: `{file:/abs/path}` bypasses relative resolution via `path.isAbsolute()` branch\n- Whitespace trimming: file content is `.trim()`'d — prevents trailing newlines from corrupting API keys\n- Missing file error: throws `ConfigInvalidError` with \"does not exist\" message pointing to the resolved path\n- Missing file with `\"empty\"` mode: gracefully returns empty string instead of throwing (used for optional file refs)\n- Comment awareness: `{file:...}` tokens inside `//` comment lines are skipped, preventing errors from documented example configs\n\n**JSONC parsing (2 tests):**\n- Valid JSONC: comments and trailing commas parse correctly (validates `jsonc-parser` wiring)\n- Syntax error reporting: `ConfigJsonError` includes the file path, line/column numbers, and the full JSONC input for debugging\n- Error echo: the problematic input text is included in the error message so users can identify the issue\n\n### Type of change\n- [x] New feature (non-breaking change which adds functionality)\n\n### Issue for this PR\nN/A — proactive test coverage. `ConfigPaths.parseText` had zero tests despite being the config loading critical path.\n\n### How did you verify your code works?\n\n```\nbun test test/config/paths.test.ts       # 11 pass, 0 fail (287ms)\n```\n\nTests were reviewed by a critic agent that:\n- Rejected 4 tests (duplicate code paths, trivially correct code)\n- Caught a critical bug: assertions used `err.properties` instead of `err.data` (would have silently passed while asserting nothing)\n- Approved 9 tests, 2 revised with the `err.data` fix\n\n### Checklist\n- [x] I have added tests that prove my fix is effective or that my feature works\n- [x] New and existing unit tests pass locally with my changes\n\nhttps://claude.ai/code/session_01LAyJZEAuipia1v9DZjbDCo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for configuration path parsing, including environment variable substitution, file inclusion handling, and JSONC validation with robust error detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->