### PR TITLE
test: command hints + skill formatting coverage

### DIFF
--- a/packages/opencode/test/command/hints.test.ts
+++ b/packages/opencode/test/command/hints.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "bun:test"
+import { Command } from "../../src/command/index"
+
+describe("Command.hints: template placeholder extraction", () => {
+  test("returns empty array for template with no placeholders", () => {
+    expect(Command.hints("Run the tests and report results")).toEqual([])
+    expect(Command.hints("")).toEqual([])
+  })
+
+  test("extracts numbered placeholders in sorted order", () => {
+    expect(Command.hints("Review $2 and compare with $1")).toEqual(["$1", "$2"])
+  })
+
+  test("deduplicates repeated placeholder occurrences", () => {
+    expect(Command.hints("Use $1 then use $1 again and $2")).toEqual(["$1", "$2"])
+  })
+
+  test("appends $ARGUMENTS when present", () => {
+    expect(Command.hints("Do something with $ARGUMENTS")).toEqual(["$ARGUMENTS"])
+  })
+
+  test("multi-digit placeholders sort lexicographically", () => {
+    // $10 sorts before $2 in lexicographic order — this is the actual behavior
+    // since the code uses [...new Set(numbered)].sort() which is string sort
+    const result = Command.hints("Map $1 to $2 and also $10")
+    expect(result).toEqual(["$1", "$10", "$2"])
+  })
+})

--- a/packages/opencode/test/skill/fmt.test.ts
+++ b/packages/opencode/test/skill/fmt.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from "bun:test"
+import { Skill } from "../../src/skill/skill"
+
+function skill(overrides: Partial<Skill.Info> = {}): Skill.Info {
+  return {
+    name: overrides.name ?? "test-skill",
+    description: overrides.description ?? "A test skill",
+    location: overrides.location ?? "/home/user/skills/test-skill/SKILL.md",
+    content: overrides.content ?? "# Test\nDo the thing.",
+  }
+}
+
+describe("Skill.fmt: skill list formatting", () => {
+  test("returns 'No skills' message for empty list", () => {
+    expect(Skill.fmt([], { verbose: false })).toBe("No skills are currently available.")
+    expect(Skill.fmt([], { verbose: true })).toBe("No skills are currently available.")
+  })
+
+  test("verbose mode returns XML with skill tags", () => {
+    const skills = [
+      skill({ name: "analyze", description: "Analyze code", location: "/path/to/analyze/SKILL.md" }),
+      skill({ name: "deploy", description: "Deploy app", location: "/path/to/deploy/SKILL.md" }),
+    ]
+    const output = Skill.fmt(skills, { verbose: true })
+    expect(output).toContain("<available_skills>")
+    expect(output).toContain("</available_skills>")
+    expect(output).toContain("<name>analyze</name>")
+    expect(output).toContain("<description>Analyze code</description>")
+    expect(output).toContain("<name>deploy</name>")
+    expect(output).toContain("<description>Deploy app</description>")
+    // File paths get converted to file:// URLs
+    expect(output).toContain("file:///path/to/analyze/SKILL.md")
+  })
+
+  test("non-verbose returns markdown with bullet points", () => {
+    const skills = [
+      skill({ name: "lint", description: "Lint the code" }),
+      skill({ name: "format", description: "Format files" }),
+    ]
+    const output = Skill.fmt(skills, { verbose: false })
+    expect(output).toContain("## Available Skills")
+    expect(output).toContain("- **lint**: Lint the code")
+    expect(output).toContain("- **format**: Format files")
+  })
+
+  test("verbose mode preserves builtin: protocol without file:// conversion", () => {
+    const skills = [
+      skill({ name: "builtin-skill", description: "Built in", location: "builtin:my-skill/SKILL.md" }),
+    ]
+    const output = Skill.fmt(skills, { verbose: true })
+    expect(output).toContain("<location>builtin:my-skill/SKILL.md</location>")
+    // Should NOT contain file:// for builtin: paths
+    expect(output).not.toContain("file://")
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Adds 9 new tests across 2 previously untested pure functions that power user-facing UI elements.

**1. `Command.hints()` — `src/command/index.ts`** (5 new tests)

This function extracts placeholder tokens (`$1`, `$2`, `$ARGUMENTS`) from command templates and feeds them to the TUI command dialog so users know what arguments to provide. Zero tests existed. New coverage includes:
- Empty template and no-placeholder cases return empty array
- Numbered placeholders are extracted and sorted (lexicographic order)
- Duplicate placeholders are deduplicated via `Set`
- `$ARGUMENTS` is appended independently of numbered placeholders
- Multi-digit placeholders (`$10`) sort lexicographically (`$1, $10, $2`) — documents the actual behavior so future refactors don't assume numeric ordering

**2. `Skill.fmt()` — `src/skill/skill.ts`** (4 new tests)

This function formats the skill listing shown in both the TUI skill browser and the system prompt injected into LLM context. Zero tests existed. New coverage includes:
- Empty skill list returns "No skills are currently available." for both modes
- Verbose mode produces correct XML structure with `<available_skills>`, `<skill>`, `<name>`, `<description>`, `<location>` tags
- Non-verbose mode produces markdown with `## Available Skills` header and `**name**: description` bullets
- `builtin:` protocol locations are preserved as-is (no `file://` conversion) — this is an altimate-specific change that protects embedded skill paths from being mangled by `pathToFileURL()`

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage from test-discovery rotation (Week 1: skills + tools)

### How did you verify your code works?

```
bun test test/command/hints.test.ts    # 5 pass, 6 expect() calls
bun test test/skill/fmt.test.ts        # 4 pass, 14 expect() calls
```

### Test quality review

Tests were reviewed by a critic agent before committing:
- **Approved (9):** All tests exercise distinct code paths with real user-facing risk
- **Rejected (2):** "Returns both numbered and $ARGUMENTS together" (composition of two other tests, no new path) and "Multiple skills are all listed" (no new branch vs. single-skill tests)
- **Revised/Skipped (2):** `Skill.available()` permission filtering was too integration-heavy for a unit test run and delegates to already-tested `PermissionNext.evaluate()`

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_011MEvdFUnKtEEi18HBQcJz5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for command hints functionality to validate placeholder extraction and handling.
  * Added test suites for skill formatting output across different display modes and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->