### PR TITLE
test: warehouse connections — MongoDB auth + env var loading

### DIFF
--- a/packages/opencode/test/altimate/connections.test.ts
+++ b/packages/opencode/test/altimate/connections.test.ts
@@ -75,6 +75,55 @@ describe("ConnectionRegistry", () => {
 })
 
 // ---------------------------------------------------------------------------
+// loadFromEnv — env var connection parsing (ALTIMATE_CODE_CONN_*)
+// ---------------------------------------------------------------------------
+
+describe("ConnectionRegistry: loadFromEnv", () => {
+  beforeEach(() => {
+    Registry.reset()
+  })
+
+  test("loads connection from ALTIMATE_CODE_CONN_* env var", () => {
+    process.env.ALTIMATE_CODE_CONN_TESTPG = JSON.stringify({
+      type: "postgres",
+      host: "localhost",
+      database: "ci_db",
+    })
+    try {
+      Registry.load()
+      // Env var suffix is lowercased: TESTPG → "testpg"
+      const config = Registry.getConfig("testpg")
+      expect(config).toBeDefined()
+      expect(config?.type).toBe("postgres")
+      expect(config?.host).toBe("localhost")
+      expect(config?.database).toBe("ci_db")
+    } finally {
+      delete process.env.ALTIMATE_CODE_CONN_TESTPG
+    }
+  })
+
+  test("ignores env var with invalid JSON", () => {
+    process.env.ALTIMATE_CODE_CONN_BAD = "not-valid-json"
+    try {
+      Registry.load()
+      expect(Registry.getConfig("bad")).toBeUndefined()
+    } finally {
+      delete process.env.ALTIMATE_CODE_CONN_BAD
+    }
+  })
+
+  test("ignores env var with missing type field", () => {
+    process.env.ALTIMATE_CODE_CONN_NOTYPE = JSON.stringify({ host: "localhost" })
+    try {
+      Registry.load()
+      expect(Registry.getConfig("notype")).toBeUndefined()
+    } finally {
+      delete process.env.ALTIMATE_CODE_CONN_NOTYPE
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
 // CredentialStore (keytar not available in test environment)
 // ---------------------------------------------------------------------------
 

--- a/packages/opencode/test/altimate/warehouse-telemetry.test.ts
+++ b/packages/opencode/test/altimate/warehouse-telemetry.test.ts
@@ -169,6 +169,20 @@ describe("warehouse telemetry: detectAuthMethod", () => {
     expect(connectEvent).toBeDefined()
     expect(connectEvent.auth_method).toBe("unknown")
   })
+
+  // MongoDB-specific branch (added with MongoDB driver support).
+  // Without this branch, { type: "mongodb" } with no password would return
+  // "unknown" instead of "connection_string".
+  test("detects MongoDB connection_string fallback (no password)", () => {
+    // Direct call — no password, no connection_string field, so only the
+    // type-specific branch at line 229 can produce "connection_string".
+    expect(Registry.detectAuthMethod({ type: "mongodb", host: "localhost" } as any)).toBe("connection_string")
+  })
+
+  test("detects mongo alias connection_string fallback", () => {
+    // Verifies the `|| t === "mongo"` half of the OR condition.
+    expect(Registry.detectAuthMethod({ type: "mongo", host: "localhost" } as any)).toBe("connection_string")
+  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### What does this PR do?

**1. `detectAuthMethod` — MongoDB branch** (`src/altimate/native/connections/registry.ts`) (2 new tests)

MongoDB driver support was added this week (commit abcaa1d, PR #482). The `detectAuthMethod` function gained a new `mongodb`/`mongo` branch that returns `"connection_string"` as the fallback auth method for MongoDB configs without a password — distinct from other driver types which fall through to `"unknown"`. Zero tests existed for this new branch. Without these tests, the MongoDB-specific line could be deleted and no test would fail, silently mislabeling telemetry for all MongoDB users.

New coverage includes:
- `{ type: "mongodb", host: "..." }` (no password) returns `"connection_string"` not `"unknown"`
- `{ type: "mongo", host: "..." }` (alias) returns `"connection_string"` — verifies the `|| t === "mongo"` half of the OR condition

**2. `loadFromEnv` — `ALTIMATE_CODE_CONN_*` env var parsing** (`src/altimate/native/connections/registry.ts`) (3 new tests)

CI/CD users configure warehouse connections via `ALTIMATE_CODE_CONN_*` environment variables. The `loadFromEnv()` function (lines 64–82) parses these into connection configs during `load()`. This code path had zero direct test coverage. If JSON parsing broke silently or the `type` field guard were removed, CI connections would vanish with no error.

New coverage includes:
- Valid JSON env var is parsed and available via `getConfig()` (includes lowercase name conversion)
- Invalid JSON env var is silently skipped (no crash, no config entry)
- JSON missing the required `type` field is rejected

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage for newly added MongoDB driver support and untested CI/CD configuration path.

### How did you verify your code works?

```
bun test test/altimate/connections.test.ts           # 42 pass
bun test test/altimate/warehouse-telemetry.test.ts   # 43 pass
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01QvuBUD1uLcEPSu6EugNcyf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for environment variable-based configuration loading and authentication method detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->