### PR TITLE
test: finops + tool-lookup — RBAC formatting and Zod schema introspection

### DIFF
--- a/packages/opencode/test/altimate/finops-role-access.test.ts
+++ b/packages/opencode/test/altimate/finops-role-access.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for finops role-access formatting functions:
+ * formatGrants, formatHierarchy, formatUserRoles.
+ *
+ * These render RBAC data as markdown tables. Incorrect output
+ * could cause data engineers to miss security issues during audits.
+ * Tests use Dispatcher.call spying to supply known RBAC data.
+ */
+import { describe, test, expect, spyOn, afterAll, beforeEach } from "bun:test"
+import * as Dispatcher from "../../src/altimate/native/dispatcher"
+import {
+  FinopsRoleGrantsTool,
+  FinopsRoleHierarchyTool,
+  FinopsUserRolesTool,
+} from "../../src/altimate/tools/finops-role-access"
+import { SessionID, MessageID } from "../../src/session/schema"
+
+beforeEach(() => {
+  process.env.ALTIMATE_TELEMETRY_DISABLED = "true"
+})
+afterAll(() => {
+  delete process.env.ALTIMATE_TELEMETRY_DISABLED
+})
+
+const ctx = {
+  sessionID: SessionID.make("ses_test"),
+  messageID: MessageID.make("msg_test"),
+  callID: "call_test",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => {},
+  ask: async () => {},
+}
+
+let dispatcherSpy: ReturnType<typeof spyOn>
+
+function mockDispatcher(responses: Record<string, any>) {
+  dispatcherSpy?.mockRestore()
+  dispatcherSpy = spyOn(Dispatcher, "call").mockImplementation(async (method: string) => {
+    if (responses[method]) return responses[method]
+    throw new Error(`No mock for ${method}`)
+  })
+}
+
+afterAll(() => {
+  dispatcherSpy?.mockRestore()
+})
+
+describe("formatGrants: privilege summary and grant rows", () => {
+  test("renders privilege summary and grant table with standard Snowflake fields", async () => {
+    mockDispatcher({
+      "finops.role_grants": {
+        success: true,
+        grant_count: 2,
+        privilege_summary: { SELECT: 2, INSERT: 1 },
+        grants: [
+          { grantee_name: "ANALYST", privilege: "SELECT", object_type: "TABLE", object_name: "orders" },
+          { grantee_name: "ADMIN", privilege: "INSERT", object_type: "TABLE", object_name: "users" },
+        ],
+      },
+    })
+
+    const tool = await FinopsRoleGrantsTool.init()
+    const result = await tool.execute({ warehouse: "test_wh", limit: 100 }, ctx as any)
+
+    expect(result.title).toContain("2 found")
+    expect(result.output).toContain("Privilege Summary")
+    expect(result.output).toContain("SELECT: 2")
+    expect(result.output).toContain("INSERT: 1")
+    expect(result.output).toContain("ANALYST | SELECT | TABLE | orders")
+    expect(result.output).toContain("ADMIN | INSERT | TABLE | users")
+  })
+
+  test("uses fallback field aliases (role, granted_on, name)", async () => {
+    mockDispatcher({
+      "finops.role_grants": {
+        success: true,
+        grant_count: 1,
+        privilege_summary: {},
+        grants: [
+          { role: "DBA", privilege: "USAGE", granted_on: "WAREHOUSE", name: "compute_wh" },
+        ],
+      },
+    })
+
+    const tool = await FinopsRoleGrantsTool.init()
+    const result = await tool.execute({ warehouse: "test_wh", limit: 100 }, ctx as any)
+
+    // formatGrants should fall back to r.role, r.granted_on, r.name
+    expect(result.output).toContain("DBA | USAGE | WAREHOUSE | compute_wh")
+  })
+
+  test("handles empty grants array", async () => {
+    mockDispatcher({
+      "finops.role_grants": {
+        success: true,
+        grant_count: 0,
+        privilege_summary: {},
+        grants: [],
+      },
+    })
+
+    const tool = await FinopsRoleGrantsTool.init()
+    const result = await tool.execute({ warehouse: "test_wh", limit: 100 }, ctx as any)
+
+    expect(result.output).toContain("No grants found")
+  })
+
+  test("returns error message on Dispatcher failure", async () => {
+    mockDispatcher({
+      "finops.role_grants": {
+        success: false,
+        error: "Connection refused",
+      },
+    })
+
+    const tool = await FinopsRoleGrantsTool.init()
+    const result = await tool.execute({ warehouse: "test_wh", limit: 100 }, ctx as any)
+
+    expect(result.title).toContain("FAILED")
+    expect(result.output).toContain("Connection refused")
+  })
+})
+
+describe("formatHierarchy: recursive role tree rendering", () => {
+  test("renders two-level nested hierarchy with children key", async () => {
+    mockDispatcher({
+      "finops.role_hierarchy": {
+        success: true,
+        role_count: 3,
+        hierarchy: [
+          {
+            name: "SYSADMIN",
+            children: [
+              { name: "DBA", children: [] },
+              { name: "ANALYST", children: [] },
+            ],
+          },
+        ],
+      },
+    })
+
+    const tool = await FinopsRoleHierarchyTool.init()
+    const result = await tool.execute({ warehouse: "test_wh" }, ctx as any)
+
+    expect(result.title).toContain("3 roles")
+    expect(result.output).toContain("Role Hierarchy")
+    expect(result.output).toContain("SYSADMIN")
+    expect(result.output).toContain("-> DBA")
+    expect(result.output).toContain("-> ANALYST")
+  })
+
+  test("uses granted_roles fallback alias for children", async () => {
+    mockDispatcher({
+      "finops.role_hierarchy": {
+        success: true,
+        role_count: 2,
+        hierarchy: [
+          {
+            role: "ACCOUNTADMIN",
+            granted_roles: [{ role: "SECURITYADMIN" }],
+          },
+        ],
+      },
+    })
+
+    const tool = await FinopsRoleHierarchyTool.init()
+    const result = await tool.execute({ warehouse: "test_wh" }, ctx as any)
+
+    // Should use r.role as name and r.granted_roles as children
+    expect(result.output).toContain("ACCOUNTADMIN")
+    expect(result.output).toContain("-> SECURITYADMIN")
+  })
+
+  test("handles empty hierarchy", async () => {
+    mockDispatcher({
+      "finops.role_hierarchy": {
+        success: true,
+        role_count: 0,
+        hierarchy: [],
+      },
+    })
+
+    const tool = await FinopsRoleHierarchyTool.init()
+    const result = await tool.execute({ warehouse: "test_wh" }, ctx as any)
+
+    expect(result.output).toContain("Role Hierarchy")
+    // No roles rendered but header is present
+    expect(result.output).not.toContain("->")
+  })
+})
+
+describe("formatUserRoles: user-role assignment table", () => {
+  test("renders user assignments with standard fields", async () => {
+    mockDispatcher({
+      "finops.user_roles": {
+        success: true,
+        assignment_count: 2,
+        assignments: [
+          { grantee_name: "alice@corp.com", role: "ANALYST", granted_by: "SECURITYADMIN" },
+          { grantee_name: "bob@corp.com", role: "DBA", granted_by: "ACCOUNTADMIN" },
+        ],
+      },
+    })
+
+    const tool = await FinopsUserRolesTool.init()
+    const result = await tool.execute({ warehouse: "test_wh", limit: 100 }, ctx as any)
+
+    expect(result.title).toContain("2 assignments")
+    expect(result.output).toContain("User Role Assignments")
+    expect(result.output).toContain("alice@corp.com | ANALYST | SECURITYADMIN")
+    expect(result.output).toContain("bob@corp.com | DBA | ACCOUNTADMIN")
+  })
+
+  test("uses fallback aliases (user_name, role_name, grantor)", async () => {
+    mockDispatcher({
+      "finops.user_roles": {
+        success: true,
+        assignment_count: 1,
+        assignments: [
+          { user_name: "charlie", role_name: "READER", grantor: "ADMIN" },
+        ],
+      },
+    })
+
+    const tool = await FinopsUserRolesTool.init()
+    const result = await tool.execute({ warehouse: "test_wh", limit: 100 }, ctx as any)
+
+    // Falls back to r.user_name (via user fallback chain), r.role_name, r.grantor
+    expect(result.output).toContain("charlie | READER | ADMIN")
+  })
+
+  test("handles empty assignments", async () => {
+    mockDispatcher({
+      "finops.user_roles": {
+        success: true,
+        assignment_count: 0,
+        assignments: [],
+      },
+    })
+
+    const tool = await FinopsUserRolesTool.init()
+    const result = await tool.execute({ warehouse: "test_wh", limit: 100 }, ctx as any)
+
+    expect(result.output).toContain("No user role assignments found")
+  })
+})

