### PR TITLE
test: id — Identifier generation, ordering, and timestamp extraction

### DIFF
--- a/packages/opencode/test/id/id.test.ts
+++ b/packages/opencode/test/id/id.test.ts
@@ -1,0 +1,91 @@
+import { describe, test, expect } from "bun:test"
+import { Identifier } from "../../src/id/id"
+
+describe("Identifier", () => {
+  describe("ascending", () => {
+    test("generates ID with correct prefix", () => {
+      const id = Identifier.ascending("session")
+      expect(id).toStartWith("ses_")
+      expect(id.length).toBeGreaterThan(10)
+    })
+
+    test("generates monotonically increasing IDs", () => {
+      const ids = Array.from({ length: 100 }, () => Identifier.ascending("message"))
+      for (let i = 1; i < ids.length; i++) {
+        expect(ids[i] > ids[i - 1]).toBe(true)
+      }
+    })
+
+    test("returns given ID when prefix matches", () => {
+      const given = "ses_abc123"
+      const id = Identifier.ascending("session", given)
+      expect(id).toBe(given)
+    })
+
+    test("accepts any string that starts with the prefix — prefix check is permissive", () => {
+      // "session_xyz" starts with "ses", so generateID accepts it
+      const given = "ses_sion_xyz"
+      const id = Identifier.ascending("session", given)
+      expect(id).toBe(given)
+    })
+
+    test("throws on mismatched prefix", () => {
+      expect(() => Identifier.ascending("session", "msg_abc123")).toThrow(
+        "ID msg_abc123 does not start with ses",
+      )
+    })
+  })
+
+  describe("descending", () => {
+    test("generates ID with correct prefix", () => {
+      const id = Identifier.descending("session")
+      expect(id).toStartWith("ses_")
+    })
+
+    test("generates monotonically decreasing IDs", () => {
+      const ids = Array.from({ length: 100 }, () => Identifier.descending("session"))
+      for (let i = 1; i < ids.length; i++) {
+        expect(ids[i] < ids[i - 1]).toBe(true)
+      }
+    })
+  })
+
+  describe("timestamp", () => {
+    test("relative comparison works between IDs created close together", () => {
+      // timestamp() is used in tool/truncation.ts for relative age comparisons.
+      // It only stores 48 bits, so absolute values overflow for modern timestamps,
+      // but relative comparisons between IDs in the same era are consistent.
+      const earlier = Identifier.create("tool", false, Date.now() - 60_000)
+      const later = Identifier.create("tool", false, Date.now())
+      expect(Identifier.timestamp(later)).toBeGreaterThan(Identifier.timestamp(earlier))
+    })
+
+    test("extracts consistent value from same ID", () => {
+      const id = Identifier.ascending("session")
+      const ts1 = Identifier.timestamp(id)
+      const ts2 = Identifier.timestamp(id)
+      expect(ts1).toBe(ts2)
+    })
+  })
+
+  describe("all prefixes", () => {
+    const prefixes = [
+      ["session", "ses_"],
+      ["message", "msg_"],
+      ["permission", "per_"],
+      ["question", "que_"],
+      ["user", "usr_"],
+      ["part", "prt_"],
+      ["pty", "pty_"],
+      ["tool", "tool_"],
+      ["workspace", "wrk_"],
+    ] as const
+
+    for (const [key, prefix] of prefixes) {
+      test(`${key} generates IDs starting with ${prefix}`, () => {
+        const id = Identifier.ascending(key as any)
+        expect(id).toStartWith(prefix)
+      })
+    }
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Adds the first test coverage for the `Identifier` module (`src/id/id.ts`), which is the core ID generation system used by every session, message, part, permission, and workspace in altimate-code. Previously had zero tests.

**1. `Identifier.ascending` and `Identifier.descending` — `src/id/id.ts`** (7 new tests)

This module generates monotonic, lexicographically-sortable IDs that power message ordering, session listing, and data integrity throughout the system. Zero tests existed. New coverage includes:
- Correct prefix generation for all 9 entity types (session, message, permission, question, user, part, pty, tool, workspace)
- Monotonic ascending ordering: 100 sequential IDs are strictly increasing (lexicographic)
- Monotonic descending ordering: 100 sequential IDs are strictly decreasing
- Given-ID pass-through returns the exact input when prefix matches
- Permissive prefix validation behavior is documented (any string starting with the 3-char prefix is accepted)
- Mismatched prefix throws descriptive error

**2. `Identifier.timestamp` — `src/id/id.ts`** (2 new tests)

The `timestamp()` function extracts creation time from ascending IDs, used in `tool/truncation.ts` for age-based cleanup. Testing revealed that **absolute timestamp extraction overflows** for modern timestamps (the 6-byte / 48-bit encoding can't hold `Date.now() * 0x1000`), but **relative comparisons between IDs created in the same era work correctly** — which is exactly how the codebase uses it. Tests document this behavior:
- Relative comparison: IDs created 60s apart have correctly ordered timestamps
- Idempotency: same ID always extracts the same timestamp value

### Discovery: 48-bit timestamp overflow

During testing, discovered that `Identifier.timestamp()` silently overflows for current-era timestamps. The encoding stores `ts * 0x1000` in 48 bits, but modern timestamps exceed 2^36 ms (~1972). This doesn't affect production because the only caller (`tool/truncation.ts`) uses it for relative age comparisons where both sides overflow identically. Filed as a known behavior, not a blocking bug.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage for core infrastructure

### How did you verify your code works?

```
bun test test/id/id.test.ts       # 18 pass, 0 fail, 215 expect() calls
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_012maTw3RYyvmA13VfxTeYpJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for identifier generation and validation functionality, ensuring reliability of ID operations across ascending, descending, and timestamp-based scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->