### PR TITLE
test: MongoDB driver — normalizeConfig aliases and detectAuthMethod

### DIFF
--- a/packages/opencode/test/altimate/driver-normalize.test.ts
+++ b/packages/opencode/test/altimate/driver-normalize.test.ts
@@ -649,6 +649,126 @@ describe("normalizeConfig — DuckDB/SQLite passthrough", () => {
 })
 
 // ---------------------------------------------------------------------------
+// normalizeConfig — MongoDB
+// ---------------------------------------------------------------------------
+
+describe("normalizeConfig — MongoDB", () => {
+  test("connectionString → connection_string for mongodb", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      connectionString: "mongodb://localhost:27017/mydb",
+    })
+    expect(result.connection_string).toBe("mongodb://localhost:27017/mydb")
+    expect(result.connectionString).toBeUndefined()
+  })
+
+  test("uri → connection_string for mongodb", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      uri: "mongodb://localhost:27017/mydb",
+    })
+    expect(result.connection_string).toBe("mongodb://localhost:27017/mydb")
+    expect(result.uri).toBeUndefined()
+  })
+
+  test("url → connection_string for mongodb", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      url: "mongodb+srv://cluster0.example.net/mydb",
+    })
+    expect(result.connection_string).toBe("mongodb+srv://cluster0.example.net/mydb")
+    expect(result.url).toBeUndefined()
+  })
+
+  test("authSource → auth_source for mongodb", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      host: "localhost",
+      authSource: "admin",
+    })
+    expect(result.auth_source).toBe("admin")
+    expect(result.authSource).toBeUndefined()
+  })
+
+  test("replicaSet → replica_set for mongodb", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      host: "localhost",
+      replicaSet: "rs0",
+    })
+    expect(result.replica_set).toBe("rs0")
+    expect(result.replicaSet).toBeUndefined()
+  })
+
+  test("directConnection → direct_connection for mongodb", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      host: "localhost",
+      directConnection: true,
+    })
+    expect(result.direct_connection).toBe(true)
+    expect(result.directConnection).toBeUndefined()
+  })
+
+  test("connectTimeoutMS → connect_timeout for mongodb", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      host: "localhost",
+      connectTimeoutMS: 5000,
+    })
+    expect(result.connect_timeout).toBe(5000)
+    expect(result.connectTimeoutMS).toBeUndefined()
+  })
+
+  test("serverSelectionTimeoutMS → server_selection_timeout for mongodb", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      host: "localhost",
+      serverSelectionTimeoutMS: 15000,
+    })
+    expect(result.server_selection_timeout).toBe(15000)
+    expect(result.serverSelectionTimeoutMS).toBeUndefined()
+  })
+
+  test("mongo type alias works", () => {
+    const result = normalizeConfig({
+      type: "mongo",
+      uri: "mongodb://localhost:27017",
+      authSource: "admin",
+    })
+    expect(result.connection_string).toBe("mongodb://localhost:27017")
+    expect(result.auth_source).toBe("admin")
+    expect(result.uri).toBeUndefined()
+    expect(result.authSource).toBeUndefined()
+  })
+
+  test("resolves multiple aliases in a single config", () => {
+    const result = normalizeConfig({
+      type: "mongodb",
+      uri: "mongodb://localhost:27017/mydb",
+      authSource: "admin",
+      replicaSet: "rs0",
+      directConnection: false,
+      connectTimeoutMS: 5000,
+      serverSelectionTimeoutMS: 15000,
+    })
+    expect(result.connection_string).toBe("mongodb://localhost:27017/mydb")
+    expect(result.auth_source).toBe("admin")
+    expect(result.replica_set).toBe("rs0")
+    expect(result.direct_connection).toBe(false)
+    expect(result.connect_timeout).toBe(5000)
+    expect(result.server_selection_timeout).toBe(15000)
+    // All aliases removed
+    expect(result.uri).toBeUndefined()
+    expect(result.authSource).toBeUndefined()
+    expect(result.replicaSet).toBeUndefined()
+    expect(result.directConnection).toBeUndefined()
+    expect(result.connectTimeoutMS).toBeUndefined()
+    expect(result.serverSelectionTimeoutMS).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
 // normalizeConfig — Snowflake private_key edge cases
 // ---------------------------------------------------------------------------
 

--- a/packages/opencode/test/altimate/telemetry-safety.test.ts
+++ b/packages/opencode/test/altimate/telemetry-safety.test.ts
@@ -59,6 +59,11 @@ describe("Telemetry Safety: Helper functions never throw", () => {
     expect(detectAuthMethod({ type: "duckdb" })).toBe("file")
     expect(detectAuthMethod({ type: "sqlite" })).toBe("file")
     expect(detectAuthMethod({ type: "postgres" })).toBe("unknown")
+    // MongoDB auth detection
+    expect(detectAuthMethod({ type: "mongodb", connection_string: "mongodb://localhost" })).toBe("connection_string")
+    expect(detectAuthMethod({ type: "mongodb", password: "secret" })).toBe("password")
+    expect(detectAuthMethod({ type: "mongodb" })).toBe("connection_string")
+    expect(detectAuthMethod({ type: "mongo" })).toBe("connection_string")
     // Edge cases
     expect(detectAuthMethod({} as any)).toBe("unknown")
     expect(detectAuthMethod({ type: "" })).toBe("unknown")


### PR DESCRIPTION
### What does this PR do?

MongoDB driver support was added in v0.5.13 (commit abcaa1d, PR #482), but the config normalization aliases and auth method detection for MongoDB had **zero test coverage**. This PR adds targeted tests to close that gap.

**1. `normalizeConfig` — MongoDB aliases in `packages/drivers/src/normalize.ts`** (10 new tests)

The `MONGODB_ALIASES` map (lines 76–84) and the `mongo` type alias (lines 99–100) were added alongside the MongoDB driver but the existing test file (`driver-normalize.test.ts`) covered every other driver type *except* MongoDB. Without these tests, a regression in alias resolution would cause silent connection failures for users configuring MongoDB with dbt/SDK-style field names like `uri`, `connectionString`, `authSource`, `replicaSet`, etc.

New coverage includes:
- Each individual alias: `connectionString`, `uri`, `url` → `connection_string`; `authSource` → `auth_source`; `replicaSet` → `replica_set`; `directConnection` → `direct_connection`; `connectTimeoutMS` → `connect_timeout`; `serverSelectionTimeoutMS` → `server_selection_timeout`
- The `mongo` type alias resolves identically to `mongodb`
- A combined test verifying all aliases resolve correctly in a single realistic config object

**2. `detectAuthMethod` — MongoDB auth detection in `src/altimate/native/connections/registry.ts`** (4 new assertions)

The MongoDB-specific auth detection branch (line 229) was added but had no test assertions. Added coverage for:
- `connection_string` field → `"connection_string"`
- `password` field → `"password"` (caught by generic check at line 226)
- Bare `mongodb` type with no credentials → `"connection_string"` fallback (line 229)
- `mongo` type alias → same fallback behavior

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage for newly shipped MongoDB driver support

### How did you verify your code works?

```
bun test test/altimate/driver-normalize.test.ts       # 88 pass (78 existing + 10 new)
bun test test/altimate/telemetry-safety.test.ts --test-name-pattern "detectAuthMethod"  # 2 pass (4 new assertions in existing test)
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01U7mUcNzrnXfdtJSJxVTuQv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for MongoDB configuration normalization, including alias property resolution and authentication method detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->