### PR TITLE
test: keybind parsing & credential multi-field stripping

### DIFF
--- a/packages/opencode/test/altimate/connections.test.ts
+++ b/packages/opencode/test/altimate/connections.test.ts
@@ -12,7 +12,7 @@ afterAll(() => { delete process.env.ALTIMATE_TELEMETRY_DISABLED })
 import * as Registry from "../../src/altimate/native/connections/registry"
 import * as CredentialStore from "../../src/altimate/native/connections/credential-store"
 import { parseDbtProfiles } from "../../src/altimate/native/connections/dbt-profiles"
-import { discoverContainers } from "../../src/altimate/native/connections/docker-discovery"
+import { discoverContainers, containerToConfig } from "../../src/altimate/native/connections/docker-discovery"
 import { registerAll } from "../../src/altimate/native/connections/register"
 
 // ---------------------------------------------------------------------------
@@ -126,6 +126,39 @@ describe("CredentialStore", () => {
     const { sanitized, warnings } = await CredentialStore.saveConnection("sf_keypair", config)
     expect(sanitized.private_key).toBeUndefined()
     expect(warnings.length).toBeGreaterThan(0)
+  })
+
+  test("saveConnection strips all sensitive fields from complex config", async () => {
+    const config = {
+      type: "snowflake",
+      account: "abc123",
+      user: "svc_user",
+      password: "pw123",
+      private_key: "-----BEGIN PRIVATE KEY-----",
+      private_key_passphrase: "passphrase",
+      token: "oauth-token",
+      oauth_client_secret: "client-secret",
+      ssh_password: "ssh-pw",
+      connection_string: "mongodb://...",
+    } as any
+    const { sanitized, warnings } = await CredentialStore.saveConnection("complex", config)
+
+    // All sensitive fields stripped
+    expect(sanitized.password).toBeUndefined()
+    expect(sanitized.private_key).toBeUndefined()
+    expect(sanitized.private_key_passphrase).toBeUndefined()
+    expect(sanitized.token).toBeUndefined()
+    expect(sanitized.oauth_client_secret).toBeUndefined()
+    expect(sanitized.ssh_password).toBeUndefined()
+    expect(sanitized.connection_string).toBeUndefined()
+
+    // Non-sensitive fields preserved
+    expect(sanitized.type).toBe("snowflake")
+    expect(sanitized.account).toBe("abc123")
+    expect(sanitized.user).toBe("svc_user")
+
+    // One warning per stripped field
+    expect(warnings).toHaveLength(7)
   })
 
   test("saveConnection strips OAuth credentials as sensitive", async () => {
@@ -271,6 +304,29 @@ describe("Docker discovery", () => {
   test("returns empty array when dockerode not installed", async () => {
     const containers = await discoverContainers()
     expect(containers).toEqual([])
+  })
+
+  test("containerToConfig omits undefined optional fields", () => {
+    const container = {
+      container_id: "def456",
+      name: "mysql_dev",
+      image: "mysql:8",
+      db_type: "mysql",
+      host: "127.0.0.1",
+      port: 3306,
+      user: undefined as string | undefined,
+      password: undefined as string | undefined,
+      database: undefined as string | undefined,
+      status: "running",
+    }
+    const config = containerToConfig(container as any)
+    expect(config.type).toBe("mysql")
+    expect(config.host).toBe("127.0.0.1")
+    expect(config.port).toBe(3306)
+    // Optional fields should not be set when undefined
+    expect(config.user).toBeUndefined()
+    expect(config.password).toBeUndefined()
+    expect(config.database).toBeUndefined()
   })
 })
 

--- a/packages/opencode/test/util/keybind.test.ts
+++ b/packages/opencode/test/util/keybind.test.ts
@@ -1,0 +1,232 @@
+import { describe, test, expect } from "bun:test"
+import { Keybind } from "../../src/util/keybind"
+
+// ---------------------------------------------------------------------------
+// Keybind.parse
+// ---------------------------------------------------------------------------
+
+describe("Keybind.parse", () => {
+  test("parses simple key", () => {
+    const result = Keybind.parse("a")
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      ctrl: false,
+      meta: false,
+      shift: false,
+      leader: false,
+      name: "a",
+    })
+  })
+
+  test("parses ctrl modifier", () => {
+    const [key] = Keybind.parse("ctrl+a")
+    expect(key.ctrl).toBe(true)
+    expect(key.name).toBe("a")
+  })
+
+  test("parses alt/meta/option as meta", () => {
+    expect(Keybind.parse("alt+x")[0].meta).toBe(true)
+    expect(Keybind.parse("meta+x")[0].meta).toBe(true)
+    expect(Keybind.parse("option+x")[0].meta).toBe(true)
+  })
+
+  test("parses multiple modifiers", () => {
+    const [key] = Keybind.parse("ctrl+shift+a")
+    expect(key.ctrl).toBe(true)
+    expect(key.shift).toBe(true)
+    expect(key.name).toBe("a")
+  })
+
+  test("parses super modifier", () => {
+    const [key] = Keybind.parse("super+a")
+    expect(key.super).toBe(true)
+    expect(key.name).toBe("a")
+  })
+
+  test("parses leader key", () => {
+    const [key] = Keybind.parse("<leader>a")
+    expect(key.leader).toBe(true)
+    expect(key.name).toBe("a")
+  })
+
+  test("parses comma-separated multiple bindings", () => {
+    const result = Keybind.parse("ctrl+a,ctrl+b")
+    expect(result).toHaveLength(2)
+    expect(result[0].name).toBe("a")
+    expect(result[1].name).toBe("b")
+  })
+
+  test("normalizes esc to escape", () => {
+    const [key] = Keybind.parse("esc")
+    expect(key.name).toBe("escape")
+  })
+
+  test("returns empty array for 'none'", () => {
+    expect(Keybind.parse("none")).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Keybind.match
+// ---------------------------------------------------------------------------
+
+describe("Keybind.match", () => {
+  test("matches identical keys", () => {
+    const key: Keybind.Info = {
+      ctrl: true,
+      meta: false,
+      shift: false,
+      leader: false,
+      name: "a",
+      super: false,
+    }
+    expect(Keybind.match(key, key)).toBe(true)
+  })
+
+  test("returns false for undefined first arg", () => {
+    const key: Keybind.Info = {
+      ctrl: false,
+      meta: false,
+      shift: false,
+      leader: false,
+      name: "a",
+      super: false,
+    }
+    expect(Keybind.match(undefined, key)).toBe(false)
+  })
+
+  test("normalizes missing super field to false", () => {
+    const a = { ctrl: false, meta: false, shift: false, leader: false, name: "x" } as Keybind.Info
+    const b: Keybind.Info = {
+      ctrl: false,
+      meta: false,
+      shift: false,
+      leader: false,
+      name: "x",
+      super: false,
+    }
+    expect(Keybind.match(a, b)).toBe(true)
+  })
+
+  test("super: true vs super: false don't match", () => {
+    const a: Keybind.Info = {
+      ctrl: false,
+      meta: false,
+      shift: false,
+      leader: false,
+      name: "a",
+      super: true,
+    }
+    const b: Keybind.Info = {
+      ctrl: false,
+      meta: false,
+      shift: false,
+      leader: false,
+      name: "a",
+      super: false,
+    }
+    expect(Keybind.match(a, b)).toBe(false)
+  })
+
+  test("different modifiers don't match", () => {
+    const a: Keybind.Info = {
+      ctrl: true,
+      meta: false,
+      shift: false,
+      leader: false,
+      name: "a",
+      super: false,
+    }
+    const b: Keybind.Info = {
+      ctrl: false,
+      meta: false,
+      shift: false,
+      leader: false,
+      name: "a",
+      super: false,
+    }
+    expect(Keybind.match(a, b)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Keybind.toString
+// ---------------------------------------------------------------------------
+
+describe("Keybind.toString", () => {
+  test("returns empty string for undefined", () => {
+    expect(Keybind.toString(undefined)).toBe("")
+  })
+
+  test("formats simple key", () => {
+    const key: Keybind.Info = {
+      ctrl: false,
+      meta: false,
+      shift: false,
+      leader: false,
+      name: "a",
+      super: false,
+    }
+    expect(Keybind.toString(key)).toBe("a")
+  })
+
+  test("formats modifiers in order: ctrl+alt+super+shift", () => {
+    const key: Keybind.Info = {
+      ctrl: true,
+      meta: true,
+      shift: true,
+      leader: false,
+      name: "a",
+      super: true,
+    }
+    expect(Keybind.toString(key)).toBe("ctrl+alt+super+shift+a")
+  })
+
+  test("formats leader prefix", () => {
+    const key: Keybind.Info = {
+      ctrl: false,
+      meta: false,
+      shift: false,
+      leader: true,
+      name: "a",
+      super: false,
+    }
+    expect(Keybind.toString(key)).toBe("<leader> a")
+  })
+
+  test("maps delete to del", () => {
+    const key: Keybind.Info = {
+      ctrl: false,
+      meta: false,
+      shift: false,
+      leader: false,
+      name: "delete",
+      super: false,
+    }
+    expect(Keybind.toString(key)).toBe("del")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Keybind.fromParsedKey
+// ---------------------------------------------------------------------------
+
+describe("Keybind.fromParsedKey", () => {
+  test("normalizes space to 'space'", () => {
+    const parsed = { name: " ", ctrl: false, meta: false, shift: false, super: false }
+    const result = Keybind.fromParsedKey(parsed as any)
+    expect(result.name).toBe("space")
+  })
+
+  test("sets leader flag when passed", () => {
+    const parsed = { name: "a", ctrl: false, meta: false, shift: false, super: false }
+    const result = Keybind.fromParsedKey(parsed as any, true)
+    expect(result.leader).toBe(true)
+  })
+
+  test("defaults leader to false", () => {
+    const parsed = { name: "a", ctrl: false, meta: false, shift: false, super: false }
+    const result = Keybind.fromParsedKey(parsed as any)
+    expect(result.leader).toBe(false)
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Adds targeted unit tests for two untested areas discovered during automated test discovery, plus extends an existing test suite.

**1. `Keybind` — `src/util/keybind.ts`** (22 new tests)

This module is the TUI's entire keyboard shortcut system — parsing key strings like `"ctrl+shift+a"`, matching parsed keys against each other, and formatting them for display. It had **zero tests**. A regression here silently breaks all keyboard shortcuts in the primary user interface.

New coverage includes:
- `parse()`: simple keys, modifier combinations (ctrl/alt/meta/option/shift/super), `<leader>` prefix, comma-separated multi-bindings, `esc→escape` normalization, `"none"` sentinel
- `match()`: identical key matching, `undefined` first-arg guard, `super` field normalization (missing → `false`), modifier mismatch rejection
- `toString()`: modifier ordering (ctrl+alt+super+shift), leader prefix formatting, `delete→del` mapping, undefined input
- `fromParsedKey()`: space normalization to `"space"`, leader flag propagation, default leader=false

**2. `CredentialStore.saveConnection` multi-field stripping — `src/altimate/native/connections/credential-store.ts`** (1 new test)

Existing tests verified single-field stripping (password alone, private_key alone, OAuth alone). But real Snowflake configs have **7+ simultaneous sensitive fields** (password, private_key, private_key_passphrase, token, oauth_client_secret, ssh_password, connection_string). If the iteration logic has a bug (early return, skipped field), credentials could leak to the config JSON file. The new test exercises the full multi-field path and verifies warning count matches.

**3. `containerToConfig` conditional field omission — `src/altimate/native/connections/docker-discovery.ts`** (1 new test)

The `containerToConfig` function converts auto-discovered Docker containers to `ConnectionConfig`. When optional fields (user, password, database) are `undefined`, they must not appear in the output config. The existing Docker discovery test only checked "returns empty when dockerode not installed". The new test verifies the conditional field omission behavior that users hit when Docker containers lack explicit credentials.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage from automated test discovery

### How did you verify your code works?

```
bun test test/util/keybind.test.ts          # 22 pass, 32 expect() calls
bun test test/altimate/connections.test.ts   # 41 pass (39 existing + 2 new), 97 expect() calls
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01Lui6DcLFYL75nCttunEPpH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded Docker discovery and connection credential handling test coverage to verify proper sensitive field removal, preservation of non-sensitive fields, and corresponding warning generation during credential storage operations.
  * Added comprehensive keybinding utility test suite covering key parsing with modifier support, key matching logic, string formatting with proper modifier ordering, and parsed key normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->