### PR TITLE
feat: add Verdaccio-based sanity suite for real npm install testing

### DIFF
--- a/test/sanity/Dockerfile.verdaccio
+++ b/test/sanity/Dockerfile.verdaccio
@@ -1,0 +1,42 @@
+FROM oven/bun:1.3.10-debian
+
+# System deps (what a real user would have)
+RUN apt-get update && apt-get install -y \
+    git python3 python3-pip python3-venv curl sqlite3 npm \
+    && rm -rf /var/lib/apt/lists/*
+
+# dbt in venv (matches real user setup)
+RUN python3 -m venv /opt/dbt && \
+    /opt/dbt/bin/pip install --quiet dbt-core==1.11.7 dbt-duckdb==1.10.1 dbt-postgres==1.10.0
+ENV PATH="/opt/dbt/bin:$PATH"
+
+# Fresh user, clean HOME — simulates new user
+ENV HOME=/home/testuser
+RUN useradd -m testuser
+USER testuser
+WORKDIR /home/testuser
+
+# ── Copy build artifacts (pre-built by `bun run build`) ────────
+COPY --chown=testuser packages/opencode/dist/ /home/testuser/build/packages/opencode/dist/
+COPY --chown=testuser packages/opencode/bin/ /home/testuser/build/packages/opencode/bin/
+COPY --chown=testuser packages/opencode/script/postinstall.mjs /home/testuser/build/packages/opencode/script/postinstall.mjs
+COPY --chown=testuser packages/opencode/package.json /home/testuser/build/packages/opencode/package.json
+COPY --chown=testuser packages/dbt-tools/dist/ /home/testuser/build/packages/dbt-tools/dist/
+COPY --chown=testuser packages/dbt-tools/bin/ /home/testuser/build/packages/dbt-tools/bin/
+COPY --chown=testuser .opencode/skills/ /home/testuser/build/.opencode/skills/
+COPY --chown=testuser LICENSE /home/testuser/build/LICENSE
+COPY --chown=testuser CHANGELOG.md /home/testuser/build/CHANGELOG.md
+COPY --chown=testuser README.md /home/testuser/build/README.md
+
+# Copy test scripts and entrypoint
+COPY --chown=testuser test/sanity/ /home/testuser/sanity/
+RUN chmod +x /home/testuser/sanity/run.sh \
+    /home/testuser/sanity/phases/*.sh \
+    /home/testuser/sanity/pr-tests/*.sh \
+    /home/testuser/sanity/lib/*.sh
+
+# Copy the publish-and-install entrypoint
+COPY --chown=testuser test/sanity/verdaccio/entrypoint.sh /home/testuser/entrypoint.sh
+RUN chmod +x /home/testuser/entrypoint.sh
+
+ENTRYPOINT ["/home/testuser/entrypoint.sh"]

--- a/test/sanity/docker-compose.verdaccio.yml
+++ b/test/sanity/docker-compose.verdaccio.yml
@@ -1,0 +1,54 @@
+# Verdaccio-based sanity suite: tests the real npm install -g flow
+# Usage: docker compose -f test/sanity/docker-compose.verdaccio.yml up --build --abort-on-container-exit --exit-code-from sanity
+services:
+  verdaccio:
+    image: verdaccio/verdaccio:5
+    volumes:
+      - ./verdaccio/config.yaml:/verdaccio/conf/config.yaml
+    ports:
+      - "127.0.0.1:4873:4873"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O/dev/null", "http://0.0.0.0:4873/-/ping"]
+      interval: 3s
+      retries: 10
+
+  sanity:
+    build:
+      context: ../..
+      dockerfile: test/sanity/Dockerfile.verdaccio
+    environment:
+      - REGISTRY_URL=http://verdaccio:4873
+      - ANTHROPIC_API_KEY
+      - ALTIMATE_CODE_CONN_SNOWFLAKE_TEST
+      - TEST_PG_HOST=postgres
+      - TEST_PG_PORT=5432
+      - TEST_PG_PASSWORD=testpass123
+      - TEST_MONGODB_HOST=mongodb
+      - TEST_MONGODB_PORT=27017
+    depends_on:
+      verdaccio:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      mongodb:
+        condition: service_healthy
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_PASSWORD: testpass123
+    ports:
+      - "127.0.0.1:15432:5432"
+    healthcheck:
+      test: pg_isready
+      interval: 5s
+      retries: 10
+
+  mongodb:
+    image: mongo:7
+    ports:
+      - "127.0.0.1:17017:27017"
+    healthcheck:
+      test: mongosh --eval "db.adminCommand('ping')" --quiet
+      interval: 5s
+      retries: 10

--- a/test/sanity/run-verdaccio.sh
+++ b/test/sanity/run-verdaccio.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Run the Verdaccio-based sanity suite: build → publish to local registry → npm install -g → test
+# This tests the EXACT same flow a real user goes through with `npm install -g altimate-code`
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+echo "========================================"
+echo "  Verdaccio Sanity Suite"
+echo "  Tests the real npm install -g flow"
+echo "  Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "========================================"
+echo ""
+
+# Ensure binaries are built
+if [ ! -d "$REPO_ROOT/packages/opencode/dist/@altimateai" ]; then
+  echo "ERROR: No built binary found at packages/opencode/dist/@altimateai/"
+  echo "  Run: cd packages/opencode && bun run build"
+  exit 1
+fi
+if [ ! -f "$REPO_ROOT/packages/dbt-tools/dist/index.js" ]; then
+  echo "ERROR: dbt-tools not built at packages/dbt-tools/dist/index.js"
+  echo "  Run: cd packages/dbt-tools && bun run build"
+  exit 1
+fi
+
+# Clean up on exit
+cleanup() {
+  echo ""
+  echo "Cleaning up Docker containers..."
+  docker compose -f "$SCRIPT_DIR/docker-compose.verdaccio.yml" down --volumes --remove-orphans 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Run the suite (disable errexit so we capture the exit code for summary)
+set +e
+docker compose -f "$SCRIPT_DIR/docker-compose.verdaccio.yml" up \
+  --build \
+  --abort-on-container-exit \
+  --exit-code-from sanity
+EXIT_CODE=$?
+set -e
+
+echo ""
+if [ $EXIT_CODE -eq 0 ]; then
+  echo "  VERDACCIO SANITY: ALL PASSED"
+else
+  echo "  VERDACCIO SANITY: FAILED (exit $EXIT_CODE)"
+fi
+
+exit $EXIT_CODE

--- a/test/sanity/verdaccio/config.yaml
+++ b/test/sanity/verdaccio/config.yaml
@@ -1,0 +1,39 @@
+# Verdaccio config for sanity testing — permissive local registry
+# Anonymous publish enabled for test infrastructure only.
+storage: /verdaccio/storage
+auth:
+  htpasswd:
+    file: /verdaccio/conf/htpasswd
+    max_users: -1
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+packages:
+  # Platform binaries — must be published locally, never proxy to npmjs
+  "@altimateai/altimate-code-*":
+    access: $all
+    publish: $all
+    unpublish: $all
+    # no proxy: fail fast if binary not published locally
+  # Other @altimateai packages (e.g., altimate-core) — proxy to npmjs
+  "@altimateai/*":
+    access: $all
+    publish: $all
+    proxy: npmjs
+  # Unscoped altimate-code — must be published locally
+  "altimate-code":
+    access: $all
+    publish: $all
+    unpublish: $all
+    # no proxy: fail fast if main package not published locally
+  # Everything else — proxy to npmjs
+  "**":
+    access: $all
+    proxy: npmjs
+max_body_size: 500mb
+server:
+  keepAliveTimeout: 60
+log:
+  type: stdout
+  format: pretty
+  level: warn

--- a/test/sanity/verdaccio/entrypoint.sh
+++ b/test/sanity/verdaccio/entrypoint.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+# Verdaccio sanity entrypoint: publish to local registry → npm install -g → run sanity tests
+# This runs at container startup (not during build) so Verdaccio is available.
+set -euo pipefail
+
+REGISTRY_URL="${REGISTRY_URL:-http://verdaccio:4873}"
+BUILD_DIR="/home/testuser/build"
+MAX_PUBLISH_RETRIES=3
+
+echo "========================================"
+echo "  Verdaccio Install Pipeline"
+echo "  Registry: $REGISTRY_URL"
+echo "========================================"
+
+# ── Wait for Verdaccio ─────────────────────────────────────────
+echo ""
+echo "--- Waiting for Verdaccio ---"
+for i in $(seq 1 60); do
+  if curl -sf "$REGISTRY_URL/-/ping" >/dev/null 2>&1; then
+    echo "  Verdaccio is ready"
+    break
+  fi
+  if [ "$i" -eq 60 ]; then
+    echo "  FATAL: Verdaccio not reachable after 60s"
+    exit 1
+  fi
+  sleep 1
+done
+
+# ── Configure npm to use Verdaccio ─────────────────────────────
+REGISTRY_HOST="${REGISTRY_URL#http://}"
+REGISTRY_HOST="${REGISTRY_HOST#https://}"
+REGISTRY_HOST="${REGISTRY_HOST%/}"
+cat > ~/.npmrc <<NPMRCEOF
+registry=${REGISTRY_URL}
+//${REGISTRY_HOST}/:_authToken=anonymous-sanity-token
+always-auth=true
+NPMRCEOF
+echo "  Registry: $REGISTRY_URL"
+echo "  .npmrc configured"
+sed 's/\(_authToken=\).*/\1***REDACTED***/' ~/.npmrc
+
+# ── Helper: npm publish with retry (matches publish.ts:130-143) ─
+npm_publish_with_retry() {
+  local dir="$1"
+  local attempt
+  for attempt in $(seq 1 "$MAX_PUBLISH_RETRIES"); do
+    if (cd "$dir" && npm publish --registry "$REGISTRY_URL" 2>&1); then
+      return 0
+    fi
+    local is_last=$((attempt == MAX_PUBLISH_RETRIES))
+    if [ "$is_last" -eq 1 ]; then
+      echo "  FATAL: npm publish failed after $MAX_PUBLISH_RETRIES attempts"
+      return 1
+    fi
+    local wait=$((attempt * 5))
+    echo "  Publish attempt $attempt failed, retrying in ${wait}s..."
+    sleep "$wait"
+  done
+}
+
+# ── Step 1: Publish platform binary package ────────────────────
+echo ""
+echo "--- Publishing platform binary ---"
+cd "$BUILD_DIR/packages/opencode"
+ARCH=$(uname -m | sed 's/x86_64/x64/' | sed 's/aarch64/arm64/')
+BIN_PKG_DIR="dist/@altimateai/altimate-code-linux-${ARCH}"
+
+if [ ! -d "$BIN_PKG_DIR" ]; then
+  echo "  FATAL: No binary package for architecture: $ARCH ($(uname -m))"
+  echo "  Expected: $BIN_PKG_DIR"
+  exit 1
+fi
+
+# Sanitize version: replace ALL invalid semver chars, not just "/"
+RAW_VERSION=$(node -e "console.log(require('./${BIN_PKG_DIR}/package.json').version)")
+VERSION=$(printf '%s' "$RAW_VERSION" | sed 's|[^a-zA-Z0-9._-]|-|g')
+BIN_NAME="@altimateai/altimate-code-linux-${ARCH}"
+BIN_VERSION="$VERSION"
+CORE_DEP=$(node -e "console.log(require('./package.json').dependencies['@altimateai/altimate-core'])")
+
+echo "  Version: $VERSION"
+echo "  Binary: $BIN_NAME@$BIN_VERSION"
+echo "  Core dep: @altimateai/altimate-core@$CORE_DEP"
+
+# Patch version in binary package.json to sanitized version (no shell injection — use env vars)
+cd "$BIN_PKG_DIR"
+VERSION="$VERSION" node -e "
+  const p = require('./package.json');
+  p.version = process.env.VERSION;
+  require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2) + '\n');
+"
+chmod -R 755 .
+npm_publish_with_retry "$(pwd)"
+
+# ── Step 2: Build and publish main altimate-code package ───────
+echo ""
+echo "--- Building main package ---"
+PUBLISH_DIR=$(mktemp -d /tmp/altimate-publish-XXXXXX)
+
+# Copy exactly what publish.ts copies
+cd "$BUILD_DIR/packages/opencode"
+cp -r bin "$PUBLISH_DIR/bin"
+cp script/postinstall.mjs "$PUBLISH_DIR/postinstall.mjs"
+cp -r "$BUILD_DIR/.opencode/skills" "$PUBLISH_DIR/skills"
+
+# Bundle dbt-tools (matching publish.ts:57-78)
+mkdir -p "$PUBLISH_DIR/dbt-tools/bin" "$PUBLISH_DIR/dbt-tools/dist"
+cp "$BUILD_DIR/packages/dbt-tools/bin/altimate-dbt" "$PUBLISH_DIR/dbt-tools/bin/altimate-dbt"
+cp "$BUILD_DIR/packages/dbt-tools/dist/index.js" "$PUBLISH_DIR/dbt-tools/dist/"
+cp "$BUILD_DIR/packages/dbt-tools/dist/node_python_bridge.py" "$PUBLISH_DIR/dbt-tools/dist/"
+echo '{"type":"module"}' > "$PUBLISH_DIR/dbt-tools/package.json"
+# Copy altimate_python_packages if present (publish.ts:76-78)
+if [ -d "$BUILD_DIR/packages/dbt-tools/dist/altimate_python_packages" ]; then
+  cp -r "$BUILD_DIR/packages/dbt-tools/dist/altimate_python_packages" "$PUBLISH_DIR/dbt-tools/dist/"
+fi
+
+cp "$BUILD_DIR/LICENSE" "$PUBLISH_DIR/LICENSE"
+cp "$BUILD_DIR/CHANGELOG.md" "$PUBLISH_DIR/CHANGELOG.md"
+cp "$BUILD_DIR/README.md" "$PUBLISH_DIR/README.md"
+
+# Write package.json matching what publish.ts produces (no shell injection — use env vars)
+VERSION="$VERSION" CORE_DEP="$CORE_DEP" BIN_NAME="$BIN_NAME" BIN_VERSION="$BIN_VERSION" \
+  PUBLISH_DIR="$PUBLISH_DIR" node -e "
+const pkg = {
+  name: 'altimate-code',
+  version: process.env.VERSION,
+  license: 'MIT',
+  bin: { altimate: './bin/altimate', 'altimate-code': './bin/altimate-code' },
+  scripts: { postinstall: 'bun ./postinstall.mjs || node ./postinstall.mjs' },
+  dependencies: { '@altimateai/altimate-core': process.env.CORE_DEP },
+  optionalDependencies: { [process.env.BIN_NAME]: process.env.BIN_VERSION },
+  peerDependencies: {
+    pg: '>=8', 'snowflake-sdk': '>=1', '@google-cloud/bigquery': '>=8',
+    '@databricks/sql': '>=1', mysql2: '>=3', mssql: '>=11',
+    oracledb: '>=6', duckdb: '>=1'
+  },
+  peerDependenciesMeta: {
+    pg: {optional:true}, 'snowflake-sdk': {optional:true},
+    '@google-cloud/bigquery': {optional:true}, '@databricks/sql': {optional:true},
+    mysql2: {optional:true}, mssql: {optional:true}, oracledb: {optional:true},
+    duckdb: {optional:true}
+  }
+};
+require('fs').writeFileSync(
+  require('path').join(process.env.PUBLISH_DIR, 'package.json'),
+  JSON.stringify(pkg, null, 2) + '\n'
+);
+"
+
+echo "--- Publishing main package ---"
+chmod -R 755 "$PUBLISH_DIR"
+npm_publish_with_retry "$PUBLISH_DIR"
+echo "  Published altimate-code@$VERSION to $REGISTRY_URL"
+
+# ── Step 3: Clean install as a real user ───────────────────────
+echo ""
+echo "--- npm install -g altimate-code ---"
+# Wipe build artifacts — user starts fresh
+rm -rf "$BUILD_DIR" "$PUBLISH_DIR"
+cd /home/testuser
+
+# Install to user-local prefix (testuser can't write /usr/local)
+mkdir -p /home/testuser/.npm-global
+npm config set prefix /home/testuser/.npm-global
+export PATH="/home/testuser/.npm-global/bin:$PATH"
+npm install -g "altimate-code@$VERSION" --registry "$REGISTRY_URL" 2>&1
+echo ""
+echo "  Installed: $(which altimate 2>/dev/null || echo 'NOT FOUND')"
+echo "  Version: $(altimate --version 2>/dev/null || echo 'FAILED')"
+
+# ── Step 4: Run sanity tests ──────────────────────────────────
+echo ""
+echo "========================================"
+echo "  Running sanity tests against npm install"
+echo "========================================"
+exec /home/testuser/sanity/run.sh


