### PR TITLE
test: command hints + sql_analyze tool coverage

### DIFF
--- a/packages/opencode/test/altimate/tools/sql-analyze-tool.test.ts
+++ b/packages/opencode/test/altimate/tools/sql-analyze-tool.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for SqlAnalyzeTool.execute — success flag semantics and output formatting.
+ *
+ * The bug fix AI-5975 changed sql_analyze to report success:true when analysis
+ * completes (even when issues are found). Regression would cause ~4000 false
+ * "unknown error" telemetry events per day.
+ */
+import { describe, test, expect, spyOn, afterAll, beforeEach } from "bun:test"
+import * as Dispatcher from "../../../src/altimate/native/dispatcher"
+import { SqlAnalyzeTool } from "../../../src/altimate/tools/sql-analyze"
+import { SessionID, MessageID } from "../../../src/session/schema"
+
+beforeEach(() => {
+  process.env.ALTIMATE_TELEMETRY_DISABLED = "true"
+})
+
+const ctx = {
+  sessionID: SessionID.make("ses_test"),
+  messageID: MessageID.make("msg_test"),
+  callID: "call_test",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => {},
+  ask: async () => {},
+}
+
+let dispatcherSpy: ReturnType<typeof spyOn>
+
+function mockDispatcher(response: any) {
+  dispatcherSpy?.mockRestore()
+  dispatcherSpy = spyOn(Dispatcher, "call").mockImplementation(async () => response)
+}
+
+afterAll(() => {
+  dispatcherSpy?.mockRestore()
+  delete process.env.ALTIMATE_TELEMETRY_DISABLED
+})
+
+describe("SqlAnalyzeTool.execute: success semantics", () => {
+  test("issues found → success:true, no error in metadata", async () => {
+    mockDispatcher({
+      success: true,
+      issues: [
+        {
+          type: "lint",
+          severity: "warning",
+          message: "SELECT * detected",
+          recommendation: "List columns explicitly",
+          confidence: "high",
+        },
+      ],
+      issue_count: 1,
+      confidence: "high",
+      confidence_factors: ["lint"],
+    })
+
+    const tool = await SqlAnalyzeTool.init()
+    const result = await tool.execute(
+      { sql: "SELECT * FROM t", dialect: "snowflake" },
+      ctx as any,
+    )
+
+    expect(result.metadata.success).toBe(true)
+    expect(result.metadata.error).toBeUndefined()
+    expect(result.title).toContain("1 issue")
+    expect(result.title).not.toContain("PARSE ERROR")
+  })
+
+  test("zero issues → success:true, 'No anti-patterns' output", async () => {
+    mockDispatcher({
+      success: true,
+      issues: [],
+      issue_count: 0,
+      confidence: "high",
+      confidence_factors: [],
+    })
+
+    const tool = await SqlAnalyzeTool.init()
+    const result = await tool.execute(
+      { sql: "SELECT id FROM t", dialect: "snowflake" },
+      ctx as any,
+    )
+
+    expect(result.metadata.success).toBe(true)
+    expect(result.output).toContain("No anti-patterns")
+    expect(result.title).toContain("0 issues")
+  })
+
+  test("parse error → success:false, error in metadata and title", async () => {
+    mockDispatcher({
+      success: false,
+      issues: [],
+      issue_count: 0,
+      confidence: "low",
+      confidence_factors: [],
+      error: "syntax error near SELECT",
+    })
+
+    const tool = await SqlAnalyzeTool.init()
+    const result = await tool.execute(
+      { sql: "SELEC FROM", dialect: "snowflake" },
+      ctx as any,
+    )
+
+    expect(result.metadata.success).toBe(false)
+    expect(result.metadata.error).toBe("syntax error near SELECT")
+    expect(result.title).toContain("PARSE ERROR")
+  })
+
+  test("dispatcher throws → catch block returns ERROR title", async () => {
+    dispatcherSpy?.mockRestore()
+    dispatcherSpy = spyOn(Dispatcher, "call").mockRejectedValue(new Error("native crash"))
+
+    const tool = await SqlAnalyzeTool.init()
+    const result = await tool.execute(
+      { sql: "SELECT 1", dialect: "snowflake" },
+      ctx as any,
+    )
+
+    expect(result.title).toBe("Analyze: ERROR")
+    expect(result.metadata.success).toBe(false)
+    expect(result.metadata.error).toBe("native crash")
+    expect(result.output).toContain("Failed to analyze SQL: native crash")
+  })
+})
+
+describe("SqlAnalyzeTool.execute: formatAnalysis output", () => {
+  test("singular issue → '1 issue' not '1 issues'", async () => {
+    mockDispatcher({
+      success: true,
+      issues: [
+        {
+          type: "lint",
+          severity: "warning",
+          message: "test issue",
+          recommendation: "fix it",
+          confidence: "high",
+        },
+      ],
+      issue_count: 1,
+      confidence: "high",
+      confidence_factors: ["lint"],
+    })
+
+    const tool = await SqlAnalyzeTool.init()
+    const result = await tool.execute(
+      { sql: "x", dialect: "snowflake" },
+      ctx as any,
+    )
+
+    expect(result.output).toContain("Found 1 issue ")
+    expect(result.output).not.toContain("1 issues")
+  })
+
+  test("multiple issues with location, confidence, and factors", async () => {
+    mockDispatcher({
+      success: true,
+      issues: [
+        {
+          type: "lint",
+          severity: "warning",
+          message: "SELECT * used",
+          recommendation: "List columns",
+          confidence: "high",
+        },
+        {
+          type: "safety",
+          severity: "high",
+          message: "DROP TABLE detected",
+          recommendation: "Use caution",
+          location: "chars 0-5",
+          confidence: "medium",
+        },
+      ],
+      issue_count: 2,
+      confidence: "high",
+      confidence_factors: ["lint", "safety"],
+    })
+
+    const tool = await SqlAnalyzeTool.init()
+    const result = await tool.execute(
+      { sql: "x", dialect: "snowflake" },
+      ctx as any,
+    )
+
+    expect(result.output).toContain("2 issues")
+    expect(result.output).toContain("[WARNING] lint")
+    expect(result.output).toContain("[HIGH] safety [medium confidence]")
+    expect(result.output).toContain("chars 0-5")
+    expect(result.output).toContain("Note: lint; safety")
+  })
+})

