### PR TITLE
test: connections — env-var loading and MongoDB auth detection

### DIFF
--- a/packages/opencode/test/altimate/registry-env.test.ts
+++ b/packages/opencode/test/altimate/registry-env.test.ts
@@ -1,0 +1,80 @@
+// altimate_change start — unit tests for ConnectionRegistry loadFromEnv code path
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import * as Registry from "../../src/altimate/native/connections/registry"
+
+// ---------------------------------------------------------------------------
+// loadFromEnv — env-var based connection configuration
+// ---------------------------------------------------------------------------
+// These tests exercise the ALTIMATE_CODE_CONN_* env-var parsing in
+// registry.ts → loadFromEnv(). CI/CD users rely on this to inject
+// warehouse connections without config files on disk.
+//
+// NOTE: Registry.load() also reads from ~/.altimate-code/connections.json
+// and .altimate-code/connections.json. The assertions below only check for
+// specific keys set via env vars, so unrelated entries from disk do not
+// interfere.
+// ---------------------------------------------------------------------------
+
+describe("ConnectionRegistry: loadFromEnv", () => {
+  // Track env vars we set so we can clean them up
+  const envVarsSet: string[] = []
+
+  function setEnv(key: string, value: string) {
+    process.env[key] = value
+    envVarsSet.push(key)
+  }
+
+  beforeEach(() => {
+    Registry.reset()
+  })
+
+  afterEach(() => {
+    for (const key of envVarsSet) {
+      delete process.env[key]
+    }
+    envVarsSet.length = 0
+  })
+
+  test("parses valid ALTIMATE_CODE_CONN_* env var and lowercases the name", () => {
+    setEnv("ALTIMATE_CODE_CONN_MYDB", JSON.stringify({ type: "postgres", host: "localhost", port: 5432 }))
+    Registry.load()
+
+    const config = Registry.getConfig("mydb")
+    expect(config).toBeDefined()
+    expect(config?.type).toBe("postgres")
+    expect(config?.host).toBe("localhost")
+  })
+
+  test("ignores malformed JSON in env var without crashing", () => {
+    setEnv("ALTIMATE_CODE_CONN_BAD", "not-valid-json{{{")
+    Registry.load()
+
+    // The malformed env var should be silently skipped
+    expect(Registry.getConfig("bad")).toBeUndefined()
+  })
+
+  test("ignores env var config objects missing the type field", () => {
+    setEnv("ALTIMATE_CODE_CONN_NOTYPE", JSON.stringify({ host: "localhost", port: 5432 }))
+    Registry.load()
+
+    // Without a type field, the config should not be registered
+    expect(Registry.getConfig("notype")).toBeUndefined()
+  })
+
+  test("ignores env vars with empty values", () => {
+    setEnv("ALTIMATE_CODE_CONN_EMPTY", "")
+    Registry.load()
+
+    expect(Registry.getConfig("empty")).toBeUndefined()
+  })
+
+  test("parses multiple env var connections", () => {
+    setEnv("ALTIMATE_CODE_CONN_PG", JSON.stringify({ type: "postgres", host: "pg.example.com" }))
+    setEnv("ALTIMATE_CODE_CONN_SF", JSON.stringify({ type: "snowflake", account: "abc123" }))
+    Registry.load()
+
+    expect(Registry.getConfig("pg")?.type).toBe("postgres")
+    expect(Registry.getConfig("sf")?.type).toBe("snowflake")
+  })
+})
+// altimate_change end

--- a/packages/opencode/test/altimate/warehouse-telemetry.test.ts
+++ b/packages/opencode/test/altimate/warehouse-telemetry.test.ts
@@ -158,6 +158,24 @@ describe("warehouse telemetry: detectAuthMethod", () => {
     expect(connectEvent.auth_method).toBe("file")
   })
 
+  // altimate_change start — MongoDB detectAuthMethod coverage (PR #482)
+  // These call detectAuthMethod directly rather than going through Registry.get(),
+  // because the MongoDB driver import + connect would time out in test environments.
+  test("detects connection_string auth for mongodb without password", () => {
+    expect(Registry.detectAuthMethod({ type: "mongodb", host: "localhost" })).toBe("connection_string")
+  })
+
+  test("detects connection_string auth for mongo alias without password", () => {
+    expect(Registry.detectAuthMethod({ type: "mongo", host: "localhost" })).toBe("connection_string")
+  })
+
+  test("detects password auth for mongodb with password", () => {
+    // Note: the generic password check (line 226) fires before the mongo branch,
+    // but the result is the same — "password". This verifies the overall behavior.
+    expect(Registry.detectAuthMethod({ type: "mongodb", password: "secret" })).toBe("password")
+  })
+  // altimate_change end
+
   test("returns unknown for unrecognized auth", async () => {
     Registry.setConfigs({
       mystery: { type: "unsupported_db_type", host: "localhost" },


### PR DESCRIPTION
### What does this PR do?

**1. `loadFromEnv` — `src/altimate/native/connections/registry.ts`** (5 new tests)

The `ALTIMATE_CODE_CONN_*` env-var connection loading path had zero unit test coverage. CI/CD users rely on this to inject warehouse connections without config files on disk. If JSON parsing or name normalization (uppercase prefix → lowercase key) broke, connections would silently fail to load with no indication why.

New coverage includes:
- Valid env var parsing with name lowercasing
- Malformed JSON is silently ignored (no crash)
- Config objects missing the `type` field are rejected
- Empty env var values are ignored
- Multiple env var connections are parsed correctly

**2. `detectAuthMethod` for MongoDB — `src/altimate/native/connections/registry.ts`** (3 new tests)

PR #482 added MongoDB driver support with a new branch in `detectAuthMethod` (line 229) that returns `"connection_string"` for MongoDB connections without a password. This branch had zero test coverage. Wrong auth detection means incorrect telemetry for MongoDB users.

New coverage includes:
- `type: "mongodb"` without password → `"connection_string"`
- `type: "mongo"` (alias) without password → `"connection_string"`
- `type: "mongodb"` with password → `"password"` (exercises the generic password check path)

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage

### How did you verify your code works?

```
bun test test/altimate/registry-env.test.ts          # 5 pass
bun test test/altimate/warehouse-telemetry.test.ts   # 44 pass (41 existing + 3 new)
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01Uf1H6t7768cFYAT9AbKSzr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for configuration loading from environment variables and MongoDB authentication detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->