### PR TITLE
test: command — hints parser and altimate builtin registration

### DIFF
--- a/packages/opencode/test/command/command-resilience.test.ts
+++ b/packages/opencode/test/command/command-resilience.test.ts
@@ -90,6 +90,49 @@ describe("Command module", () => {
         expect(cmd).toBeUndefined()
       })
     })
+
+    test("altimate builtin commands are registered", async () => {
+      await withInstance(async () => {
+        const commands = await Command.list()
+        const names = commands.map((c) => c.name)
+        expect(names).toContain("configure-claude")
+        expect(names).toContain("configure-codex")
+        expect(names).toContain("discover-and-add-mcps")
+      })
+    })
+
+    test("discover-and-add-mcps has correct metadata", async () => {
+      await withInstance(async () => {
+        const cmd = await Command.get("discover-and-add-mcps")
+        expect(cmd).toBeDefined()
+        expect(cmd.source).toBe("command")
+        expect(cmd.description).toBe("discover MCP servers from external AI tool configs and add them")
+      })
+    })
+
+    test("discover-and-add-mcps template references mcp_discover tool", async () => {
+      await withInstance(async () => {
+        const cmd = await Command.get("discover-and-add-mcps")
+        const template = await cmd.template
+        expect(template).toContain("mcp_discover")
+      })
+    })
+
+    test("discover-and-add-mcps has $ARGUMENTS hint", async () => {
+      await withInstance(async () => {
+        const cmd = await Command.get("discover-and-add-mcps")
+        expect(cmd.hints).toContain("$ARGUMENTS")
+      })
+    })
+
+    test("configure-claude has correct metadata", async () => {
+      await withInstance(async () => {
+        const cmd = await Command.get("configure-claude")
+        expect(cmd).toBeDefined()
+        expect(cmd.source).toBe("command")
+        expect(cmd.description).toBe("configure /altimate command in Claude Code")
+      })
+    })
   })
 
   describe("user-defined commands from config", () => {

--- a/packages/opencode/test/command/hints.test.ts
+++ b/packages/opencode/test/command/hints.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect } from "bun:test"
+import { Command } from "../../src/command/index"
+
+describe("Command.hints: template placeholder extraction", () => {
+  test("extracts numbered placeholders in sorted order", () => {
+    expect(Command.hints("Do $2 then $1")).toEqual(["$1", "$2"])
+  })
+
+  test("deduplicates repeated placeholders", () => {
+    expect(Command.hints("Use $1 and $1 again")).toEqual(["$1"])
+  })
+
+  test("extracts $ARGUMENTS", () => {
+    expect(Command.hints("Run with $ARGUMENTS")).toEqual(["$ARGUMENTS"])
+  })
+
+  test("extracts both numbered and $ARGUMENTS", () => {
+    expect(Command.hints("Do $1 with $ARGUMENTS")).toEqual(["$1", "$ARGUMENTS"])
+  })
+
+  test("returns empty for templates with no placeholders", () => {
+    expect(Command.hints("Just a plain prompt")).toEqual([])
+  })
+
+  test("does not extract $ARGUMENTS as numbered", () => {
+    // $ARGUMENTS should only appear via the explicit check, not the numbered regex
+    expect(Command.hints("$ARGUMENTS only")).toEqual(["$ARGUMENTS"])
+  })
+
+  test("handles double-digit placeholders with lexicographic sort", () => {
+    // Note: sort is lexicographic, so $10 < $2. This documents current behavior.
+    expect(Command.hints("$10 then $2 then $1")).toEqual(["$1", "$10", "$2"])
+  })
+})


### PR DESCRIPTION
### What does this PR do?

**1. `Command.hints` — `src/command/index.ts:53-61`** (7 new tests)

This pure function extracts template placeholders (`$1`, `$2`, `$ARGUMENTS`) from command templates and is used by every command registration (default, user-defined, MCP, and skill commands) to determine what TUI hints to display. Zero tests existed. New coverage includes:

- Numbered placeholder extraction and sorted deduplication
- `$ARGUMENTS` detection (separate from numbered regex)
- Combined numbered + `$ARGUMENTS` templates
- Empty template (no placeholders)
- Lexicographic sort behavior for double-digit placeholders (`$10` sorts before `$2` — documents current behavior)

**2. Altimate builtin commands registration — `src/command/index.ts:63-144`** (5 new tests)

Commit 528af75 shipped `discover-and-add-mcps` as a builtin command to fix a phantom command issue where the toast suggestion sent users to a non-existent command. The three altimate-specific builtin commands (`configure-claude`, `configure-codex`, `discover-and-add-mcps`) had zero test coverage. New coverage includes:

- All three altimate commands are present in `Command.list()`
- `discover-and-add-mcps` has correct source, description, template referencing `mcp_discover`, and `$ARGUMENTS` hint
- `configure-claude` has correct source and exact description string

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage

### How did you verify your code works?

```
bun test test/command/hints.test.ts              # 7 pass
bun test test/command/command-resilience.test.ts  # 5 new + 9 existing (all require tmpdir git fixture)
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01LBpRnh2zYViskgkbqiTG8v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for new built-in commands (`configure-claude`, `configure-codex`, `discover-and-add-mcps`) and their configurations.
  * Enhanced test suite for command hint and placeholder extraction functionality to ensure correct behavior and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->