--- a/packages/opencode/test/command/hints.test.ts
+++ b/packages/opencode/test/command/hints.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from "bun:test"
+import { Command } from "../../src/command/index"
+
+describe("Command.hints: template placeholder parsing", () => {
+  test("extracts numbered placeholders in order", () => {
+    expect(Command.hints("run $1 with $2")).toEqual(["$1", "$2"])
+  })
+
+  test("deduplicates repeated placeholders", () => {
+    expect(Command.hints("compare $1 to $1")).toEqual(["$1"])
+  })
+
+  test("sorts numbered placeholders lexicographically", () => {
+    // String sort: "$1" < "$2" < "$3"
+    expect(Command.hints("$3 then $1 then $2")).toEqual(["$1", "$2", "$3"])
+  })
+
+  test("$ARGUMENTS appears after numbered placeholders", () => {
+    expect(Command.hints("do $1 $ARGUMENTS")).toEqual(["$1", "$ARGUMENTS"])
+  })
+
+  test("returns only $ARGUMENTS when no numbered placeholders", () => {
+    expect(Command.hints("run $ARGUMENTS")).toEqual(["$ARGUMENTS"])
+  })
+
+  test("returns empty array when no placeholders", () => {
+    expect(Command.hints("static template with no args")).toEqual([])
+  })
+
+  test("multi-digit placeholders sort lexicographically, not numerically", () => {
+    // String sort puts "$10" before "$2" — this is the actual behavior.
+    // If a template uses $10+, the TUI hint order will be $1, $10, $2.
+    expect(Command.hints("$10 $2 $1")).toEqual(["$1", "$10", "$2"])
+  })
+
+  test("empty template returns empty array", () => {
+    expect(Command.hints("")).toEqual([])
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Adds 14 new tests across two previously untested modules, discovered via automated test-discovery reconnaissance.

**1. `Command.hints()` — `src/command/index.ts`** (8 new tests)

This pure function parses `$1`, `$2`, `$ARGUMENTS` placeholders from command templates to generate TUI argument hints for slash commands. Zero tests existed. If broken, users invoking `/review`, `/discover`, or custom commands would see wrong or missing argument hints. New coverage includes:

- Extraction of numbered placeholders in sorted order
- Deduplication of repeated placeholders (e.g., `$1` used twice)
- `$ARGUMENTS` ordering (always appended after numbered placeholders)
- Multi-digit placeholder lexicographic sorting (`$1, $10, $2` — documents the actual behavior)
- Empty template and no-placeholder edge cases

**2. `SqlAnalyzeTool.execute` — `src/altimate/tools/sql-analyze.ts`** (6 new tests)

The recent bug fix AI-5975 changed `sql_analyze` to report `success: true` when analysis completes (even when lint/semantic/safety issues are found). Previously, finding issues set `success: false`, causing ~4,000 false "unknown error" telemetry events per day. These regression tests lock down the corrected semantics:

- Issues found → `success: true`, no `error` in metadata
- Zero issues → `success: true`, "No anti-patterns" output
- Parse error → `success: false`, error surfaced in metadata and title
- Dispatcher crash → catch block returns "ERROR" title with error message
- Singular/plural formatting (`"1 issue"` vs `"2 issues"`)
- Issue location, confidence annotation, and confidence factors in output

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage

### How did you verify your code works?

```
bun test test/command/hints.test.ts                        # 8 pass
bun test test/altimate/tools/sql-analyze-tool.test.ts      # 6 pass
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01VV8nsL7MbNaJtwMDKQBzdz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for SQL analysis tool execution, covering success/error scenarios and output formatting.
  * Added test suite for command placeholder parsing and ordering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->