### PR TITLE
test: config — ConfigPaths.parseText JSONC parsing and substitution

### DIFF
--- a/packages/opencode/test/config/paths.test.ts
+++ b/packages/opencode/test/config/paths.test.ts
@@ -1,0 +1,144 @@
+import { describe, test, expect } from "bun:test"
+import { ConfigPaths } from "../../src/config/paths"
+import { tmpdir } from "../fixture/fixture"
+import * as fs from "fs/promises"
+import path from "path"
+
+describe("ConfigPaths.parseText: valid JSONC", () => {
+  test("parses valid JSONC with trailing comma", async () => {
+    const text = '{\n  "name": "test",\n  "value": 42,\n}'
+    const result = await ConfigPaths.parseText(text, "/fake/config.json")
+    expect(result).toEqual({ name: "test", value: 42 })
+  })
+
+  test("parses JSONC with line comments", async () => {
+    const text = '{\n  // a comment\n  "key": "val"\n}'
+    const result = await ConfigPaths.parseText(text, "/fake/config.json")
+    expect(result).toEqual({ key: "val" })
+  })
+})
+
+describe("ConfigPaths.parseText: JSONC error reporting", () => {
+  test("throws JsonError with line and column for missing comma", async () => {
+    // Missing comma between "name" and "value" properties
+    const text = '{\n  "name": "test"\n  "value": 42\n}'
+    await expect(ConfigPaths.parseText(text, "/fake/config.json")).rejects.toMatchObject({
+      name: "ConfigJsonError",
+      data: {
+        path: "/fake/config.json",
+      },
+    })
+    // Verify the error message includes position details
+    try {
+      await ConfigPaths.parseText(text, "/fake/config.json")
+    } catch (e: any) {
+      expect(e.data.message).toMatch(/line \d+/)
+      expect(e.data.message).toMatch(/column \d+/)
+    }
+  })
+
+  test("error message includes the offending line content", async () => {
+    const text = '{\n  "a": [1, 2\n  "b": 3\n}'
+    try {
+      await ConfigPaths.parseText(text, "/fake/config.json")
+      throw new Error("should have thrown")
+    } catch (e: any) {
+      if (e.message === "should have thrown") throw e
+      // The error message should include the JSONC input and a caret marker
+      expect(e.data.message).toContain("JSONC Input")
+      expect(e.data.message).toContain("^")
+    }
+  })
+})
+
+describe("ConfigPaths.parseText: {env:} substitution", () => {
+  test("replaces {env:VAR} with environment variable value", async () => {
+    const prev = process.env["TEST_PARSE_TEXT_VAR"]
+    process.env["TEST_PARSE_TEXT_VAR"] = "hello_world"
+    try {
+      const result = await ConfigPaths.parseText(
+        '{ "key": "{env:TEST_PARSE_TEXT_VAR}" }',
+        "/fake/config.json",
+      )
+      expect(result.key).toBe("hello_world")
+    } finally {
+      if (prev === undefined) delete process.env["TEST_PARSE_TEXT_VAR"]
+      else process.env["TEST_PARSE_TEXT_VAR"] = prev
+    }
+  })
+
+  test("replaces missing env var with empty string", async () => {
+    delete process.env["DEFINITELY_MISSING_PARSE_TEXT_VAR_98765"]
+    const result = await ConfigPaths.parseText(
+      '{ "key": "{env:DEFINITELY_MISSING_PARSE_TEXT_VAR_98765}" }',
+      "/fake/config.json",
+    )
+    expect(result.key).toBe("")
+  })
+})
+
+describe("ConfigPaths.parseText: {file:} comment skipping", () => {
+  test("skips {file:} tokens inside line comments", async () => {
+    // If the comment-skip logic is broken, this would throw ENOENT
+    const text = '{\n  // {file:nonexistent-file-that-does-not-exist.txt}\n  "key": "value"\n}'
+    const result = await ConfigPaths.parseText(text, "/fake/config.json")
+    expect(result.key).toBe("value")
+  })
+})
+
+describe("ConfigPaths.parseText: {file:} missing file error", () => {
+  test("throws InvalidError when referenced file does not exist", async () => {
+    const text = '{ "key": "{file:/tmp/definitely-nonexistent-parse-text-file-abc123.txt}" }'
+    await expect(ConfigPaths.parseText(text, "/fake/config.json")).rejects.toMatchObject({
+      name: "ConfigInvalidError",
+      data: {
+        path: "/fake/config.json",
+      },
+    })
+    // Verify specific error details
+    try {
+      await ConfigPaths.parseText(text, "/fake/config.json")
+    } catch (e: any) {
+      expect(e.data.message).toContain("does not exist")
+    }
+  })
+
+  test("returns empty string for missing file when missing='empty'", async () => {
+    const text = '{ "key": "{file:/tmp/definitely-nonexistent-parse-text-file-abc123.txt}" }'
+    const result = await ConfigPaths.parseText(text, "/fake/config.json", "empty")
+    expect(result.key).toBe("")
+  })
+})
+
+describe("ConfigPaths.parseText: {file:} real file substitution", () => {
+  test("substitutes {file:path} with actual file content", async () => {
+    await using tmp = await tmpdir()
+    const secretFile = path.join(tmp.path, "secret.txt")
+    await fs.writeFile(secretFile, "my-secret-value")
+
+    const text = `{ "apiKey": "{file:${secretFile}}" }`
+    const result = await ConfigPaths.parseText(text, "/fake/config.json")
+    expect(result.apiKey).toBe("my-secret-value")
+  })
+
+  test("trims whitespace from file content", async () => {
+    await using tmp = await tmpdir()
+    const secretFile = path.join(tmp.path, "secret.txt")
+    await fs.writeFile(secretFile, "  my-value  \n")
+
+    const text = `{ "apiKey": "{file:${secretFile}}" }`
+    const result = await ConfigPaths.parseText(text, "/fake/config.json")
+    expect(result.apiKey).toBe("my-value")
+  })
+
+  test("resolves relative {file:} paths against config directory", async () => {
+    await using tmp = await tmpdir()
+    const secretFile = path.join(tmp.path, "api-key.txt")
+    await fs.writeFile(secretFile, "relative-secret")
+
+    const configPath = path.join(tmp.path, "opencode.json")
+    const text = '{ "apiKey": "{file:api-key.txt}" }'
+    const result = await ConfigPaths.parseText(text, configPath)
+    expect(result.apiKey).toBe("relative-secret")
+  })
+})


