### PR TITLE
test: MongoDB normalizeConfig aliases — close coverage gap from #482

### DIFF
--- a/packages/opencode/test/altimate/driver-normalize.test.ts
+++ b/packages/opencode/test/altimate/driver-normalize.test.ts
@@ -663,3 +663,85 @@ describe("normalizeConfig — Snowflake private_key edge cases", () => {
     expect(result.private_key_path).toBeUndefined()
   })
 })
+
+// ---------------------------------------------------------------------------
+// normalizeConfig — MongoDB aliases
+// ---------------------------------------------------------------------------
+
+describe("normalizeConfig — MongoDB", () => {
+  test("connectionString → connection_string", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      connectionString: "mongodb://localhost:27017/mydb",
+    })
+    expect(result.connection_string).toBe("mongodb://localhost:27017/mydb")
+    expect(result.connectionString).toBeUndefined()
+  })
+
+  test("uri → connection_string", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      uri: "mongodb://localhost:27017/mydb",
+    })
+    expect(result.connection_string).toBe("mongodb://localhost:27017/mydb")
+    expect(result.uri).toBeUndefined()
+  })
+
+  test("authSource → auth_source", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      authSource: "admin",
+    })
+    expect(result.auth_source).toBe("admin")
+    expect(result.authSource).toBeUndefined()
+  })
+
+  test("replicaSet → replica_set", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      replicaSet: "rs0",
+    })
+    expect(result.replica_set).toBe("rs0")
+    expect(result.replicaSet).toBeUndefined()
+  })
+
+  test("directConnection → direct_connection", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      directConnection: true,
+    })
+    expect(result.direct_connection).toBe(true)
+    expect(result.directConnection).toBeUndefined()
+  })
+
+  test("connectTimeoutMS → connect_timeout", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      connectTimeoutMS: 5000,
+    })
+    expect(result.connect_timeout).toBe(5000)
+    expect(result.connectTimeoutMS).toBeUndefined()
+  })
+
+  test("'mongo' type alias routes to MongoDB aliases", () => {
+    const result = normalizeConfig({
+      type: "mongo",
+      uri: "mongodb://localhost/test",
+    })
+    expect(result.connection_string).toBe("mongodb://localhost/test")
+    expect(result.uri).toBeUndefined()
+  })
+
+  test("canonical mongodb config passes through unchanged", () => {
+    const config = {
+      type: "mongodb",
+      connection_string: "mongodb://localhost:27017",
+      user: "admin",
+      password: "secret",
+      database: "mydb",
+      auth_source: "admin",
+      replica_set: "rs0",
+    }
+    expect(normalizeConfig(config)).toEqual(config)
+  })
+})


### PR DESCRIPTION
### What does this PR do?

**1. `normalizeConfig` — MongoDB aliases in `packages/drivers/src/normalize.ts`** (8 new tests)

MongoDB driver support was added in #482, but `driver-normalize.test.ts` had **zero tests** for the `MONGODB_ALIASES` map. Every other driver (Postgres, Snowflake, BigQuery, Databricks, SQL Server, Oracle, MySQL) had alias normalization tests — MongoDB was the only gap.

**Why it matters:** Users configure MongoDB connections using field names from the MongoDB Node.js driver docs (`connectionString`), mongosh docs (`uri`), or the native driver options (`authSource`, `replicaSet`, `directConnection`, `connectTimeoutMS`). Without normalization working correctly, these camelCase/alternative names silently fail — the driver doesn't see the connection string and falls back to constructing a URI from host/port, causing connection failures or connecting to the wrong database.

**Specific scenarios covered:**
- `connectionString` → `connection_string` (MongoDB Node.js driver convention)
- `uri` → `connection_string` (mongosh / pymongo convention)
- `authSource` → `auth_source` (driver option)
- `replicaSet` → `replica_set` (driver option)
- `directConnection` → `direct_connection` (driver option, boolean)
- `connectTimeoutMS` → `connect_timeout` (driver option, number)
- `mongo` type alias routes to MongoDB alias map (not just `mongodb`)
- Canonical MongoDB config passes through unchanged (regression guard)

**What was intentionally excluded (critic review):**
- Common aliases (`username` → `user`, `dbname` → `database`) — already tested for other drivers via the shared `COMMON_ALIASES` object
- `url` → `connection_string` — same code path as `uri`, no additional coverage
- `detectAuthMethod` MongoDB branch — critic analysis showed the branch is shadowed by prior guards; proposed tests would pass for wrong reasons

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage for #482

### How did you verify your code works?

```
bun test test/altimate/driver-normalize.test.ts    # 86 pass (78 existing + 8 new)
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01AhNUh22SS3cRR9GVNiTcit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for MongoDB configuration normalization, including field alias mapping and type alias routing verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->