### PR TITLE
fix: Config.update() writes to wrong file, PATCH /config settings silently lost

### DIFF
--- a/packages/drivers/src/sqlserver.ts
+++ b/packages/drivers/src/sqlserver.ts
@@ -7,7 +7,6 @@ import type { ConnectionConfig, Connector, ConnectorResult, SchemaColumn } from 
 export async function connect(config: ConnectionConfig): Promise<Connector> {
   let mssql: any
   try {
-    // @ts-expect-error — mssql has no type declarations; installed as optional peerDependency
     mssql = await import("mssql")
     mssql = mssql.default || mssql
   } catch {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1425,7 +1425,11 @@ export namespace Config {
   }
 
   export async function update(config: Info) {
-    const filepath = path.join(Instance.directory, "config.json")
+    // Find an existing project config file, or default to opencode.json.
+    // ConfigPaths.projectFiles("opencode", ...) looks for opencode.jsonc and opencode.json,
+    // so we must write to one of those — not config.json which is never loaded by state().
+    const projectFiles = await ConfigPaths.projectFiles("opencode", Instance.directory, Instance.worktree)
+    const filepath = projectFiles[projectFiles.length - 1] ?? path.join(Instance.directory, "opencode.json")
     const existing = await loadFile(filepath)
     await Filesystem.writeJson(filepath, mergeDeep(existing, config))
     await Instance.dispose()

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -699,7 +699,7 @@ test("updates config and writes to file", async () => {
       const newConfig = { model: "updated/model" }
       await Config.update(newConfig as any)
 
-      const writtenConfig = await Filesystem.readJson(path.join(tmp.path, "config.json"))
+      const writtenConfig = await Filesystem.readJson(path.join(tmp.path, "opencode.json"))
       expect(writtenConfig.model).toBe("updated/model")
     },
   })


### PR DESCRIPTION
## Summary

- `Config.update()` wrote to `config.json` in the project directory, but `Config.state()` loads project config from `opencode.json` / `opencode.jsonc` via `ConfigPaths.projectFiles("opencode", ...)`. The file names didn't match, so any setting saved through `PATCH /config` was written to a file that was never read back.
- This caused the VS Code extension's model picker to appear to save the selection, but the server would fall back to the provider-level default model on the next request — leading to errors like `No endpoints found for google/gemini-3-pro-preview` when the default model was stale/removed from OpenRouter.
- The fix finds the existing project config file using the same `ConfigPaths.projectFiles()` that `state()` uses, falling back to `opencode.json` if none exists.

## Root Cause

| Function | File it uses | Loaded by `state()`? |
|----------|-------------|---------------------|
| `Config.update()` (before fix) | `config.json` | No — only loaded from `Global.Path.config`, never from project dir |
| `Config.state()` project loading | `opencode.json` / `opencode.jsonc` | Yes |
| `Config.update()` (after fix) | Uses `ConfigPaths.projectFiles()` or falls back to `opencode.json` | Yes |

## How it was found

1. VS Code extension's Altimate Code Chat showed `APIError:` with no message when sending messages
2. The error was actually `No endpoints found for google/gemini-3-pro-preview` (a stale default model)
3. User selected Claude Sonnet 4.6 in the model picker UI → extension called `PATCH /config` with `{"model": "openrouter/anthropic/claude-sonnet-4.6"}` → returned success
4. But `GET /config` right after didn't include the `model` field — it was lost
5. Traced to `Config.update()` writing `config.json` while `Config.state()` reads `opencode.json`

## Test plan

- [ ] Call `PATCH /config` with `{"model": "openrouter/anthropic/claude-sonnet-4.6"}`
- [ ] Call `GET /config` — verify `model` field is present in response
- [ ] Send a message — verify it uses the configured model, not the provider default
- [ ] Verify existing `opencode.json` / `opencode.jsonc` files are updated in-place (not a new file created)
- [ ] Verify fresh project with no config file creates `opencode.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration updates now save to the correct project config file (falls back to opencode.json), so persisted settings are found by subsequent operations.

* **Tests**
  * Updated tests to expect config persistence at the corrected filename.

* **Chores**
  * Cleaned up a TypeScript annotation related to a database driver import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->