### PR TITLE
test: log-buffer, RWLock concurrency, SSE chunk splitting — 13 new tests

### DIFF
--- a/packages/dbt-tools/test/log-buffer.test.ts
+++ b/packages/dbt-tools/test/log-buffer.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect, beforeEach } from "bun:test"
+import { bufferLog, getRecentDbtLogs, clearDbtLogs } from "../src/log-buffer"
+
+describe("dbt log-buffer", () => {
+  beforeEach(() => {
+    clearDbtLogs()
+  })
+
+  test("buffers log messages in insertion order", () => {
+    bufferLog("first")
+    bufferLog("second")
+    bufferLog("third")
+    expect(getRecentDbtLogs()).toEqual(["first", "second", "third"])
+  })
+
+  test("evicts oldest entries when buffer exceeds 100", () => {
+    for (let i = 0; i < 105; i++) {
+      bufferLog(`msg-${i}`)
+    }
+    const logs = getRecentDbtLogs()
+    expect(logs).toHaveLength(100)
+    expect(logs[0]).toBe("msg-5")
+    expect(logs[99]).toBe("msg-104")
+  })
+
+  test("clearDbtLogs empties the buffer", () => {
+    bufferLog("something")
+    clearDbtLogs()
+    expect(getRecentDbtLogs()).toEqual([])
+  })
+
+  test("getRecentDbtLogs returns a copy, not a reference", () => {
+    bufferLog("original")
+    const copy = getRecentDbtLogs()
+    copy.push("injected")
+    expect(getRecentDbtLogs()).toEqual(["original"])
+  })
+
+  test("handles empty buffer", () => {
+    expect(getRecentDbtLogs()).toEqual([])
+  })
+
+  test("buffer stays at exactly 100 after repeated overflow", () => {
+    for (let i = 0; i < 200; i++) {
+      bufferLog(`msg-${i}`)
+    }
+    expect(getRecentDbtLogs()).toHaveLength(100)
+    expect(getRecentDbtLogs()[0]).toBe("msg-100")
+    expect(getRecentDbtLogs()[99]).toBe("msg-199")
+  })
+})

--- a/packages/opencode/test/control-plane/sse.test.ts
+++ b/packages/opencode/test/control-plane/sse.test.ts
@@ -53,4 +53,83 @@ describe("control-plane/sse", () => {
       },
     ])
   })
+
+  test("handles events split across chunk boundaries", async () => {
+    const events: unknown[] = []
+    const stop = new AbortController()
+
+    await parseSSE(
+      stream(['data: {"type":"spl', 'it"}\n\n']),
+      stop.signal,
+      (event) => events.push(event),
+    )
+
+    expect(events).toEqual([{ type: "split" }])
+  })
+
+  test("handles double newline split across chunks", async () => {
+    const events: unknown[] = []
+    const stop = new AbortController()
+
+    await parseSSE(
+      stream(['data: {"type":"boundary"}\n', '\ndata: {"type":"next"}\n\n']),
+      stop.signal,
+      (event) => events.push(event),
+    )
+
+    expect(events).toEqual([{ type: "boundary" }, { type: "next" }])
+  })
+
+  test("ignores empty events (double newline with no data)", async () => {
+    const events: unknown[] = []
+    const stop = new AbortController()
+
+    await parseSSE(
+      stream(['\n\ndata: {"type":"real"}\n\n']),
+      stop.signal,
+      (event) => events.push(event),
+    )
+
+    expect(events).toEqual([{ type: "real" }])
+  })
+
+  test("abort signal stops processing mid-stream", async () => {
+    const events: unknown[] = []
+    const stop = new AbortController()
+
+    // Stream that delivers chunks on demand via pull(); abort fires
+    // between the first and second read.
+    let pullCount = 0
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        const encoder = new TextEncoder()
+        pullCount++
+        if (pullCount === 1) {
+          controller.enqueue(encoder.encode('data: {"type":"first"}\n\n'))
+          // Abort before next pull delivers second event
+          stop.abort()
+        } else {
+          controller.enqueue(encoder.encode('data: {"type":"second"}\n\n'))
+          controller.close()
+        }
+      },
+    })
+
+    await parseSSE(body, stop.signal, (event) => events.push(event))
+
+    expect(events).toEqual([{ type: "first" }])
+  })
+
+  test("handles bare \\r line endings", async () => {
+    const events: unknown[] = []
+    const stop = new AbortController()
+
+    await parseSSE(
+      stream(['data: {"type":"cr"}\r\r']),
+      stop.signal,
+      (event) => events.push(event),
+    )
+
+    expect(events).toEqual([{ type: "cr" }])
+  })
 })

--- a/packages/opencode/test/util/lock.test.ts
+++ b/packages/opencode/test/util/lock.test.ts
@@ -69,4 +69,72 @@ describe("util.lock", () => {
 
     reader[Symbol.dispose]()
   })