--- a/packages/opencode/test/altimate/tool-lookup.test.ts
+++ b/packages/opencode/test/altimate/tool-lookup.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for the tool_lookup tool — Zod schema introspection
+ * (describeZodSchema, inferZodType, unwrap, getShape).
+ *
+ * The agent uses tool_lookup to discover other tools' parameter contracts.
+ * Incorrect introspection leads to wrong tool calls.
+ */
+import { describe, test, expect, beforeEach, afterAll } from "bun:test"
+import z from "zod"
+import { ToolLookupTool } from "../../src/altimate/tools/tool-lookup"
+import { ToolRegistry } from "../../src/tool/registry"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+import { SessionID, MessageID } from "../../src/session/schema"
+
+beforeEach(() => {
+  process.env.ALTIMATE_TELEMETRY_DISABLED = "true"
+})
+afterAll(() => {
+  delete process.env.ALTIMATE_TELEMETRY_DISABLED
+})
+
+const ctx = {
+  sessionID: SessionID.make("ses_test"),
+  messageID: MessageID.make("msg_test"),
+  callID: "call_test",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => {},
+  ask: async () => {},
+}
+
+describe("ToolLookupTool: Zod schema introspection", () => {
+  test("returns parameter info for tool with mixed types", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const testTool = {
+          id: "__test_lookup_mixed",
+          init: async () => ({
+            description: "Test tool with mixed params",
+            parameters: z.object({
+              name: z.string().describe("The name"),
+              count: z.number().describe("How many"),
+              verbose: z.boolean().optional().describe("Enable verbosity"),
+              tags: z.array(z.string()).describe("Tags list"),
+              mode: z.enum(["fast", "slow"]).default("fast").describe("Execution mode"),
+            }),
+            execute: async () => ({ title: "", output: "", metadata: {} }),
+          }),
+        }
+        await ToolRegistry.register(testTool)
+
+        const tool = await ToolLookupTool.init()
+        const result = await tool.execute({ tool_name: "__test_lookup_mixed" }, ctx as any)
+
+        // Required string param
+        expect(result.output).toContain("name")
+        expect(result.output).toContain("string")
+        expect(result.output).toContain("required")
+        expect(result.output).toContain("The name")
+
+        // Number param
+        expect(result.output).toContain("count")
+        expect(result.output).toContain("number")
+
+        // Optional boolean
+        expect(result.output).toContain("verbose")
+        expect(result.output).toContain("optional")
+
+        // Array param
+        expect(result.output).toContain("tags")
+        expect(result.output).toContain("array")
+
+        // Enum with default — inferZodType unwraps default then hits enum
+        expect(result.output).toContain("mode")
+        expect(result.output).toContain("enum")
+      },
+    })
+  })
+
+  test("returns 'Tool not found' with available tools list", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = await ToolLookupTool.init()
+        const result = await tool.execute({ tool_name: "nonexistent_tool_xyz" }, ctx as any)
+        expect(result.title).toBe("Tool not found")
+        expect(result.output).toContain('No tool named "nonexistent_tool_xyz"')
+        expect(result.output).toContain("Available tools:")
+      },
+    })
+  })
+
+  test("handles tool with empty parameters object", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const testTool = {
+          id: "__test_lookup_empty",
+          init: async () => ({
+            description: "Tool with empty params",
+            parameters: z.object({}),
+            execute: async () => ({ title: "", output: "", metadata: {} }),
+          }),
+        }
+        await ToolRegistry.register(testTool)
+
+        const tool = await ToolLookupTool.init()
+        const result = await tool.execute({ tool_name: "__test_lookup_empty" }, ctx as any)
+        expect(result.output).toContain("No parameters")
+      },
+    })
+  })
+
+  test("unwraps nested optional/default wrappers correctly", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const testTool = {
+          id: "__test_lookup_nested",
+          init: async () => ({
+            description: "Tool with nested wrappers",
+            parameters: z.object({
+              // default wrapping optional wrapping string
+              deep: z.string().optional().default("hello").describe("Deeply wrapped"),
+            }),
+            execute: async () => ({ title: "", output: "", metadata: {} }),
+          }),
+        }
+        await ToolRegistry.register(testTool)
+
+        const tool = await ToolLookupTool.init()
+        const result = await tool.execute({ tool_name: "__test_lookup_nested" }, ctx as any)
+
+        // Should unwrap to the inner string type
+        expect(result.output).toContain("deep")
+        expect(result.output).toContain("Deeply wrapped")
+        // The outer wrapper is default, so it should show as optional
+        expect(result.output).toContain("optional")
+      },
+    })
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Adds 14 new tests covering two completely untested modules that have real user-facing risk.

