### PR TITLE
test: SQL tool formatters — check, equivalence, semantics (38 tests)

### DIFF
--- a/packages/opencode/src/altimate/tools/altimate-core-check.ts
+++ b/packages/opencode/src/altimate/tools/altimate-core-check.ts
@@ -57,7 +57,7 @@ export const AltimateCoreCheckTool = Tool.define("altimate_core_check", {
   },
 })
 
-function formatCheckTitle(data: Record<string, any>): string {
+export function formatCheckTitle(data: Record<string, any>): string {
   const parts: string[] = []
   if (!data.validation?.valid) parts.push("validation errors")
   if (!data.lint?.clean) parts.push(`${data.lint?.findings?.length ?? 0} lint findings`)
@@ -66,7 +66,7 @@ function formatCheckTitle(data: Record<string, any>): string {
   return parts.length ? parts.join(", ") : "PASS"
 }
 
-function formatCheck(data: Record<string, any>): string {
+export function formatCheck(data: Record<string, any>): string {
   const lines: string[] = []
 
   lines.push("=== Validation ===")

--- a/packages/opencode/src/altimate/tools/altimate-core-equivalence.ts
+++ b/packages/opencode/src/altimate/tools/altimate-core-equivalence.ts
@@ -65,7 +65,7 @@ export const AltimateCoreEquivalenceTool = Tool.define("altimate_core_equivalenc
   },
 })
 
-function extractEquivalenceErrors(data: Record<string, any>): string | undefined {
+export function extractEquivalenceErrors(data: Record<string, any>): string | undefined {
   if (Array.isArray(data.validation_errors) && data.validation_errors.length > 0) {
     const msgs = data.validation_errors
       .map((e: any) => (typeof e === "string" ? e : (e.message ?? String(e))))
@@ -75,7 +75,7 @@ function extractEquivalenceErrors(data: Record<string, any>): string | undefined
   return undefined
 }
 
-function formatEquivalence(data: Record<string, any>): string {
+export function formatEquivalence(data: Record<string, any>): string {
   if (data.error) return `Error: ${data.error}`
   const lines: string[] = []
   lines.push(data.equivalent ? "Queries are semantically equivalent." : "Queries produce different results.")

--- a/packages/opencode/src/altimate/tools/altimate-core-semantics.ts
+++ b/packages/opencode/src/altimate/tools/altimate-core-semantics.ts
@@ -61,7 +61,7 @@ export const AltimateCoreSemanticsTool = Tool.define("altimate_core_semantics", 
   },
 })
 
-function extractSemanticsErrors(data: Record<string, any>): string | undefined {
+export function extractSemanticsErrors(data: Record<string, any>): string | undefined {
   if (Array.isArray(data.validation_errors) && data.validation_errors.length > 0) {
     const msgs = data.validation_errors
       .map((e: any) => (typeof e === "string" ? e : (e.message ?? String(e))))
@@ -71,7 +71,7 @@ function extractSemanticsErrors(data: Record<string, any>): string | undefined {
   return undefined
 }
 
-function formatSemantics(data: Record<string, any>): string {
+export function formatSemantics(data: Record<string, any>): string {
   if (data.error) return `Error: ${data.error}`
   if (data.valid) return "No semantic issues found."
   const lines = ["Semantic issues:\n"]

--- a/packages/opencode/test/altimate/altimate-core-check-formatters.test.ts
+++ b/packages/opencode/test/altimate/altimate-core-check-formatters.test.ts
@@ -1,0 +1,151 @@
+import { describe, test, expect } from "bun:test"
+import { formatCheckTitle, formatCheck } from "../../src/altimate/tools/altimate-core-check"
+
+describe("formatCheckTitle", () => {
+  test("returns PASS for all-clean result", () => {
+    const data = {
+      validation: { valid: true },
+      lint: { clean: true, findings: [] },
+      safety: { safe: true },
+      pii: { findings: [] },
+    }
+    expect(formatCheckTitle(data)).toBe("PASS")
+  })
+
+  test("lists all failure categories when everything fails", () => {
+    const data = {
+      validation: { valid: false, errors: [{ message: "bad syntax" }] },
+      lint: { clean: false, findings: [{ rule: "L001" }, { rule: "L002" }] },
+      safety: { safe: false, threats: [{ type: "injection" }] },
+      pii: { findings: [{ column: "ssn", category: "SSN" }] },
+    }
+    const result = formatCheckTitle(data)
+    expect(result).toContain("validation errors")
+    expect(result).toContain("2 lint findings")
+    expect(result).toContain("safety threats")
+    expect(result).toContain("PII detected")
+  })
+
+  test("treats missing sections as failures (undefined is falsy)", () => {
+    // When data is empty, !undefined is true, so each section looks like a failure
+    const data = {} as Record<string, any>
+    const result = formatCheckTitle(data)
+    expect(result).toContain("validation errors")
+    expect(result).toContain("safety threats")
+    // lint.findings?.length is undefined, ?? 0 yields "0 lint findings"
+    expect(result).toContain("0 lint findings")
+  })
+
+  test("shows lint finding count when clean is false but findings is undefined", () => {
+    const data = {
+      validation: { valid: true },
+      lint: { clean: false },
+      safety: { safe: true },
+      pii: { findings: [] },
+    }
+    // lint.findings?.length is undefined, ?? 0 yields "0 lint findings"
+    expect(formatCheckTitle(data)).toBe("0 lint findings")
+  })
+
+  test("only shows failing sections, not passing ones", () => {
+    const data = {
+      validation: { valid: true },
+      lint: { clean: true },
+      safety: { safe: false, threats: [{ type: "drop_table" }] },
+      pii: { findings: [] },
+    }
+    expect(formatCheckTitle(data)).toBe("safety threats")
+  })
+})
+
+describe("formatCheck", () => {
+  test("formats all-pass result with four sections", () => {
+    const data = {
+      validation: { valid: true },
+      lint: { clean: true },
+      safety: { safe: true },
+      pii: { findings: [] },
+    }
+    const output = formatCheck(data)
+    expect(output).toContain("=== Validation ===")
+    expect(output).toContain("Valid SQL.")
+    expect(output).toContain("=== Lint ===")
+    expect(output).toContain("No lint findings.")
+    expect(output).toContain("=== Safety ===")
+    expect(output).toContain("Safe — no threats.")
+    expect(output).toContain("=== PII ===")
+    expect(output).toContain("No PII detected.")
+  })
+
+  test("formats validation errors", () => {
+    const data = {
+      validation: { valid: false, errors: [{ message: "syntax error at line 3" }, { message: "unknown column" }] },
+      lint: { clean: true },
+      safety: { safe: true },
+      pii: {},
+    }
+    const output = formatCheck(data)
+    expect(output).toContain("Invalid: syntax error at line 3; unknown column")
+  })
+
+  test("formats lint findings with severity and rule", () => {
+    const data = {
+      validation: { valid: true },
+      lint: {
+        clean: false,
+        findings: [
+          { severity: "warning", rule: "L001", message: "Unnecessary whitespace" },
+          { severity: "error", rule: "L003", message: "Indentation not consistent" },
+        ],
+      },
+      safety: { safe: true },
+      pii: {},
+    }
+    const output = formatCheck(data)
+    expect(output).toContain("[warning] L001: Unnecessary whitespace")
+    expect(output).toContain("[error] L003: Indentation not consistent")
+  })
+
+  test("formats safety threats", () => {
+    const data = {
+      validation: { valid: true },
+      lint: { clean: true },
+      safety: {
+        safe: false,
+        threats: [{ severity: "critical", type: "sql_injection", description: "Tautology detected: 1=1" }],
+      },
+      pii: {},
+    }
+    const output = formatCheck(data)
+    expect(output).toContain("[critical] sql_injection: Tautology detected: 1=1")
+  })
+
+  test("formats PII findings with column and confidence", () => {
+    const data = {
+      validation: { valid: true },
+      lint: { clean: true },
+      safety: { safe: true },
+      pii: {
+        findings: [
+          { column: "ssn", category: "SSN", confidence: "high" },
+          { column: "email", category: "EMAIL", confidence: "medium" },
+        ],
+      },
+    }
+    const output = formatCheck(data)
+    expect(output).toContain("ssn: SSN (high confidence)")
+    expect(output).toContain("email: EMAIL (medium confidence)")
+  })
+
+  test("handles empty/missing sections without crashing", () => {
+    const data = {} as Record<string, any>
+    const output = formatCheck(data)
+    // Should still produce all four section headers
+    expect(output).toContain("=== Validation ===")
+    expect(output).toContain("=== Lint ===")
+    expect(output).toContain("=== Safety ===")
+    expect(output).toContain("=== PII ===")
+    // validation.valid is undefined (falsy) → "Invalid: unknown"
+    expect(output).toContain("Invalid:")
+  })
+})

--- a/packages/opencode/test/altimate/altimate-core-equivalence-formatters.test.ts
+++ b/packages/opencode/test/altimate/altimate-core-equivalence-formatters.test.ts
@@ -1,0 +1,107 @@
+import { describe, test, expect } from "bun:test"
+import {
+  extractEquivalenceErrors,
+  formatEquivalence,
+} from "../../src/altimate/tools/altimate-core-equivalence"
+
+describe("extractEquivalenceErrors", () => {
+  test("returns undefined when validation_errors is absent", () => {
+    expect(extractEquivalenceErrors({})).toBeUndefined()
+  })
+
+  test("returns undefined for empty validation_errors array", () => {
+    expect(extractEquivalenceErrors({ validation_errors: [] })).toBeUndefined()
+  })
+
+  test("joins string errors with semicolons", () => {
+    const data = { validation_errors: ["column X not found", "table Y not found"] }
+    expect(extractEquivalenceErrors(data)).toBe("column X not found; table Y not found")
+  })
+
+  test("extracts .message from object errors", () => {
+    const data = {
+      validation_errors: [
+        { message: "unresolved reference to column 'id'" },
+        { message: "ambiguous column name" },
+      ],
+    }
+    expect(extractEquivalenceErrors(data)).toBe(
+      "unresolved reference to column 'id'; ambiguous column name",
+    )
+  })
+
+  test("falls back to String(e) for non-string primitive errors", () => {
+    const data = { validation_errors: [42] }
+    // 42 → typeof 42 !== "string" → e.message (undefined) ?? String(42) = "42"
+    expect(extractEquivalenceErrors(data)).toBe("42")
+  })
+
+  test("crashes on null entries in validation_errors (known bug)", () => {
+    // BUG: null passes typeof check (not "string") but null.message throws TypeError
+    // The ?? operator cannot protect because property access on null throws first
+    const data = { validation_errors: [null] }
+    expect(() => extractEquivalenceErrors(data)).toThrow(TypeError)
+  })
+
+  test("filters out falsy messages", () => {
+    const data = { validation_errors: [{ message: "" }, { message: "real error" }] }
+    // Empty string is filtered by .filter(Boolean)
+    expect(extractEquivalenceErrors(data)).toBe("real error")
+  })
+
+  test("returns undefined when all messages are empty", () => {
+    const data = { validation_errors: [{ message: "" }] }
+    expect(extractEquivalenceErrors(data)).toBeUndefined()
+  })
+})
+
+describe("formatEquivalence", () => {
+  test("shows error message when data.error is present (short-circuits)", () => {
+    const data = { error: "Schema not found", equivalent: true }
+    // error takes priority over equivalent
+    expect(formatEquivalence(data)).toBe("Error: Schema not found")
+  })
+
+  test("shows equivalent message when queries match", () => {
+    const data = { equivalent: true }
+    expect(formatEquivalence(data)).toBe("Queries are semantically equivalent.")
+  })
+
+  test("shows different message when queries don't match", () => {
+    const data = { equivalent: false }
+    expect(formatEquivalence(data)).toContain("Queries produce different results.")
+  })
+
+  test("lists differences with description field", () => {
+    const data = {
+      equivalent: false,
+      differences: [
+        { description: "WHERE clause differs" },
+        { description: "Column order differs" },
+      ],
+    }
+    const output = formatEquivalence(data)
+    expect(output).toContain("Differences:")
+    expect(output).toContain("  - WHERE clause differs")
+    expect(output).toContain("  - Column order differs")
+  })
+
+  test("falls back to raw value when description is absent", () => {
+    const data = {
+      equivalent: false,
+      differences: ["plain string difference"],
+    }
+    const output = formatEquivalence(data)
+    expect(output).toContain("  - plain string difference")
+  })
+
+  test("shows confidence level", () => {
+    const data = { equivalent: true, confidence: "high" }
+    expect(formatEquivalence(data)).toContain("Confidence: high")
+  })
+
+  test("omits confidence when not present", () => {
+    const data = { equivalent: true }
+    expect(formatEquivalence(data)).not.toContain("Confidence")
+  })
+})

--- a/packages/opencode/test/altimate/altimate-core-semantics-formatters.test.ts
+++ b/packages/opencode/test/altimate/altimate-core-semantics-formatters.test.ts
@@ -1,0 +1,102 @@
+import { describe, test, expect } from "bun:test"
+import {
+  extractSemanticsErrors,
+  formatSemantics,
+} from "../../src/altimate/tools/altimate-core-semantics"
+
+describe("extractSemanticsErrors", () => {
+  test("returns undefined when validation_errors is absent", () => {
+    expect(extractSemanticsErrors({})).toBeUndefined()
+  })
+
+  test("returns undefined for empty validation_errors array", () => {
+    expect(extractSemanticsErrors({ validation_errors: [] })).toBeUndefined()
+  })
+
+  test("joins string errors with semicolons", () => {
+    const data = { validation_errors: ["missing table reference", "ambiguous column"] }
+    expect(extractSemanticsErrors(data)).toBe("missing table reference; ambiguous column")
+  })
+
+  test("extracts .message from object errors", () => {
+    const data = {
+      validation_errors: [{ message: "unresolved column 'foo'" }],
+    }
+    expect(extractSemanticsErrors(data)).toBe("unresolved column 'foo'")
+  })
+
+  test("returns undefined when all messages are empty strings", () => {
+    const data = { validation_errors: [{ message: "" }] }
+    expect(extractSemanticsErrors(data)).toBeUndefined()
+  })
+})
+
+describe("formatSemantics", () => {
+  test("shows error message when data.error is present (short-circuits)", () => {
+    const data = { error: "napi-rs internal failure", valid: true }
+    // error takes priority over valid
+    expect(formatSemantics(data)).toBe("Error: napi-rs internal failure")
+  })
+
+  test("shows valid message when data.valid is true", () => {
+    const data = { valid: true }
+    expect(formatSemantics(data)).toBe("No semantic issues found.")
+  })
+
+  test("shows issues header when data.valid is false even with empty issues", () => {
+    // This tests the degenerate case: valid=false but no issues array
+    const data = { valid: false }
+    const output = formatSemantics(data)
+    expect(output).toContain("Semantic issues:")
+    // No actual issue lines since data.issues is undefined
+  })
+
+  test("lists issues with severity and rule", () => {
+    const data = {
+      valid: false,
+      issues: [
+        { severity: "error", rule: "cartesian_product", message: "Unfiltered cross join detected" },
+        { severity: "warning", rule: "null_comparison", message: "= NULL should be IS NULL" },
+      ],
+    }
+    const output = formatSemantics(data)
+    expect(output).toContain("[error] cartesian_product: Unfiltered cross join detected")
+    expect(output).toContain("[warning] null_comparison: = NULL should be IS NULL")
+  })
+
+  test("defaults severity to 'warning' when absent", () => {
+    const data = {
+      valid: false,
+      issues: [{ type: "implicit_cast", message: "Implicit type cast on join" }],
+    }
+    const output = formatSemantics(data)
+    // severity ?? "warning" → defaults to "warning"
+    // rule ?? issue.type → uses type as fallback
+    expect(output).toContain("[warning] implicit_cast: Implicit type cast on join")
+  })
+
+  test("includes fix suggestions when present", () => {
+    const data = {
+      valid: false,
+      issues: [
+        {
+          severity: "warning",
+          rule: "null_comparison",
+          message: "= NULL should be IS NULL",
+          suggestion: "Change `WHERE col = NULL` to `WHERE col IS NULL`",
+        },
+      ],
+    }
+    const output = formatSemantics(data)
+    expect(output).toContain("Fix: Change `WHERE col = NULL` to `WHERE col IS NULL`")
+  })
+
+  test("omits fix line when suggestion is absent", () => {
+    const data = {
+      valid: false,
+      issues: [{ severity: "error", rule: "bad_join", message: "Wrong join condition" }],
+    }
+    const output = formatSemantics(data)
+    expect(output).not.toContain("Fix:")
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Adds 38 unit tests for pure formatting and error-extraction functions across three SQL analysis tools that previously had **zero direct test coverage**. These formatters produce every string users see when running SQL analysis commands.

**1. `formatCheckTitle` and `formatCheck` — `src/altimate/tools/altimate-core-check.ts`** (11 tests)

These functions format the output of the `altimate_core_check` composite pipeline (validate + lint + safety + PII). Added in PR #453, they had no tests. The formatters use negative conditionals (`!data.validation?.valid`) where `undefined` behaves like `false`, making them prone to subtle bugs when upstream response shapes change. Coverage includes:
- All-pass result returns "PASS"
- All-fail result lists every failure category
- Missing/undefined sections treated as failures (documents intentional behavior)
- Lint finding count with `?? 0` fallback when `findings` array is undefined
- Each output section (Validation, Lint, Safety, PII) formatted correctly
- Empty data object doesn't crash

**2. `extractEquivalenceErrors` and `formatEquivalence` — `src/altimate/tools/altimate-core-equivalence.ts`** (15 tests)

Error extraction was added in PR #429 to fix 6,905+ "unknown error" telemetry entries. These formatters had no tests despite being a critical fix. Coverage includes:
- String errors joined with semicolons
- Object errors with `.message` field extracted correctly
- Empty arrays and absent fields return `undefined`
- Falsy messages filtered out
- `data.error` short-circuits over `data.equivalent`
- Differences listed with `description` field and raw string fallback
- Confidence level shown when present
- **Bug discovered**: `null` entries in `validation_errors` crash with TypeError (`null.message` throws before `??` can evaluate). Test documents the bug.

**3. `extractSemanticsErrors` and `formatSemantics` — `src/altimate/tools/altimate-core-semantics.ts`** (12 tests)

Same pattern as equivalence — error extraction and result formatting for semantic SQL analysis. Coverage includes:
- Error extraction from nested `validation_errors` array
- Valid result shows clean message
- `valid=false` with empty issues produces header-only output (documents behavior)
- Issues listed with severity and rule, defaulting severity to "warning"
- Fix suggestions included when present, omitted when absent
- `data.error` short-circuits over `data.valid`

**Source changes**: Only change is adding `export` to 6 pure functions (no logic changes) so they can be imported by tests.

### Bug found

`extractEquivalenceErrors` (and `extractSemanticsErrors`, same code) crashes on `null` entries in `validation_errors`:
```typescript
// Line 71: e.message throws TypeError when e is null
.map((e: any) => (typeof e === "string" ? e : (e.message ?? String(e))))
```
The `??` operator cannot protect because property access on `null` throws first. This would affect users if napi-rs ever returns `[null, "real error"]` in `validation_errors`.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage from test-discovery

### How did you verify your code works?

```
bun test test/altimate/altimate-core-check-formatters.test.ts        # 11 pass
bun test test/altimate/altimate-core-equivalence-formatters.test.ts  # 15 pass
bun test test/altimate/altimate-core-semantics-formatters.test.ts    # 12 pass
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01Lz8zxrbwHXfsC2FbHxXZh9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization by making formatter utility functions publicly accessible across modules for better code reuse.

* **Tests**
  * Added comprehensive test coverage for check, equivalence, and semantics formatter modules to validate formatting and error extraction behavior across various input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->