### PR DESCRIPTION
### What does this PR do?\n\n**1. `ConfigPaths.parseText` — `src/config/paths.ts`** (12 new tests)\n\nThis function is the core JSONC config parser used by both `Config.get()` and TUI config loading. It handles `{env:VAR}` and `{file:path}` token substitution, JSONC comment handling, and error reporting with line/column positions. Previously, it was only tested indirectly through integration tests in `config.test.ts`. Zero direct unit tests existed.\n\nNew coverage includes:\n\n**Valid JSONC parsing (2 tests)**\n- Trailing comma support (verifies `allowTrailingComma: true` flag)\n- Line comment preservation during parsing\n\n**JSONC error reporting (2 tests)**\n- Missing comma throws `ConfigJsonError` with source path, line number, and column number\n- Error message includes the offending line content and a caret (`^`) marker pointing to the error position\n\n**`{env:VAR}` substitution (2 tests)**\n- Present environment variable is substituted correctly\n- Missing environment variable resolves to empty string (not undefined/error)\n\n**`{file:}` comment skipping (1 test)**\n- `{file:nonexistent.txt}` inside a JSONC `//` comment is correctly skipped and does NOT trigger file I/O. This tests the `prefix.startsWith(\"//\")` guard in the `substitute` function — if broken, users with commented-out file references would get cryptic ENOENT errors.\n\n**`{file:}` missing file error handling (2 tests)**\n- Missing file throws `ConfigInvalidError` with \"does not exist\" message and source config path\n- `missing='empty'` mode gracefully returns empty string instead of throwing\n\n**`{file:}` real file substitution (3 tests)**\n- Absolute path file content is substituted correctly\n- File content whitespace is trimmed (verifies the `.trim()` call)\n- Relative `{file:}` paths are resolved against the config file's directory (not CWD)\n\n### Type of change\n- [x] New feature (non-breaking change which adds functionality)\n\n### Issue for this PR\nN/A — proactive test coverage from `/test-discovery`\n\n### How did you verify your code works?\n\n```\nbun test test/config/paths.test.ts    # 12 pass, 0 fail\n```\n\n### Checklist\n- [x] I have added tests that prove my fix is effective or that my feature works\n- [x] New and existing unit tests pass locally with my changes\n\nhttps://claude.ai/code/session_0153Zp8Yg62ibyUuu3vcxz3k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for configuration file parsing functionality, covering JSONC (JSON with Comments) support including trailing commas and comments, error handling with detailed diagnostic information and position tracking, environment variable substitution with fallback behavior, and file inclusion features. Tests ensure robust configuration file processing and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->