### PR DESCRIPTION
## Summary
- Add a Verdaccio-based sanity suite that tests the **actual `npm install -g altimate-code` flow** using a local npm registry
- Pipeline: build → publish to local Verdaccio → `npm install -g` from Verdaccio → run sanity tests
- Addresses all 11 issues from 9-model code review

## What this catches that the old approach didn't
- Missing files in npm tarball (symlinks not followed by `npm pack`)
- Broken `postinstall.mjs` scripts
- Wrong `bin` field in package.json
- Dependency resolution failures at install time
- Native binary platform detection failures in the install flow

## Real bug found
The postinstall script fails because `bin/altimate-code` is a symlink → `altimate` in the platform binary package. When `npm pack` creates a tarball and npm unpacks it, the symlink target isn't found. This bug exists in the real published package too — the Verdaccio suite correctly catches it.

```
Binary not found at .../node_modules/@altimateai/altimate-code-linux-arm64/bin/altimate-code
```

## 9-Model Code Review Fixes Applied
All 11 fixable issues from the consensus review addressed:

| # | Issue | Fix |
|---|-------|-----|
| 1 | `@altimateai/*` no-proxy blocks altimate-core | Split rules: `altimate-code-*` (no proxy) vs `@altimateai/*` (proxy: npmjs) |
| 2 | htpasswd committed unused | Deleted |
| 3 | Shell injection in `node -e` | All scripts use `process.env.*` instead of `$VAR` interpolation |
| 4 | Version sanitization incomplete | `sed 's\|[^a-zA-Z0-9._-]\|-\|g'` replaces all invalid chars |
| 5 | No publish retry | Added `npm_publish_with_retry()` with 3 attempts + backoff |
| 6 | Missing altimate_python_packages | Added conditional copy matching publish.ts |
| 7 | Should use chmod before publish | Added `chmod -R 755` matching publish.ts:125 |
| 8 | Unused REGISTRY_URL build arg | Moved to `environment`, removed from `args` |
| 9 | MongoDB peer dep mismatch | Removed from entrypoint to match publish.ts |
| 10 | Missing dbt-tools check | Added to run-verdaccio.sh |
| 11 | Pin Verdaccio version | `verdaccio/verdaccio:5` |

## Test Results
```
✅ Verdaccio starts and responds to health checks
✅ Binary package published to local registry (68.8 MB)
✅ Main package published to local registry (1.1 MB + python packages)
✅ npm install -g triggers postinstall.mjs
❌ postinstall fails: bin/altimate-code symlink broken after npm unpack
   (This is the real bug — exists in production too)
```

## Test plan
- [x] `bash -n` syntax check on all shell scripts
- [x] `docker compose config` validates YAML
- [x] Both packages publish to Verdaccio successfully
- [x] `npm install -g` runs and triggers postinstall
- [x] Postinstall correctly fails on symlink bug (real packaging issue, needs separate fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end npm package installation testing infrastructure including containerized local npm registry with automated publishing workflows, Docker Compose orchestration for multi-service test environments supporting PostgreSQL and MongoDB integration, registry health validation, semantic version management, global npm package installation verification, and automated sanity test execution with proper environment cleanup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->