### PR TITLE
fix: slugify returns fallback for non-ASCII input instead of empty string

### DIFF
--- a/packages/opencode/src/altimate/tools/training-import.ts
+++ b/packages/opencode/src/altimate/tools/training-import.ts
@@ -223,10 +223,11 @@ function parseMarkdownSections(markdown: string): MarkdownSection[] {
 }
 
 function slugify(text: string): string {
-  return text
+  const slug = text
     .toLowerCase()
     .replace(/[^a-z0-9\s-]/g, "")
     .replace(/\s+/g, "-")
     .replace(/^-+|-+$/g, "")
     .slice(0, 64)
+  return slug || `entry-${Date.now()}`
 }

--- a/packages/opencode/test/altimate/training-import.test.ts
+++ b/packages/opencode/test/altimate/training-import.test.ts
@@ -274,6 +274,24 @@ describe("training_import: slugify edge cases", () => {
     // Slugified name should strip special chars and use hyphens
     expect(result.output).toContain("cte-best-practices-v20-updated")
   })
+
+  test("handles pure non-ASCII headings with fallback", async () => {
+    setupMocks({
+      fileContent: [
+        "## \u65E5\u672C\u8A9E\u30B9\u30BF\u30A4\u30EB\u30AC\u30A4\u30C9",
+        "Use consistent naming.",
+      ].join("\n"),
+    })
+
+    const tool = await TrainingImportTool.init()
+    const result = await tool.execute(
+      { file_path: "japanese.md", kind: "standard", scope: "project", dry_run: true, max_entries: 20 },
+      ctx,
+    )
+    expect(result.metadata.count).toBe(1)
+    // Non-ASCII heading should produce a fallback slug, not an empty string
+    expect(result.output).toContain("entry-")
+  })
 })
 
 describe("training_import: error handling", () => {


### PR DESCRIPTION
## Summary

`slugify()` in `training-import.ts` strips all non-ASCII characters, returning an empty string for non-English content like Japanese or Chinese headings. This breaks training import for those teams. Added a fallback that returns `entry-{timestamp}` when the slug would be empty.

## Test Plan

Added test case with pure Japanese heading. All 11 tests pass.

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] CHANGELOG updated (if user-facing)

Fixes #370