### PR TITLE
test: id + file/ignore — monotonic ID ordering and ignore pattern coverage

### DIFF
--- a/packages/opencode/test/file/ignore.test.ts
+++ b/packages/opencode/test/file/ignore.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test"
+import { describe, test, expect } from "bun:test"
 import { FileIgnore } from "../../src/file/ignore"
 
 test("match nested and non-nested", () => {
@@ -7,4 +7,48 @@ test("match nested and non-nested", () => {
   expect(FileIgnore.match("node_modules/")).toBe(true)
   expect(FileIgnore.match("node_modules/bar")).toBe(true)
   expect(FileIgnore.match("node_modules/bar/")).toBe(true)
+})
+
+describe("FileIgnore.match: directory and file patterns", () => {
+  test("matches registered directory patterns beyond node_modules", () => {
+    expect(FileIgnore.match("dist/bundle.js")).toBe(true)
+    expect(FileIgnore.match("build/output.css")).toBe(true)
+    expect(FileIgnore.match(".git/config")).toBe(true)
+    expect(FileIgnore.match("__pycache__/module.pyc")).toBe(true)
+    expect(FileIgnore.match(".next/server/pages")).toBe(true)
+    expect(FileIgnore.match("out/index.html")).toBe(true)
+    expect(FileIgnore.match("bin/cli")).toBe(true)
+    // "desktop" is in FOLDERS — broad match, verify it works as specified
+    expect(FileIgnore.match("desktop/app.js")).toBe(true)
+  })
+
+  test("matches file glob patterns", () => {
+    expect(FileIgnore.match("src/editor.swp")).toBe(true)
+    expect(FileIgnore.match("deep/nested/file.swp")).toBe(true)
+    expect(FileIgnore.match("src/.DS_Store")).toBe(true)
+    expect(FileIgnore.match("cache.pyc")).toBe(true)
+    expect(FileIgnore.match("logs/app.log")).toBe(true)
+    expect(FileIgnore.match("tmp/upload.bin")).toBe(true)
+  })
+
+  test("does not match normal source files", () => {
+    expect(FileIgnore.match("src/index.ts")).toBe(false)
+    expect(FileIgnore.match("README.md")).toBe(false)
+    expect(FileIgnore.match("package.json")).toBe(false)
+    expect(FileIgnore.match("lib/utils.js")).toBe(false)
+  })
+
+  test("whitelist overrides directory match", () => {
+    expect(FileIgnore.match("node_modules/my-package/index.js", { whitelist: ["node_modules/**"] })).toBe(false)
+  })
+
+  test("extra patterns extend matching", () => {
+    expect(FileIgnore.match("config/.env")).toBe(false)
+    expect(FileIgnore.match("config/.env", { extra: ["**/.env"] })).toBe(true)
+  })
+
+  test("handles Windows-style path separators", () => {
+    expect(FileIgnore.match("node_modules\\package\\index.js")).toBe(true)
+    expect(FileIgnore.match("src\\.git\\config")).toBe(true)
+  })
 })

--- a/packages/opencode/test/id/id.test.ts
+++ b/packages/opencode/test/id/id.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect } from "bun:test"
+import { Identifier } from "../../src/id/id"
+
+describe("Identifier: monotonic ID generation", () => {
+  test("ascending IDs are strictly increasing", () => {
+    const ids: string[] = []
+    for (let i = 0; i < 20; i++) {
+      ids.push(Identifier.ascending("session"))
+    }
+    for (let i = 1; i < ids.length; i++) {
+      expect(ids[i]! > ids[i - 1]!).toBe(true)
+    }
+  })
+
+  test("descending IDs are strictly decreasing", () => {
+    const ids: string[] = []
+    for (let i = 0; i < 20; i++) {
+      ids.push(Identifier.descending("session"))
+    }
+    for (let i = 1; i < ids.length; i++) {
+      expect(ids[i]! < ids[i - 1]!).toBe(true)
+    }
+  })
+
+  test("ascending IDs have correct prefix for each type", () => {
+    expect(Identifier.ascending("session")).toStartWith("ses_")
+    expect(Identifier.ascending("message")).toStartWith("msg_")
+    expect(Identifier.ascending("part")).toStartWith("prt_")
+    expect(Identifier.ascending("permission")).toStartWith("per_")
+    expect(Identifier.ascending("tool")).toStartWith("tool_")
+  })
+
+  test("same-millisecond IDs are unique via counter", () => {
+    const ids = new Set<string>()
+    for (let i = 0; i < 100; i++) {
+      ids.add(Identifier.ascending("session"))
+    }
+    expect(ids.size).toBe(100)
+  })
+
+  test("given parameter returns same ID when prefix matches", () => {
+    const id = Identifier.ascending("session")
+    expect(Identifier.ascending("session", id)).toBe(id)
+  })
+
+  test("given parameter throws when prefix does not match", () => {
+    const msgId = Identifier.ascending("message")
+    expect(() => Identifier.ascending("session", msgId)).toThrow()
+  })
+
+  test("timestamp values are relatively ordered for IDs created at different times", () => {
+    // timestamp() returns a truncated value (lower 48 bits of ts*4096),
+    // not the actual wall-clock time. But relative ordering is preserved,
+    // which is how it's used in practice (e.g., truncation.ts comparisons).
+    const id1 = Identifier.create("session", false, 1000000)
+    const id2 = Identifier.create("session", false, 2000000)
+    expect(Identifier.timestamp(id2)).toBeGreaterThan(Identifier.timestamp(id1))
+  })
+
+  test("timestamp round-trips for small timestamps within 48-bit range", () => {
+    // For small timestamps (< 2^36 ≈ 68.7B), the value fits in 48 bits
+    // and round-trips exactly. Modern Date.now() values overflow this.
+    const smallTs = 1000000
+    const id = Identifier.create("session", false, smallTs)
+    expect(Identifier.timestamp(id)).toBe(smallTs)
+  })
+})


### PR DESCRIPTION
## Summary

### What does this PR do?

**1. `Identifier` — `src/id/id.ts`** (8 new tests)

This module generates all monotonic IDs used across the application for sessions, messages, parts, permissions, and tools. Zero tests existed previously. New coverage includes:
- Ascending IDs are strictly increasing (lexicographic order matches creation order)
- Descending IDs are strictly decreasing
- Correct prefix for all ID types (`ses_`, `msg_`, `prt_`, `per_`, `tool_`)
- Same-millisecond uniqueness via internal counter (100 rapid-fire IDs all unique)
- `given` parameter passthrough when prefix matches, throws on mismatch
- `timestamp()` relative ordering is preserved between IDs created at different times
- `timestamp()` round-trips exactly for small timestamps within 48-bit range

**Why it matters:** ID misordering would cause messages to display out of order in the TUI and API. Duplicate IDs would cause silent data corruption. The `timestamp()` function is used in `truncation.ts` for retention cleanup — incorrect relative ordering would cause premature or missed cleanup.

**Notable finding:** `timestamp()` does not return the actual wall-clock `Date.now()` for modern timestamps because `BigInt(ts) * BigInt(0x1000)` exceeds 48 bits (the storage width). However, relative comparisons between `timestamp()` values remain correct, which is how it's used in practice. The tests document this behavior.

**2. `FileIgnore.match` — `src/file/ignore.ts`** (6 new tests, extending 1 existing)

This function controls which files are excluded from watching, scanning, and tool access. The existing test only covered `node_modules` directory matching. New coverage includes:
- All registered directory patterns beyond `node_modules` (`dist`, `build`, `.git`, `__pycache__`, `.next`, `out`, `bin`, `desktop`)
- File glob patterns (`.swp`, `.DS_Store`, `.pyc`, `.log`, `tmp/**`)
- Negative cases — normal source files (`src/index.ts`, `README.md`, `package.json`) are NOT ignored
- Whitelist override — whitelisted patterns prevent directory matches
- Extra patterns — caller-supplied patterns extend the default ignore set
- Windows-style path separators (`\\`) are handled correctly

**Why it matters:** If whitelist overrides don't work, users can't customize which directories are watched. If extra patterns silently fail, config-driven ignore rules are broken. False positives would silently exclude source files from the agent's view.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage from automated test discovery

### How did you verify your code works?

```
bun test test/id/id.test.ts          # 8 pass
bun test test/file/ignore.test.ts    # 7 pass (1 existing + 6 new)
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_012pJZ9ApRnh2fGKMS957frr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased test coverage for file pattern matching behavior, with improvements for advanced directory patterns, glob file matching, configuration options, and cross-platform path separator handling.
  * Implemented comprehensive tests validating identifier monotonic ID generation behavior, including type-specific ID prefixes, strict ID ordering (ascending and descending), uniqueness guarantees, and accurate timestamp handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->