### PR TITLE
fix: add missing altimate_change marker for Marker Guard CI

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -140,7 +140,9 @@ let cli = yargs(hideBin(process.argv))
     // altimate_change start - db marker name
     const marker = path.join(Global.Path.data, "altimate-code.db")
     // altimate_change end
+    // altimate_change start — check: skip DB migration for stateless check command
     if (!isStatelessCommand && !(await Filesystem.exists(marker))) {
+    // altimate_change end
       const tty = process.stderr.isTTY
       process.stderr.write("Performing one time database migration, may take a few minutes..." + EOL)
       const width = 36


### PR DESCRIPTION
### What does this PR do?

Adds a missing `altimate_change` marker around the `isStatelessCommand` guard condition in `index.ts`. This line modifies an upstream-shared `if` condition and needs a marker to pass Marker Guard CI.

### Type of change
- [x] Bug fix

### Issue for this PR

Closes #454

### How did you verify your code works?

- Marker Guard CI passes on PR branch
- Typecheck passes

### Checklist
- [x] Code follows project conventions
- [x] Uses altimate_change markers for upstream-shared files

🤖 Generated with [Claude Code](https://claude.com/claude-code)