### PR TITLE
test: config — ConfigPaths.parseText substitution and JSONC parsing

### DIFF
--- a/packages/opencode/test/config/paths-parsetext.test.ts
+++ b/packages/opencode/test/config/paths-parsetext.test.ts
@@ -1,0 +1,186 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { ConfigPaths } from "../../src/config/paths"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+import fs from "fs/promises"
+
+describe("ConfigPaths.parseText: JSONC parsing", () => {
+  test("parses plain JSON object", async () => {
+    const result = await ConfigPaths.parseText('{"key": "value"}', "/fake/config.json")
+    expect(result).toEqual({ key: "value" })
+  })
+
+  test("parses JSONC with comments", async () => {
+    const text = `{
+      // This is a comment
+      "key": "value"
+    }`
+    const result = await ConfigPaths.parseText(text, "/fake/config.jsonc")
+    expect(result).toEqual({ key: "value" })
+  })
+
+  test("allows trailing commas", async () => {
+    const text = '{"a": 1, "b": 2,}'
+    const result = await ConfigPaths.parseText(text, "/fake/config.json")
+    expect(result).toEqual({ a: 1, b: 2 })
+  })
+
+  test("throws JsonError on invalid JSONC", async () => {
+    const text = '{"key": value_without_quotes}'
+    try {
+      await ConfigPaths.parseText(text, "/fake/bad.json")
+      expect.unreachable("should have thrown")
+    } catch (e: any) {
+      expect(e.constructor.name).toBe("ConfigJsonError")
+      expect(e.data.path).toBe("/fake/bad.json")
+    }
+  })
+
+  test("error message includes line and column info", async () => {
+    const text = '{\n  "a": 1\n  "b": 2\n}'
+    try {
+      await ConfigPaths.parseText(text, "/fake/bad.json")
+      expect.unreachable("should have thrown")
+    } catch (e: any) {
+      expect(e.data.message).toContain("line")
+      expect(e.data.message).toContain("column")
+    }
+  })
+})
+
+describe("ConfigPaths.parseText: {env:VAR} substitution", () => {
+  const envKey = "OPENCODE_TEST_PARSE_TEXT_KEY"
+
+  beforeEach(() => {
+    process.env[envKey] = "test-api-key-12345"
+  })
+
+  afterEach(() => {
+    delete process.env[envKey]
+  })
+
+  test("substitutes {env:VAR} with environment variable value", async () => {
+    const text = `{"apiKey": "{env:${envKey}}"}`
+    const result = await ConfigPaths.parseText(text, "/fake/config.json")
+    expect(result).toEqual({ apiKey: "test-api-key-12345" })
+  })
+
+  test("substitutes to empty string when env var is not set", async () => {
+    const text = '{"apiKey": "{env:OPENCODE_TEST_NONEXISTENT_VAR_XYZ}"}'
+    const result = await ConfigPaths.parseText(text, "/fake/config.json")
+    expect(result).toEqual({ apiKey: "" })
+  })
+
+  test("substitutes multiple env vars in same text", async () => {
+    process.env.OPENCODE_TEST_HOST = "localhost"
+    process.env.OPENCODE_TEST_PORT = "5432"
+    try {
+      const text = '{"host": "{env:OPENCODE_TEST_HOST}", "port": "{env:OPENCODE_TEST_PORT}"}'
+      const result = await ConfigPaths.parseText(text, "/fake/config.json")
+      expect(result).toEqual({ host: "localhost", port: "5432" })
+    } finally {
+      delete process.env.OPENCODE_TEST_HOST
+      delete process.env.OPENCODE_TEST_PORT
+    }
+  })
+
+  test("env var substitution is raw text injection (not JSON-quoted)", async () => {
+    process.env.OPENCODE_TEST_NUM = "42"
+    try {
+      // After env substitution, this becomes {"count": 42} — a number, not a string
+      const text = '{"count": {env:OPENCODE_TEST_NUM}}'
+      const result = await ConfigPaths.parseText(text, "/fake/config.json")
+      expect(result).toEqual({ count: 42 })
+    } finally {
+      delete process.env.OPENCODE_TEST_NUM
+    }
+  })
+})
+
+describe("ConfigPaths.parseText: {file:path} substitution", () => {
+  test("substitutes {file:path} with file contents (trimmed)", async () => {
+    await using tmp = await tmpdir()
+    const secretPath = path.join(tmp.path, "secret.txt")
+    await fs.writeFile(secretPath, "my-secret-value\n")
+
+    const text = `{"secret": "{file:${secretPath}}"}`
+    const result = await ConfigPaths.parseText(text, "/fake/config.json")
+    expect(result).toEqual({ secret: "my-secret-value" })
+  })
+
+  test("resolves relative file path from config directory", async () => {
+    await using tmp = await tmpdir()
+    const secretPath = path.join(tmp.path, "creds.txt")
+    await fs.writeFile(secretPath, "relative-secret")
+
+    // source is the config file path — {file:creds.txt} resolves relative to its directory
+    const configPath = path.join(tmp.path, "config.json")
+    const text = '{"secret": "{file:creds.txt}"}'
+    const result = await ConfigPaths.parseText(text, configPath)
+    expect(result).toEqual({ secret: "relative-secret" })
+  })
+
+  test("throws InvalidError when referenced file does not exist", async () => {
+    const text = '{"secret": "{file:/nonexistent/path/secret.txt}"}'
+    try {
+      await ConfigPaths.parseText(text, "/fake/config.json")
+      expect.unreachable("should have thrown")
+    } catch (e: any) {
+      expect(e.constructor.name).toBe("ConfigInvalidError")
+      expect(e.data.path).toBe("/fake/config.json")
+      expect(e.data.message).toContain("does not exist")
+    }
+  })
+
+  test("missing='empty' returns empty string for missing files", async () => {
+    const text = '{"secret": "{file:/nonexistent/path/secret.txt}"}'
+    const result = await ConfigPaths.parseText(text, "/fake/config.json", "empty")
+    expect(result).toEqual({ secret: "" })
+  })
+
+  test("skips {file:...} inside // comments", async () => {
+    await using tmp = await tmpdir()
+    // The file doesn't exist, but it's in a comment so should not trigger an error
+    const text = `{
+      // Reference: {file:nonexistent.txt}
+      "key": "value"
+    }`
+    const result = await ConfigPaths.parseText(text, path.join(tmp.path, "config.json"))
+    expect(result).toEqual({ key: "value" })
+  })
+
+  test("escapes file content for JSON safety (quotes and newlines)", async () => {
+    await using tmp = await tmpdir()
+    const secretPath = path.join(tmp.path, "multiline.txt")
+    // Content with characters that need JSON escaping
+    await fs.writeFile(secretPath, 'value with "quotes" and\nnewlines')
+
+    const text = `{"secret": "{file:${secretPath}}"}`
+    const result = await ConfigPaths.parseText(text, "/fake/config.json")
+    // After file read → trim → JSON.stringify escape → parseJsonc, we get original content back
+    expect(result.secret).toBe('value with "quotes" and\nnewlines')
+  })
+})
+
+describe("ConfigPaths.parseText: combined substitutions", () => {
+  test("handles both {env:} and {file:} in same config", async () => {
+    await using tmp = await tmpdir()
+    const secretPath = path.join(tmp.path, "db-pass.txt")
+    await fs.writeFile(secretPath, "file-password")
+
+    process.env.OPENCODE_TEST_DB_HOST = "db.example.com"
+    try {
+      const text = `{
+        "host": "{env:OPENCODE_TEST_DB_HOST}",
+        "password": "{file:${secretPath}}"
+      }`
+      const result = await ConfigPaths.parseText(text, "/fake/config.json")
+      expect(result).toEqual({
+        host: "db.example.com",
+        password: "file-password",
+      })
+    } finally {
+      delete process.env.OPENCODE_TEST_DB_HOST
+    }
+  })
+})


