### PR TITLE
test: warehouse connections — env-var loading and MongoDB auth detection

### DIFF
--- a/packages/opencode/test/altimate/connections.test.ts
+++ b/packages/opencode/test/altimate/connections.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, beforeEach, beforeAll, afterAll } from "bun:test"
+import { describe, expect, test, beforeEach, afterEach, beforeAll, afterAll } from "bun:test"
 import * as Dispatcher from "../../src/altimate/native/dispatcher"
 
 // Disable telemetry via env var instead of mock.module
@@ -71,6 +71,70 @@ describe("ConnectionRegistry", () => {
     Registry.setConfigs({ b: { type: "mysql" }, c: { type: "duckdb" } })
     expect(Registry.list().warehouses).toHaveLength(2)
     expect(Registry.getConfig("a")).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loadFromEnv — env-var-based connection config loading
+// ---------------------------------------------------------------------------
+
+describe("loadFromEnv via Registry.load()", () => {
+  const saved: Record<string, string | undefined> = {}
+
+  function setEnv(key: string, value: string) {
+    saved[key] = process.env[key]
+    process.env[key] = value
+  }
+
+  beforeEach(() => {
+    Registry.reset()
+  })
+
+  afterEach(() => {
+    for (const [key, orig] of Object.entries(saved)) {
+      if (orig === undefined) delete process.env[key]
+      else process.env[key] = orig
+    }
+    // Clear saved state for next test
+    for (const key of Object.keys(saved)) delete saved[key]
+  })
+
+  test("parses valid JSON from ALTIMATE_CODE_CONN_* env vars", () => {
+    setEnv("ALTIMATE_CODE_CONN_MYDB", JSON.stringify({ type: "postgres", host: "localhost", port: 5432 }))
+    Registry.load()
+    const config = Registry.getConfig("mydb")
+    expect(config).toBeDefined()
+    expect(config?.type).toBe("postgres")
+    expect(config?.host).toBe("localhost")
+  })
+
+  test("lowercases connection name from env var suffix", () => {
+    setEnv("ALTIMATE_CODE_CONN_PROD_DB", JSON.stringify({ type: "snowflake", account: "abc" }))
+    Registry.load()
+    expect(Registry.getConfig("prod_db")).toBeDefined()
+    expect(Registry.getConfig("PROD_DB")).toBeUndefined()
+  })
+
+  test("ignores env var with invalid JSON", () => {
+    setEnv("ALTIMATE_CODE_CONN_BAD", "not-valid-json{")
+    Registry.load()
+    expect(Registry.getConfig("bad")).toBeUndefined()
+  })
+
+  test("ignores env var config without type field", () => {
+    setEnv("ALTIMATE_CODE_CONN_NOTYPE", JSON.stringify({ host: "localhost", port: 5432 }))
+    Registry.load()
+    expect(Registry.getConfig("notype")).toBeUndefined()
+  })
+
+  test("ignores non-object JSON values (string, number, array)", () => {
+    setEnv("ALTIMATE_CODE_CONN_STR", JSON.stringify("just a string"))
+    setEnv("ALTIMATE_CODE_CONN_NUM", JSON.stringify(42))
+    setEnv("ALTIMATE_CODE_CONN_ARR", JSON.stringify([1, 2, 3]))
+    Registry.load()
+    expect(Registry.getConfig("str")).toBeUndefined()
+    expect(Registry.getConfig("num")).toBeUndefined()
+    expect(Registry.getConfig("arr")).toBeUndefined()
   })
 })
 

--- a/packages/opencode/test/altimate/warehouse-telemetry.test.ts
+++ b/packages/opencode/test/altimate/warehouse-telemetry.test.ts
@@ -169,6 +169,23 @@ describe("warehouse telemetry: detectAuthMethod", () => {
     expect(connectEvent).toBeDefined()
     expect(connectEvent.auth_method).toBe("unknown")
   })
+
+  // MongoDB-specific auth detection (added with MongoDB driver support #482)
+  test("detects connection_string auth for mongodb without password", () => {
+    expect(Registry.detectAuthMethod({ type: "mongodb", host: "localhost" } as any)).toBe("connection_string")
+  })
+
+  test("detects password auth for mongodb with password", () => {
+    expect(Registry.detectAuthMethod({ type: "mongodb", host: "localhost", password: "secret" } as any)).toBe("password")
+  })
+
+  test("detects connection_string auth for mongo alias without password", () => {
+    expect(Registry.detectAuthMethod({ type: "mongo", host: "localhost" } as any)).toBe("connection_string")
+  })
+
+  test("prefers explicit connection_string field over mongodb type fallback", () => {
+    expect(Registry.detectAuthMethod({ type: "mongodb", connection_string: "mongodb://localhost/test" } as any)).toBe("connection_string")
+  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### What does this PR do?

**1. `loadFromEnv` via `Registry.load()` — `src/altimate/native/connections/registry.ts`** (5 new tests)

The `loadFromEnv` function parses `ALTIMATE_CODE_CONN_*` environment variables to configure database connections. This is the primary connection method for CI/CD pipelines, Docker containers, and Codespaces users. Zero unit tests existed for this code path — a parsing regression would silently break all env-var-based connections with no test signal.

New coverage includes:
- Valid JSON parsing from `ALTIMATE_CODE_CONN_*` env vars
- Connection name lowercasing from env var suffix (`PROD_DB` → `prod_db`)
- Graceful handling of invalid JSON (no crash, connection silently skipped)
- Rejection of configs missing the required `type` field
- Rejection of non-object JSON values (strings, numbers, arrays)

**2. `detectAuthMethod` for MongoDB — `src/altimate/native/connections/registry.ts`** (4 new tests)

MongoDB driver support was added in #482. The `detectAuthMethod` function has a MongoDB-specific branch (line 229) that returns `"connection_string"` when no password is present, or `"password"` when one is. This branch was completely untested. Auth method detection feeds into telemetry and provider UI — incorrect detection would cause misleading warehouse analytics.

New coverage includes:
- MongoDB without password → `connection_string` auth
- MongoDB with password → `password` auth
- `mongo` type alias (shorthand) without password → `connection_string`
- Explicit `connection_string` field takes precedence over MongoDB type fallback

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage from automated test discovery

### How did you verify your code works?

```
bun test test/altimate/connections.test.ts          # 44 pass (39 existing + 5 new)
bun test test/altimate/warehouse-telemetry.test.ts  # 45 pass (41 existing + 4 new)
```

Marker check: `bun run script/upstream/analyze.ts --markers --base main --strict` — passed (no upstream-shared files modified).

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_015egWH6W5HdaVuMysv9tFHq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for environment variable-based connection loading and validation.
  * Added unit tests for MongoDB authentication detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->