### PR TITLE
test: connections — SSH tunnel + MongoDB auth detection

### DIFF
--- a/packages/opencode/test/altimate/ssh-tunnel-and-registry.test.ts
+++ b/packages/opencode/test/altimate/ssh-tunnel-and-registry.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+
+// Disable telemetry to avoid side-effects
+beforeAll(() => { process.env.ALTIMATE_TELEMETRY_DISABLED = "true" })
+afterAll(() => { delete process.env.ALTIMATE_TELEMETRY_DISABLED })
+
+import { extractSshConfig, closeTunnel, getActiveTunnel } from "../../src/altimate/native/connections/ssh-tunnel"
+import { detectAuthMethod } from "../../src/altimate/native/connections/registry"
+
+// ---------------------------------------------------------------------------
+// extractSshConfig — pure function that extracts SSH tunnel config
+// ---------------------------------------------------------------------------
+
+describe("extractSshConfig", () => {
+  test("returns null when no ssh_host is present", () => {
+    const result = extractSshConfig({ type: "postgres", host: "db.example.com", port: 5432 })
+    expect(result).toBeNull()
+  })
+
+  test("extracts full SSH config with all fields", () => {
+    const result = extractSshConfig({
+      type: "postgres",
+      host: "db.internal",
+      port: 5433,
+      ssh_host: "bastion.example.com",
+      ssh_port: 2222,
+      ssh_user: "deployer",
+      ssh_password: "secret",
+    })
+    expect(result).toEqual({
+      ssh_host: "bastion.example.com",
+      ssh_port: 2222,
+      ssh_user: "deployer",
+      ssh_password: "secret",
+      ssh_private_key: undefined,
+      host: "db.internal",
+      port: 5433,
+    })
+  })
+
+  test("applies defaults for ssh_port, ssh_user, host, port", () => {
+    const result = extractSshConfig({
+      type: "postgres",
+      ssh_host: "bastion.example.com",
+    })
+    expect(result).not.toBeNull()
+    expect(result!.ssh_port).toBe(22)
+    expect(result!.ssh_user).toBe("root")
+    expect(result!.host).toBe("127.0.0.1")
+    expect(result!.port).toBe(5432)
+  })
+
+  test("throws when connection_string is used with SSH tunnel", () => {
+    expect(() => extractSshConfig({
+      type: "postgres",
+      ssh_host: "bastion.example.com",
+      connection_string: "postgresql://user:pass@host:5432/db",
+    })).toThrow("Cannot use SSH tunnel with connection_string")
+  })
+
+  test("supports private key authentication", () => {
+    const result = extractSshConfig({
+      type: "snowflake",
+      host: "db.internal",
+      port: 443,
+      ssh_host: "bastion.example.com",
+      ssh_private_key: "-----BEGIN OPENSSH PRIVATE KEY-----\nAAA...",
+    })
+    expect(result).not.toBeNull()
+    expect(result!.ssh_private_key).toBe("-----BEGIN OPENSSH PRIVATE KEY-----\nAAA...")
+    expect(result!.ssh_password).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// closeTunnel / getActiveTunnel — idempotent operations on empty state
+// ---------------------------------------------------------------------------
+
+describe("SSH tunnel state management", () => {
+  test("closeTunnel is a no-op for non-existent tunnel and does not corrupt state", () => {
+    closeTunnel("nonexistent-tunnel-name")
+    expect(getActiveTunnel("nonexistent-tunnel-name")).toBeUndefined()
+  })
+
+  test("getActiveTunnel returns undefined for non-existent tunnel", () => {
+    expect(getActiveTunnel("nonexistent")).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// detectAuthMethod — MongoDB-specific fallback paths (added in commit abcaa1d)
+//
+// Note: config.password triggers the generic "password" branch (line 226)
+// BEFORE the type-specific MongoDB branch (line 229). These tests document
+// the actual precedence behavior, not the MongoDB branch in isolation.
+// ---------------------------------------------------------------------------
+
+describe("detectAuthMethod: MongoDB", () => {
+  test("mongodb without password falls through to MongoDB-specific branch returning 'connection_string'", () => {
+    expect(detectAuthMethod({ type: "mongodb" })).toBe("connection_string")
+  })
+
+  test("mongo alias without password falls through to MongoDB-specific branch returning 'connection_string'", () => {
+    expect(detectAuthMethod({ type: "mongo" })).toBe("connection_string")
+  })
+
+  test("mongodb with password is caught by the generic password check (precedence test)", () => {
+    // The generic `if (config.password)` fires before the MongoDB branch
+    expect(detectAuthMethod({ type: "mongodb", password: "secret" })).toBe("password")
+  })
+
+  test("mongodb with connection_string is caught by the generic connection_string check (precedence test)", () => {
+    expect(detectAuthMethod({ type: "mongodb", connection_string: "mongodb://localhost:27017" })).toBe("connection_string")
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Adds 11 new unit tests covering two untested areas in the warehouse connection layer. Both modules sit in the critical path for database connectivity — bugs here cause silent connection failures or incorrect telemetry.

**1. `extractSshConfig` — `src/altimate/native/connections/ssh-tunnel.ts`** (7 new tests)

This pure function extracts SSH tunnel configuration from a `ConnectionConfig` and validates incompatible options. It had **zero test coverage** despite being called on every warehouse connection attempt when SSH fields are present. New coverage includes:

- Returns `null` when no `ssh_host` is present (early-return guard)
- Extracts all SSH fields correctly when fully specified
- Applies correct defaults: `ssh_port=22`, `ssh_user="root"`, `host="127.0.0.1"`, `port=5432`
- Throws a clear error when `connection_string` is combined with SSH tunnel (user-facing validation)
- Supports private key authentication (ssh_private_key populated, ssh_password undefined)
- `closeTunnel` is idempotent on non-existent tunnels and doesn't corrupt state
- `getActiveTunnel` returns undefined for non-existent tunnels

**2. `detectAuthMethod` MongoDB paths — `src/altimate/native/connections/registry.ts`** (4 new tests)

The MongoDB driver was added in #482 (commit abcaa1d), introducing a new type-specific fallback branch in `detectAuthMethod`. This branch had **zero test coverage**. New coverage includes:

- `{ type: "mongodb" }` (no password) → falls through to MongoDB-specific branch returning `"connection_string"`
- `{ type: "mongo" }` alias → same behavior via the `"mongo"` alias
- `{ type: "mongodb", password: "..." }` → caught by generic password check (documents precedence)
- `{ type: "mongodb", connection_string: "..." }` → caught by generic connection_string check (documents precedence)

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage for recently added MongoDB driver support and untested SSH tunnel extraction logic.

### How did you verify your code works?

```
bun test test/altimate/ssh-tunnel-and-registry.test.ts   # 11 pass, 17 expect() calls
```

Marker check: `bun script/upstream/analyze.ts --markers --base main --strict` → pass (no upstream files modified).

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01Wr8GYaTQDKpHV1UQDftUJr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for SSH tunnel configuration extraction, including handling of optional credentials and default values.
  * Added tests for tunnel state operations to ensure safe handling of non-existent tunnels.
  * Added tests for registry authentication method detection and precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->