### PR DESCRIPTION
## Summary

**`ConfigPaths.parseText` — `src/config/paths.ts`** (16 new tests)

This function is the foundation of all config loading in altimate-code. It handles `{env:VAR}` environment variable substitution, `{file:path}` file content injection, and JSONC parsing with error reporting. **Zero tests existed** prior to this PR — confirmed via `grep -r "parseText\|{env:\|{file:" packages/opencode/test/` returning no results.

If this code breaks:
- API keys injected via `{env:ANTHROPIC_API_KEY}` silently become empty strings
- Credential files referenced via `{file:~/secrets/key.txt}` stop being read
- Config parsing errors lose line/column info, making debugging impossible

### Specific scenarios covered

**JSONC parsing (5 tests):**
- Plain JSON object parsing
- JSONC comments are stripped correctly (`jsonc-parser` invoked, not `JSON.parse`)
- Trailing commas allowed (regression guard for `allowTrailingComma: true` option)
- `ConfigJsonError` thrown on invalid syntax with correct error shape (`e.data.path`)
- Error messages include line and column info for user debugging

**`{env:VAR}` substitution (4 tests):**
- Environment variable value is substituted correctly
- Missing env var falls back to empty string (the `|| ""` path)
- Multiple env vars in same config text all get replaced (global regex)
- Raw text injection — env vars are NOT JSON-quoted, enabling `{env:NUM}` → number

**`{file:path}` substitution (5 tests):**
- Absolute file path reads and trims content
- Relative file path resolves from config file's directory (not `process.cwd()`)
- `ConfigInvalidError` thrown for missing files with "does not exist" message
- `missing='empty'` parameter returns empty string instead of throwing
- `{file:...}` tokens inside `//` comments are skipped (comment detection logic)
- File content with quotes and newlines is JSON-escaped correctly (round-trip safety)

**Combined substitutions (1 test):**
- Both `{env:}` and `{file:}` work together in a single config parse

### Critic review

Tests were reviewed by an automated critic agent. Key fixes applied:
- All error assertions use `e.data.*` (not `e.properties.*`) matching the actual `NamedError` shape
- Removed a test that claimed to test `~/` expansion but actually tested absolute paths
- Renamed "env substitution before JSONC parsing" to clarify it tests raw text injection behavior

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Issue for this PR
N/A — proactive test coverage via `/test-discovery`

## How did you verify your code works?

```
bun test test/config/paths-parsetext.test.ts    # 16 pass, 0 fail
```

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01Q1dSZU3cd7ojBSPJodbK1J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Comprehensive test coverage for configuration file parsing functionality, validating JSON and JSONC format support with comments and trailing commas, environment variable substitution with fallback handling, file path resolution relative to configuration directories, detailed error reporting with line and column information, configurable missing file behavior, and complex multi-substitution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->