### PR TITLE
test: ssh-tunnel — extractSshConfig validation and lifecycle safety

### DIFF
--- a/packages/opencode/test/altimate/ssh-tunnel.test.ts
+++ b/packages/opencode/test/altimate/ssh-tunnel.test.ts
@@ -1,0 +1,91 @@
+import { describe, test, expect } from "bun:test"
+import {
+  extractSshConfig,
+  closeTunnel,
+  closeAllTunnels,
+  getActiveTunnel,
+} from "../../src/altimate/native/connections/ssh-tunnel"
+
+describe("SSH tunnel: extractSshConfig", () => {
+  test("returns null when no ssh_host present", () => {
+    const result = extractSshConfig({ type: "postgres", host: "db.example.com", port: 5432 })
+    expect(result).toBeNull()
+  })
+
+  test("extracts SSH config with all fields", () => {
+    const config = {
+      type: "postgres",
+      host: "db.internal",
+      port: 5432,
+      ssh_host: "bastion.example.com",
+      ssh_port: 2222,
+      ssh_user: "deploy",
+      ssh_password: "secret",
+    }
+    const result = extractSshConfig(config)
+    expect(result).toEqual({
+      ssh_host: "bastion.example.com",
+      ssh_port: 2222,
+      ssh_user: "deploy",
+      ssh_password: "secret",
+      ssh_private_key: undefined,
+      host: "db.internal",
+      port: 5432,
+    })
+  })
+
+  test("uses defaults for optional ssh_port and ssh_user", () => {
+    const result = extractSshConfig({
+      type: "postgres",
+      host: "db.internal",
+      port: 5432,
+      ssh_host: "bastion.example.com",
+    })
+    expect(result!.ssh_port).toBe(22)
+    expect(result!.ssh_user).toBe("root")
+  })
+
+  test("uses default host and port when not specified", () => {
+    const result = extractSshConfig({
+      type: "postgres",
+      ssh_host: "bastion.example.com",
+    })
+    expect(result!.host).toBe("127.0.0.1")
+    expect(result!.port).toBe(5432)
+  })
+
+  test("throws when ssh_host used with connection_string", () => {
+    expect(() =>
+      extractSshConfig({
+        type: "postgres",
+        ssh_host: "bastion.example.com",
+        connection_string: "postgresql://user:pass@host/db",
+      }),
+    ).toThrow("Cannot use SSH tunnel with connection_string")
+  })
+
+  test("passes through both ssh_private_key and ssh_password", () => {
+    const result = extractSshConfig({
+      type: "postgres",
+      host: "db.internal",
+      port: 5432,
+      ssh_host: "bastion.example.com",
+      ssh_private_key: "-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
+      ssh_password: "also-provided",
+    })
+    expect(result!.ssh_private_key).toContain("BEGIN RSA PRIVATE KEY")
+    expect(result!.ssh_password).toBe("also-provided")
+  })
+})
+
+describe("SSH tunnel: lifecycle helpers (no real SSH)", () => {
+  test("closeTunnel is a no-op for unknown name", () => {
+    closeTunnel("nonexistent-tunnel-name")
+    expect(getActiveTunnel("nonexistent-tunnel-name")).toBeUndefined()
+  })
+
+  test("closeAllTunnels is safe when no tunnels exist", () => {
+    closeAllTunnels()
+    expect(getActiveTunnel("any")).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

### What does this PR do?

**1. `extractSshConfig` and tunnel lifecycle — `src/altimate/native/connections/ssh-tunnel.ts`** (8 new tests)

This module handles SSH tunnel creation, configuration extraction, and lifecycle management for remote database connections. **Zero tests existed** prior to this PR. The `extractSshConfig` function is called on every connection creation in `registry.ts` — if it mishandles edge cases (missing port defaults, connection_string conflicts), users get cryptic errors or misconfigured tunnels.

New coverage includes:
- **Null return**: correctly returns `null` when no `ssh_host` is present (skip tunnel path)
- **Full field extraction**: all SSH config fields are correctly mapped from `ConnectionConfig`
- **Default values**: `ssh_port` defaults to `22`, `ssh_user` defaults to `"root"`, `host` defaults to `"127.0.0.1"`, `port` defaults to `5432`
- **connection_string conflict**: throws a clear error when `ssh_host` is used with `connection_string` (these are mutually exclusive — SSH tunnels need host/port to rewrite)
- **Key/password passthrough**: both `ssh_private_key` and `ssh_password` are passed through to `startTunnel` (which decides priority)
- **Lifecycle safety**: `closeTunnel` and `closeAllTunnels` are safe no-ops when no tunnels exist (no crashes on the shared `activeTunnels` Map)

### Discovery process

- Reconnaissance identified `ssh-tunnel.ts` as a critical infrastructure module with zero test coverage
- A critic agent reviewed and approved all 8 tests, rejecting 2 other candidates (MongoDB list tests that didn't exercise new code paths, and trajectory helpers that are unexported)
- Tests are pure unit tests with no network, filesystem, or timing dependencies

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage for SSH tunnel infrastructure

### How did you verify your code works?

```
bun test test/altimate/ssh-tunnel.test.ts       # 8 pass, 11 expect() calls
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01NiGUekwkcSnAAuncsehdFn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for SSH tunnel configuration and management, validating configuration extraction, default parameter handling, and tunnel lifecycle operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->