### PR TITLE
test: MongoDB normalization + detectAuthMethod coverage

### DIFF
--- a/packages/opencode/test/altimate/connections.test.ts
+++ b/packages/opencode/test/altimate/connections.test.ts
@@ -10,6 +10,7 @@ afterAll(() => { delete process.env.ALTIMATE_TELEMETRY_DISABLED })
 // ---------------------------------------------------------------------------
 
 import * as Registry from "../../src/altimate/native/connections/registry"
+import { detectAuthMethod } from "../../src/altimate/native/connections/registry"
 import * as CredentialStore from "../../src/altimate/native/connections/credential-store"
 import { parseDbtProfiles } from "../../src/altimate/native/connections/dbt-profiles"
 import { discoverContainers } from "../../src/altimate/native/connections/docker-discovery"
@@ -134,6 +135,69 @@ describe("CredentialStore", () => {
     expect(sanitized.token).toBeUndefined()
     expect(sanitized.oauth_client_secret).toBeUndefined()
     expect(sanitized.authenticator).toBe("oauth")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// detectAuthMethod
+// ---------------------------------------------------------------------------
+
+describe("detectAuthMethod", () => {
+  test("returns 'connection_string' for config with connection_string", () => {
+    expect(detectAuthMethod({ type: "postgres", connection_string: "postgresql://..." } as any)).toBe("connection_string")
+  })
+
+  test("returns 'key_pair' for Snowflake private_key_path", () => {
+    expect(detectAuthMethod({ type: "snowflake", private_key_path: "/path/to/key.p8" } as any)).toBe("key_pair")
+  })
+
+  test("returns 'key_pair' for camelCase privateKeyPath", () => {
+    expect(detectAuthMethod({ type: "snowflake", privateKeyPath: "/path/to/key.p8" } as any)).toBe("key_pair")
+  })
+
+  test("returns 'sso' for Snowflake externalbrowser", () => {
+    expect(detectAuthMethod({ type: "snowflake", authenticator: "EXTERNALBROWSER" } as any)).toBe("sso")
+  })
+
+  test("returns 'sso' for Okta URL authenticator", () => {
+    expect(detectAuthMethod({ type: "snowflake", authenticator: "https://myorg.okta.com" } as any)).toBe("sso")
+  })
+
+  test("returns 'oauth' for OAuth authenticator", () => {
+    expect(detectAuthMethod({ type: "snowflake", authenticator: "OAUTH" } as any)).toBe("oauth")
+  })
+
+  test("returns 'token' for access_token", () => {
+    expect(detectAuthMethod({ type: "databricks", access_token: "dapi..." } as any)).toBe("token")
+  })
+
+  test("returns 'password' for config with password", () => {
+    expect(detectAuthMethod({ type: "postgres", password: "secret" } as any)).toBe("password")
+  })
+
+  test("returns 'file' for duckdb", () => {
+    expect(detectAuthMethod({ type: "duckdb", path: "/data/my.db" } as any)).toBe("file")
+  })
+
+  test("returns 'file' for sqlite", () => {
+    expect(detectAuthMethod({ type: "sqlite", path: "/data/my.sqlite" } as any)).toBe("file")
+  })
+
+  test("returns 'connection_string' for mongodb without password", () => {
+    expect(detectAuthMethod({ type: "mongodb" } as any)).toBe("connection_string")
+  })
+
+  test("returns 'password' for mongo with password", () => {
+    expect(detectAuthMethod({ type: "mongo", password: "secret" } as any)).toBe("password")
+  })
+
+  test("returns 'unknown' for null/undefined", () => {
+    expect(detectAuthMethod(null)).toBe("unknown")
+    expect(detectAuthMethod(undefined)).toBe("unknown")
+  })
+
+  test("returns 'unknown' for empty config with no identifiable auth", () => {
+    expect(detectAuthMethod({ type: "postgres" } as any)).toBe("unknown")
   })
 })
 

--- a/packages/opencode/test/altimate/driver-normalize.test.ts
+++ b/packages/opencode/test/altimate/driver-normalize.test.ts
@@ -652,6 +652,55 @@ describe("normalizeConfig — DuckDB/SQLite passthrough", () => {
 // normalizeConfig — Snowflake private_key edge cases
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// normalizeConfig — MongoDB aliases
+// ---------------------------------------------------------------------------
+
+describe("normalizeConfig — MongoDB", () => {
+  test("connectionString → connection_string", () => {
+    const config = { type: "mongodb", connectionString: "mongodb://localhost:27017/mydb" }
+    const result = normalizeConfig(config)
+    expect(result.connection_string).toBe("mongodb://localhost:27017/mydb")
+    expect(result.connectionString).toBeUndefined()
+  })
+
+  test("uri → connection_string", () => {
+    const config = { type: "mongodb", uri: "mongodb://localhost:27017/mydb" }
+    const result = normalizeConfig(config)
+    expect(result.connection_string).toBe("mongodb://localhost:27017/mydb")
+    expect(result.uri).toBeUndefined()
+  })
+
+  test("url → connection_string", () => {
+    const config = { type: "mongodb", url: "mongodb+srv://user:pass@cluster.mongodb.net/db" }
+    const result = normalizeConfig(config)
+    expect(result.connection_string).toBe("mongodb+srv://user:pass@cluster.mongodb.net/db")
+    expect(result.url).toBeUndefined()
+  })
+
+  test("canonical connection_string takes precedence over uri alias", () => {
+    const config = { type: "mongodb", connection_string: "mongodb://primary", uri: "mongodb://fallback" }
+    const result = normalizeConfig(config)
+    expect(result.connection_string).toBe("mongodb://primary")
+    expect(result.uri).toBeUndefined()
+  })
+
+  test("mongo type alias resolves MongoDB-specific aliases", () => {
+    const config = { type: "mongo", uri: "mongodb://localhost:27017/test", authSource: "admin" }
+    const result = normalizeConfig(config)
+    expect(result.connection_string).toBe("mongodb://localhost:27017/test")
+    expect(result.auth_source).toBe("admin")
+    expect(result.authSource).toBeUndefined()
+  })
+
+  test("authSource → auth_source", () => {
+    const config = { type: "mongodb", host: "localhost", authSource: "admin" }
+    const result = normalizeConfig(config)
+    expect(result.auth_source).toBe("admin")
+    expect(result.authSource).toBeUndefined()
+  })
+})
+
 describe("normalizeConfig — Snowflake private_key edge cases", () => {
   test("opaque string without path indicators stays as private_key", () => {
     const result = normalizeConfig({


### PR DESCRIPTION
### What does this PR do?

**1. `normalizeConfig` — MongoDB aliases — `packages/drivers/src/normalize.ts`** (6 new tests)

MongoDB driver support was just added in #482, but the config normalization layer had zero test coverage for MongoDB-specific field aliases. This is a P0 gap: users connecting via `uri`, `url`, or `connectionString` (the most common MongoDB connection patterns from Atlas docs, Mongoose, and official drivers) would silently get no connection string passed to the driver. New coverage includes:

- `connectionString` → `connection_string` alias resolution
- `uri` → `connection_string` alias resolution
- `url` → `connection_string` alias resolution (mongodb+srv URIs)
- First-value-wins: canonical `connection_string` takes precedence over `uri`
- `mongo` type alias resolves MongoDB-specific fields (`authSource`, `uri`)
- `authSource` → `auth_source` camelCase alias

**2. `detectAuthMethod` — `packages/opencode/src/altimate/native/connections/registry.ts`** (14 new tests)

This function feeds the `auth_method` field in `warehouse_connect` telemetry events. It had zero test coverage. Wrong values corrupt warehouse analytics and make it impossible to debug connection issues by auth type. New coverage includes:

- `connection_string`, `key_pair` (both snake_case and camelCase variants), `sso` (EXTERNALBROWSER + Okta URL), `oauth`, `token`, `password` detection
- File-based auth for DuckDB and SQLite (`"file"`)
- MongoDB-specific default (`"connection_string"` when no password)
- MongoDB with password returns `"password"`
- Null/undefined guard returns `"unknown"`
- Empty config with no identifiable auth returns `"unknown"`

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage for newly added MongoDB driver (#482)

### How did you verify your code works?

```
bun test test/altimate/driver-normalize.test.ts   # 84 pass (78 existing + 6 new)
bun test test/altimate/connections.test.ts         # 53 pass (39 existing + 14 new)
```

Marker check passed: `bun run script/upstream/analyze.ts --markers --base main --strict`

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for database authentication method detection across multiple connection types
  * Added validation tests for MongoDB connection configuration normalization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->