+
+  test("concurrent readers: multiple readers can hold the lock simultaneously", async () => {
+    const key = "lock:" + Math.random().toString(36).slice(2)
+    const timeline: string[] = []
+
+    const r1 = await Lock.read(key)
+    timeline.push("r1-acquired")
+
+    const r2 = await Lock.read(key)
+    timeline.push("r2-acquired")
+
+    // Both acquired without blocking — readers are concurrent
+    expect(timeline).toEqual(["r1-acquired", "r2-acquired"])
+
+    r1[Symbol.dispose]()
+    r2[Symbol.dispose]()
+  })
+
+  test("writer starvation prevention: waiting writer blocks new readers", async () => {
+    const key = "lock:" + Math.random().toString(36).slice(2)
+    const timeline: string[] = []
+
+    // Acquire a reader
+    const r1 = await Lock.read(key)
+    timeline.push("r1-acquired")
+
+    // Queue a writer (blocks because r1 is held)
+    let writerResolved = false
+    const writerTask = Lock.write(key).then((w) => {
+      writerResolved = true
+      timeline.push("writer-acquired")
+      return w
+    })
+
+    await flush()
+    expect(writerResolved).toBe(false)
+
+    // Queue a second reader (should block because a writer is waiting —
+    // the source's process() prioritizes waitingWriters over waitingReaders)
+    let reader2Resolved = false
+    const reader2Task = Lock.read(key).then((r) => {
+      reader2Resolved = true
+      timeline.push("r2-acquired")
+      return r
+    })
+
+    await flush()
+    expect(reader2Resolved).toBe(false)
+
+    // Release r1 — writer goes next (not reader2).
+    // process() calls the writer callback synchronously via shift()+nextWriter(),
+    // which resolves the writer promise on the next microtask.  reader2 remains
+    // queued in waitingReaders until the writer releases.
+    r1[Symbol.dispose]()
+
+    const writer = await writerTask
+    expect(writerResolved).toBe(true)
+    expect(reader2Resolved).toBe(false)
+
+    // Release writer — now reader2 can proceed
+    writer[Symbol.dispose]()
+    const r2 = await reader2Task
+    expect(reader2Resolved).toBe(true)
+
+    expect(timeline).toEqual(["r1-acquired", "writer-acquired", "r2-acquired"])
+
+    r2[Symbol.dispose]()
+  })
 })


### PR DESCRIPTION
### What does this PR do?

Adds 13 new tests across 3 modules that had zero or minimal test coverage, targeting real user-facing risk areas identified during automated test discovery.

**1. `bufferLog` / `getRecentDbtLogs` / `clearDbtLogs` — `packages/dbt-tools/src/log-buffer.ts`** (6 new tests)

This ring buffer captures dbt log output to prevent TUI corruption (referenced in #249). Zero tests existed. New coverage includes:
- Insertion order preservation
- Oldest-entry eviction when the 100-message cap is exceeded
- Buffer clearing resets state completely
- `getRecentDbtLogs()` returns a defensive copy (not a mutable reference to internal state)
- Correct behavior at boundary (200 messages → exactly 100 retained, correct window)
- Empty buffer returns empty array

**2. `Lock.read` / `Lock.write` — `packages/opencode/src/util/lock.ts`** (2 new tests, 3 total)

The RWLock powers session concurrency. Only 1 test existed (basic writer exclusivity). New coverage includes:
- Concurrent readers: multiple readers acquire simultaneously without blocking
- Writer starvation prevention: a queued writer blocks subsequent readers, ensuring writers are not starved by a steady stream of read requests (tests the `process()` priority logic)

**3. `parseSSE` — `packages/opencode/src/control-plane/sse.ts`** (5 new tests, 7 total)

The SSE parser powers real-time workspace sync via the control plane. Only 2 basic tests existed. New coverage includes:
- Event data split across chunk boundaries (buffer accumulation correctness)
- `\n\n` delimiter split across two chunks (the most dangerous boundary case)
- Empty events (consecutive `\n\n` with no data lines) are correctly ignored
- Abort signal stops processing mid-stream (uses `pull()`-based stream for reliable abort timing)
- Bare `\r` line endings are normalized correctly (existing tests only covered `\r\n`)

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage via automated test discovery

### How did you verify your code works?

```
bun test packages/dbt-tools/test/log-buffer.test.ts          # 6 pass
bun test packages/opencode/test/util/lock.test.ts            # 3 pass (1 existing + 2 new)
bun test packages/opencode/test/control-plane/sse.test.ts    # 7 pass (2 existing + 5 new)
```

All tests validated by a critic agent before commit (rejected 2 proposed tests as redundant/flawed, revised 2 others for correctness).

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01153R7Dh9BMKiarndEUraBk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for log buffer operations, including overflow handling and buffer isolation.
  * Extended test coverage for SSE parsing to handle chunked payloads, split delimiters, and stream interruption scenarios.
  * Added test coverage for concurrent read locking and writer-priority behavior in lock mechanisms to prevent starvation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->