### PR TITLE
test: MongoDB config normalization aliases — 13 new tests

### DIFF
--- a/packages/opencode/test/altimate/driver-normalize.test.ts
+++ b/packages/opencode/test/altimate/driver-normalize.test.ts
@@ -663,3 +663,133 @@ describe("normalizeConfig — Snowflake private_key edge cases", () => {
     expect(result.private_key_path).toBeUndefined()
   })
 })
+
+// ---------------------------------------------------------------------------
+// normalizeConfig — MongoDB aliases
+// ---------------------------------------------------------------------------
+
+describe("normalizeConfig — MongoDB", () => {
+  test("canonical mongodb config passes through unchanged", () => {
+    const config = {
+      type: "mongodb",
+      host: "localhost",
+      port: 27017,
+      database: "mydb",
+      user: "admin",
+      password: "secret",
+    }
+    expect(normalizeConfig(config)).toEqual(config)
+  })
+
+  test("connectionString → connection_string", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      connectionString: "mongodb://admin:secret@localhost:27017/mydb",
+    })
+    expect(result.connection_string).toBe("mongodb://admin:secret@localhost:27017/mydb")
+    expect(result.connectionString).toBeUndefined()
+  })
+
+  test("uri → connection_string", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      uri: "mongodb+srv://admin:secret@cluster0.example.net/mydb",
+    })
+    expect(result.connection_string).toBe("mongodb+srv://admin:secret@cluster0.example.net/mydb")
+    expect(result.uri).toBeUndefined()
+  })
+
+  test("url → connection_string", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      url: "mongodb://localhost:27017/mydb",
+    })
+    expect(result.connection_string).toBe("mongodb://localhost:27017/mydb")
+    expect(result.url).toBeUndefined()
+  })
+
+  test("connection_string takes precedence over uri alias", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      connection_string: "mongodb://correct:27017/db",
+      uri: "mongodb://wrong:27017/db",
+    })
+    expect(result.connection_string).toBe("mongodb://correct:27017/db")
+    expect(result.uri).toBeUndefined()
+  })
+
+  test("authSource → auth_source", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      authSource: "admin",
+    })
+    expect(result.auth_source).toBe("admin")
+    expect(result.authSource).toBeUndefined()
+  })
+
+  test("replicaSet → replica_set", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      replicaSet: "rs0",
+    })
+    expect(result.replica_set).toBe("rs0")
+    expect(result.replicaSet).toBeUndefined()
+  })
+
+  test("directConnection → direct_connection", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      directConnection: true,
+    })
+    expect(result.direct_connection).toBe(true)
+    expect(result.directConnection).toBeUndefined()
+  })
+
+  test("connectTimeoutMS → connect_timeout", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      connectTimeoutMS: 5000,
+    })
+    expect(result.connect_timeout).toBe(5000)
+    expect(result.connectTimeoutMS).toBeUndefined()
+  })
+
+  test("serverSelectionTimeoutMS → server_selection_timeout", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      serverSelectionTimeoutMS: 10000,
+    })
+    expect(result.server_selection_timeout).toBe(10000)
+    expect(result.serverSelectionTimeoutMS).toBeUndefined()
+  })
+
+  test("username → user for mongodb", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      username: "admin",
+    })
+    expect(result.user).toBe("admin")
+    expect(result.username).toBeUndefined()
+  })
+
+  test("dbname → database for mongodb", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      dbname: "mydb",
+    })
+    expect(result.database).toBe("mydb")
+    expect(result.dbname).toBeUndefined()
+  })
+
+  test("mongo type alias works", () => {
+    const result = normalizeConfig({
+      type: "mongo",
+      username: "admin",
+      connectionString: "mongodb://localhost:27017/mydb",
+      authSource: "admin",
+    })
+    expect(result.user).toBe("admin")
+    expect(result.connection_string).toBe("mongodb://localhost:27017/mydb")
+    expect(result.auth_source).toBe("admin")
+  })
+})


### PR DESCRIPTION
### What does this PR do?

**1. `normalizeConfig` — MongoDB aliases — `packages/drivers/src/normalize.ts`** (13 new tests)

MongoDB was added as the 11th supported driver in PR #482 (commit `abcaa1d`), but the config normalization alias map (`MONGODB_ALIASES`) had **zero unit test coverage**. Every other driver (Snowflake, BigQuery, Databricks, Postgres, Redshift, MySQL, SQL Server, Oracle, DuckDB, SQLite) already had dedicated normalization tests in `driver-normalize.test.ts`.

**Why this matters:** Users providing MongoDB configs via dbt profiles, LLM-generated configs, or SDK conventions use camelCase keys (`connectionString`, `authSource`, `replicaSet`, `directConnection`). Without normalization, these keys silently pass through unresolved, causing connection failures with no clear error message. The `mongo` type alias (shorthand for `mongodb`) was also untested.

**Specific scenarios covered:**
- **Connection string aliases:** `connectionString`, `uri`, `url` → `connection_string` (3 tests)
- **First-value-wins precedence:** canonical `connection_string` takes priority over `uri` alias (1 test)
- **MongoDB-specific aliases:** `authSource` → `auth_source`, `replicaSet` → `replica_set`, `directConnection` → `direct_connection`, `connectTimeoutMS` → `connect_timeout`, `serverSelectionTimeoutMS` → `server_selection_timeout` (5 tests)
- **Common aliases for MongoDB:** `username` → `user`, `dbname` → `database` (2 tests)
- **Type alias:** `mongo` resolves to the same alias map as `mongodb` (1 test)
- **Identity:** canonical MongoDB config passes through unchanged (1 test)

**Test quality:** All tests are pure-function unit tests with no network, timing, or filesystem dependencies. Reviewed and approved by a critic agent before committing.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage for newly added MongoDB driver

### How did you verify your code works?

```
bun test test/altimate/driver-normalize.test.ts    # 91 pass (78 existing + 13 new)
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_019D8HyMGHH3Pf43PddTqUw5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added extensive test coverage for MongoDB configuration normalization, validating proper handling of connection parameters (connection strings and URIs), authentication fields, replica set settings, timeout configurations, and connection modes to ensure consistent configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->