### PR TITLE
fix: ship discover-and-add-mcps as a builtin command

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -11,6 +11,7 @@ import PROMPT_FEEDBACK from "./template/feedback.txt"
 // altimate_change start — configure commands for external AI CLIs
 import PROMPT_CONFIGURE_CLAUDE from "./template/configure-claude.txt"
 import PROMPT_CONFIGURE_CODEX from "./template/configure-codex.txt"
+import PROMPT_DISCOVER_MCPS from "./template/discover-and-add-mcps.txt"
 // altimate_change end
 import { MCP } from "../mcp"
 import { Skill } from "../skill"
@@ -67,6 +68,7 @@ export namespace Command {
     // altimate_change start
     CONFIGURE_CLAUDE: "configure-claude",
     CONFIGURE_CODEX: "configure-codex",
+    DISCOVER_MCPS: "discover-and-add-mcps",
     // altimate_change end
   } as const
 
@@ -129,6 +131,15 @@ export namespace Command {
           return PROMPT_CONFIGURE_CODEX
         },
         hints: hints(PROMPT_CONFIGURE_CODEX),
+      },
+      [Default.DISCOVER_MCPS]: {
+        name: Default.DISCOVER_MCPS,
+        description: "discover MCP servers from external AI tool configs and add them",
+        source: "command",
+        get template() {
+          return PROMPT_DISCOVER_MCPS
+        },
+        hints: hints(PROMPT_DISCOVER_MCPS),
       },
       // altimate_change end
     }

--- a/packages/opencode/src/command/template/discover-and-add-mcps.txt
+++ b/packages/opencode/src/command/template/discover-and-add-mcps.txt
@@ -1,7 +1,3 @@
----
-description: "Discover MCP servers from external AI tool configs and add them permanently"
----
-
 Discover MCP servers configured in other AI tools (VS Code, Cursor, GitHub Copilot, Claude Code, Gemini CLI) and add them to the altimate-code config.
 
 ## Instructions


### PR DESCRIPTION
## Summary

- Toast suggests `/discover-and-add-mcps` but the command only existed as a project-level `.opencode/command/` file not shipped with the package. Register it as a hardcoded command with a `.txt` template (same pattern as `configure-claude`) so it ships with every install.

## Test plan

- [x] `bun turbo typecheck` — clean (pre-existing `tracing-viewer-e2e.test.ts` error on main, unrelated)
- [ ] Verify `/discover-and-add-mcps` resolves as a slash command in a fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "discover-and-add-mcps" command to help users discover and integrate additional Model Context Providers into their workspace.
* **Documentation**
  * Simplified the command's prompt/template content for clearer guidance when running the new command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->