### PR TITLE
test: bus events + dbt profiles parser — registry payloads and env_var defaults

### DIFF
--- a/packages/opencode/test/altimate/connections.test.ts
+++ b/packages/opencode/test/altimate/connections.test.ts
@@ -261,6 +261,124 @@ snow:
       fs.rmSync(tmpDir, { recursive: true })
     }
   })
+
+  // altimate_change start — tests for untested dbt profiles parser edge cases
+  test("resolves env_var with default fallback when env var is missing", async () => {
+    const fs = await import("fs")
+    const os = await import("os")
+    const path = await import("path")
+
+    // Ensure the env var does NOT exist
+    delete process.env.__TEST_DBT_MISSING_VAR_12345
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dbt-test-"))
+    const profilesPath = path.join(tmpDir, "profiles.yml")
+
+    fs.writeFileSync(
+      profilesPath,
+      `
+myproject:
+  outputs:
+    dev:
+      type: postgres
+      host: "{{ env_var('__TEST_DBT_MISSING_VAR_12345', 'localhost') }}"
+      port: 5432
+      user: "{{ env_var('__TEST_DBT_MISSING_USER_12345', 'default_user') }}"
+      password: secret
+      dbname: mydb
+`,
+    )
+
+    try {
+      const connections = await parseDbtProfiles(profilesPath)
+      expect(connections).toHaveLength(1)
+      expect(connections[0].config.host).toBe("localhost")
+      expect(connections[0].config.user).toBe("default_user")
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true })
+    }
+  })
+
+  test("skips 'config' top-level key (dbt global settings)", async () => {
+    const fs = await import("fs")
+    const os = await import("os")
+    const path = await import("path")
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dbt-test-"))
+    const profilesPath = path.join(tmpDir, "profiles.yml")
+
+    fs.writeFileSync(
+      profilesPath,
+      `
+config:
+  send_anonymous_usage_stats: false
+  use_colors: true
+
+real_project:
+  outputs:
+    dev:
+      type: postgres
+      host: localhost
+      dbname: analytics
+`,
+    )
+
+    try {
+      const connections = await parseDbtProfiles(profilesPath)
+      expect(connections).toHaveLength(1)
+      expect(connections[0].name).toBe("real_project_dev")
+      // The 'config' key should not appear as a connection
+      expect(connections.find((c) => c.name.startsWith("config"))).toBeUndefined()
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true })
+    }
+  })
+
+  test("handles multiple profiles with multiple outputs", async () => {
+    const fs = await import("fs")
+    const os = await import("os")
+    const path = await import("path")
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dbt-test-"))
+    const profilesPath = path.join(tmpDir, "profiles.yml")
+
+    fs.writeFileSync(
+      profilesPath,
+      `
+warehouse_a:
+  outputs:
+    dev:
+      type: postgres
+      host: localhost
+      dbname: dev_db
+    prod:
+      type: postgres
+      host: prod.example.com
+      dbname: prod_db
+
+warehouse_b:
+  outputs:
+    staging:
+      type: snowflake
+      account: abc123
+      user: admin
+      password: pw
+      database: STAGING
+      warehouse: COMPUTE_WH
+      schema: PUBLIC
+`,
+    )
+
+    try {
+      const connections = await parseDbtProfiles(profilesPath)
+      expect(connections).toHaveLength(3)
+      const names = connections.map((c) => c.name).sort()
+      expect(names).toEqual(["warehouse_a_dev", "warehouse_a_prod", "warehouse_b_staging"])
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true })
+    }
+  })
+  // altimate_change end
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/opencode/test/bus/bus-event.test.ts
+++ b/packages/opencode/test/bus/bus-event.test.ts
@@ -1,0 +1,76 @@
+// altimate_change start — tests for BusEvent registry and payloads
+import { describe, test, expect } from "bun:test"
+import z from "zod"
+import { BusEvent } from "../../src/bus/bus-event"
+
+// Use unique type strings prefixed with __test_ to avoid colliding with
+// production events already registered in the global BusEvent registry.
+
+describe("BusEvent.define", () => {
+  test("returns an object with type string and zod schema", () => {
+    const schema = z.object({ count: z.number() })
+    const def = BusEvent.define("__test_define_shape", schema)
+
+    expect(def.type).toBe("__test_define_shape")
+    expect(def.properties).toBe(schema)
+  })
+})
+
+describe("BusEvent.payloads", () => {
+  // Register a known test event before payloads() tests
+  const testSchema = z.object({ value: z.string() })
+  BusEvent.define("__test_payloads_registered", testSchema)
+
+  test("includes a registered event in the discriminated union", () => {
+    const union = BusEvent.payloads()
+    const result = union.safeParse({
+      type: "__test_payloads_registered",
+      properties: { value: "hello" },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test("rejects event with unregistered type", () => {
+    const union = BusEvent.payloads()
+    const result = union.safeParse({
+      type: "__test_payloads_NONEXISTENT_999",
+      properties: {},
+    })
+    expect(result.success).toBe(false)
+  })
+
+  test("rejects event with wrong properties shape", () => {
+    const union = BusEvent.payloads()
+    const result = union.safeParse({
+      type: "__test_payloads_registered",
+      properties: { value: 42 }, // should be string, not number
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe("BusEvent.define duplicate handling", () => {
+  test("last define() wins when same type is registered twice", () => {
+    // First definition: requires { a: string }
+    BusEvent.define("__test_duplicate_overwrite", z.object({ a: z.string() }))
+    // Second definition: requires { b: number }
+    BusEvent.define("__test_duplicate_overwrite", z.object({ b: z.number() }))
+
+    const union = BusEvent.payloads()
+
+    // Payload matching second schema should succeed
+    const valid = union.safeParse({
+      type: "__test_duplicate_overwrite",
+      properties: { b: 42 },
+    })
+    expect(valid.success).toBe(true)
+
+    // Payload matching ONLY first schema (missing b) should fail
+    const invalid = union.safeParse({
+      type: "__test_duplicate_overwrite",
+      properties: { a: "hello" },
+    })
+    expect(invalid.success).toBe(false)
+  })
+})
+// altimate_change end


### PR DESCRIPTION
### What does this PR do?

Adds 8 new tests covering two previously untested areas discovered during proactive test discovery.

**1. `BusEvent.define` + `BusEvent.payloads` — `src/bus/bus-event.ts`** (5 new tests)

This module is the core pub/sub event registry used by 20+ modules across the codebase (sessions, files, permissions, VCS, questions, LSP, server). `BusEvent.define()` registers event types in a global registry, and `BusEvent.payloads()` builds a Zod discriminated union used in the server's SSE/HTTP API schema. **Zero tests existed.** New coverage includes:

- `define()` contract: returns `{ type, properties }` shape correctly
- Registry integration: a defined event appears in `payloads()` discriminated union
- Schema validation: `payloads()` rejects events with unregistered types
- Schema validation: `payloads()` rejects events with wrong property shapes
- Duplicate handling: last `define()` call wins when same type is registered twice (documents Map.set behavior)

Tests use `__test_` prefixed type strings to avoid colliding with production events in the shared registry.

**2. `parseDbtProfiles` — `src/altimate/native/connections/dbt-profiles.ts`** (3 new tests)

The dbt profiles parser converts `~/.dbt/profiles.yml` into warehouse connections. Existing tests covered basic parsing, env_var resolution, and adapter mapping, but missed three real-world edge cases:

- **`env_var` default fallback**: dbt users commonly write `{{ env_var('DB_HOST', 'localhost') }}` with a default value. The regex at line 58 captures the optional second argument, but this path was never tested. If the capture group broke, users would silently get empty strings instead of their configured defaults.
- **`config` key skip**: Real dbt `profiles.yml` files include a top-level `config:` key for global settings (e.g., `send_anonymous_usage_stats: false`). The parser has a guard on line 148 to skip it, but this was untested. Without it, `config` could be parsed as a phantom connection.
- **Multiple profiles with multiple outputs**: Validates the `${profileName}_${outputName}` naming convention with >1 profile, ensuring downstream code that depends on connection identity works correctly.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage

### How did you verify your code works?

```
bun test test/bus/bus-event.test.ts          # 5 pass
bun test test/altimate/connections.test.ts   # 42 pass (39 existing + 3 new)
```

Marker check passes: `bun run script/upstream/analyze.ts --markers --base main --strict`

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01XZqioFNF2eYPkr9X6USeth