**1. `ToolLookupTool` — `src/altimate/tools/tool-lookup.ts`** (4 new tests)

The agent uses `tool_lookup` to discover other tools' parameter contracts before calling them. The module contains `describeZodSchema`, `inferZodType`, `unwrap`, and `getShape` — pure functions that introspect Zod's internal `_def` structure (not a stable public API). Zero tests existed. If a Zod upgrade changes internals or a wrapper type isn't handled by `unwrap`, the agent silently gets wrong parameter info and makes incorrect tool calls.

New coverage includes:
- Mixed parameter types (string, number, boolean, array, enum) with correct type/required detection
- Default + optional wrapper unwrapping (nested `z.string().optional().default(...)`)
- Empty parameters object handling (`"No parameters."` path)
- Tool-not-found path with available tools listing

**2. `FinopsRoleAccess` formatting — `src/altimate/tools/finops-role-access.ts`** (10 new tests)

The `formatGrants`, `formatHierarchy`, and `formatUserRoles` functions render RBAC data as tables for data engineers auditing Snowflake permissions. Zero tests existed. Incorrect output could cause engineers to miss security issues.

New coverage includes:
- `formatGrants`: privilege summary rendering, grant table with standard Snowflake fields, fallback field aliases (`grantee_name` vs `role`, `object_type` vs `granted_on`, `object_name` vs `name`), empty grants, Dispatcher failure error path
- `formatHierarchy`: recursive two-level tree rendering with `children` key, `granted_roles` fallback alias, empty hierarchy
- `formatUserRoles`: standard field rendering, fallback aliases (`user_name`, `role_name`, `grantor`), empty assignments

Tests use `Dispatcher.call` spying (established pattern from `impact-analysis.test.ts`) to supply known RBAC data without requiring a real warehouse connection.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage

### How did you verify your code works?

```
bun test test/altimate/tool-lookup.test.ts         # 4 pass, 19 expect() calls
bun test test/altimate/finops-role-access.test.ts   # 10 pass, 25 expect() calls
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01PnbJpBRPw8DrqSBDxhrCjg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for finops role-access formatting tools, including validation of role grants, role hierarchies, and user role assignments.
  * Added test coverage for tool lookup functionality, including parameter schema introspection and error handling for unavailable tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->