### PR TITLE
test: fingerprint — file-based project detection rules

### DIFF
--- a/packages/opencode/test/altimate/fingerprint-detect.test.ts
+++ b/packages/opencode/test/altimate/fingerprint-detect.test.ts
@@ -1,0 +1,110 @@
+import { describe, test, expect, beforeEach } from "bun:test"
+import { Fingerprint } from "../../src/altimate/fingerprint"
+import { tmpdir } from "../fixture/fixture"
+import * as fs from "fs/promises"
+import path from "path"
+
+beforeEach(() => {
+  Fingerprint.reset()
+})
+
+describe("Fingerprint.detect: file-based project detection", () => {
+  test("detects dbt project from dbt_project.yml", async () => {
+    await using tmp = await tmpdir()
+    await fs.writeFile(path.join(tmp.path, "dbt_project.yml"), "name: my_project\nversion: 1.0.0\n")
+    const result = await Fingerprint.detect(tmp.path)
+    expect(result.tags).toContain("dbt")
+    expect(result.tags).toContain("data-engineering")
+  })
+
+  test("detects adapter type from profiles.yml", async () => {
+    await using tmp = await tmpdir()
+    await fs.writeFile(
+      path.join(tmp.path, "profiles.yml"),
+      "my_profile:\n  target: dev\n  outputs:\n    dev:\n      type: snowflake\n",
+    )
+    const result = await Fingerprint.detect(tmp.path)
+    expect(result.tags).toContain("snowflake")
+  })
+
+  test("detects sql from .sqlfluff file", async () => {
+    await using tmp = await tmpdir()
+    await fs.writeFile(path.join(tmp.path, ".sqlfluff"), "[sqlfluff]\ndialect = bigquery\n")
+    const result = await Fingerprint.detect(tmp.path)
+    expect(result.tags).toContain("sql")
+  })
+
+  test("detects sql from .sql files when no .sqlfluff", async () => {
+    await using tmp = await tmpdir()
+    await fs.writeFile(path.join(tmp.path, "query.sql"), "SELECT 1")
+    const result = await Fingerprint.detect(tmp.path)
+    expect(result.tags).toContain("sql")
+  })
+
+  test("detects airflow from airflow.cfg", async () => {
+    await using tmp = await tmpdir()
+    await fs.writeFile(path.join(tmp.path, "airflow.cfg"), "[core]\nexecutor = LocalExecutor\n")
+    const result = await Fingerprint.detect(tmp.path)
+    expect(result.tags).toContain("airflow")
+  })
+
+  test("detects airflow from dags directory", async () => {
+    await using tmp = await tmpdir()
+    await fs.mkdir(path.join(tmp.path, "dags"))
+    const result = await Fingerprint.detect(tmp.path)
+    expect(result.tags).toContain("airflow")
+  })
+
+  test("detects databricks from databricks.yml", async () => {
+    await using tmp = await tmpdir()
+    await fs.writeFile(path.join(tmp.path, "databricks.yml"), "bundle:\n  name: my_bundle\n")
+    const result = await Fingerprint.detect(tmp.path)
+    expect(result.tags).toContain("databricks")
+  })
+
+  test("returns empty tags for vanilla project", async () => {
+    await using tmp = await tmpdir()
+    const result = await Fingerprint.detect(tmp.path)
+    expect(result.tags).toEqual([])
+  })
+
+  test("caches result for same cwd", async () => {
+    await using tmp = await tmpdir()
+    await fs.writeFile(path.join(tmp.path, "dbt_project.yml"), "name: test\n")
+    const r1 = await Fingerprint.detect(tmp.path)
+    // Remove the file — cached result should still have dbt
+    await fs.rm(path.join(tmp.path, "dbt_project.yml"))
+    const r2 = await Fingerprint.detect(tmp.path)
+    expect(r1).toBe(r2) // Same reference (cached)
+  })
+
+  test("deduplicates tags from cwd and root scanning same markers", async () => {
+    // When cwd !== root, both directories are scanned. If both contain
+    // dbt_project.yml, the "dbt" and "data-engineering" tags should appear
+    // only once each (the source deduplicates via Set).
+    await using tmp = await tmpdir()
+    const subdir = path.join(tmp.path, "models")
+    await fs.mkdir(subdir)
+    // Place dbt_project.yml in BOTH root and subdir
+    await fs.writeFile(path.join(tmp.path, "dbt_project.yml"), "name: root\n")
+    await fs.writeFile(path.join(subdir, "dbt_project.yml"), "name: sub\n")
+    const result = await Fingerprint.detect(subdir, tmp.path)
+    const dbtCount = result.tags.filter((t) => t === "dbt").length
+    expect(dbtCount).toBe(1)
+    const deCount = result.tags.filter((t) => t === "data-engineering").length
+    expect(deCount).toBe(1)
+  })
+
+  test("scans both cwd and root when different", async () => {
+    await using tmp = await tmpdir()
+    const subdir = path.join(tmp.path, "models")
+    await fs.mkdir(subdir)
+    // dbt_project.yml only in root
+    await fs.writeFile(path.join(tmp.path, "dbt_project.yml"), "name: test\n")
+    // .sql file only in subdir
+    await fs.writeFile(path.join(subdir, "model.sql"), "SELECT 1")
+    const result = await Fingerprint.detect(subdir, tmp.path)
+    expect(result.tags).toContain("dbt")
+    expect(result.tags).toContain("sql")
+  })
+})


### PR DESCRIPTION
### What does this PR do?

**1. `Fingerprint.detect` — `src/altimate/fingerprint/index.ts`** (11 new tests)

This module detects project type by scanning for well-known files (`dbt_project.yml`, `profiles.yml`, `.sqlfluff`, `airflow.cfg`, `databricks.yml`, `dags/` directory, `*.sql` files). It feeds into `selectSkillsWithLLM()` and `SystemPrompt.skills()` — if fingerprinting is wrong, users get irrelevant skills in their session.

The existing `fingerprint.test.ts` only smoke-tested against the real project root directory. **None of its tests verified that a specific file produces a specific tag.** A regression in any detection rule (e.g., changing the `profiles.yml` regex, renaming a marker file check) would pass all existing tests silently.

New coverage includes:
- **Individual marker detection**: each of the 7 detection rules verified in isolation (dbt, snowflake adapter from profiles.yml, sqlfluff, raw .sql files, airflow.cfg, dags directory, databricks.yml)
- **Empty project baseline**: vanilla directory returns zero tags
- **Cache correctness**: same `cwd` returns cached reference; file removal after caching doesn't change result
- **Tag deduplication across directories**: when both `cwd` and `root` contain the same marker, tags appear only once (exercises the `Set` dedup logic)
- **Two-directory scanning**: `detect(subdir, root)` picks up markers from both directories (real scenario: user opens a subdirectory of a dbt monorepo)

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage for untested project detection logic

### How did you verify your code works?

```
bun test test/altimate/fingerprint-detect.test.ts   # 11 pass
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_015TPuQ2dEJD2CYoHF3LTQzD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for project detection functionality to verify correct identification and caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->