### PR TITLE
test: stats display + MCP OAuth XSS prevention — 26 new tests

### DIFF
--- a/packages/opencode/test/cli/stats.test.ts
+++ b/packages/opencode/test/cli/stats.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for `altimate-code stats` display formatting.
+ *
+ * displayStats() is the primary user-facing output for the stats command.
+ * formatNumber (module-private) converts token counts to human-readable
+ * format (e.g., 1500 → "1.5K"). These tests verify formatting via the
+ * exported displayStats function to catch regressions in CLI output.
+ */
+import { describe, test, expect } from "bun:test"
+import { displayStats } from "../../src/cli/cmd/stats"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Capture console.log output from a synchronous function. */
+function captureOutput(fn: () => void): string {
+  const lines: string[] = []
+  const origLog = console.log
+  // displayStats also uses process.stdout.write for ANSI cursor movement
+  // in the model-usage section — we skip that branch by not passing modelLimit.
+  console.log = (...args: unknown[]) => lines.push(args.join(" "))
+  try {
+    fn()
+  } finally {
+    console.log = origLog
+  }
+  return lines.join("\n")
+}
+
+/** Minimal valid SessionStats — all zeroes. */
+function emptyStats() {
+  return {
+    totalSessions: 0,
+    totalMessages: 0,
+    totalCost: 0,
+    totalTokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    toolUsage: {} as Record<string, number>,
+    modelUsage: {} as Record<string, { messages: number; tokens: { input: number; output: number; cache: { read: number; write: number } }; cost: number }>,
+    dateRange: { earliest: Date.now(), latest: Date.now() },
+    days: 1,
+    costPerDay: 0,
+    tokensPerSession: 0,
+    medianTokensPerSession: 0,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// formatNumber via displayStats
+// ---------------------------------------------------------------------------
+
+describe("stats: formatNumber rendering", () => {
+  test("values under 1000 display as plain integer", () => {
+    const stats = emptyStats()
+    stats.totalTokens.input = 999
+    const out = captureOutput(() => displayStats(stats))
+    expect(out).toContain("999")
+    // Should not be formatted with K or M suffix
+    expect(out).not.toMatch(/999.*K/)
+  })
+
+  test("exactly 1000 displays as 1.0K", () => {
+    const stats = emptyStats()
+    stats.totalTokens.input = 1000
+    const out = captureOutput(() => displayStats(stats))
+    expect(out).toContain("1.0K")
+  })
+
+  test("1500 displays as 1.5K", () => {
+    const stats = emptyStats()
+    stats.totalTokens.input = 1500
+    const out = captureOutput(() => displayStats(stats))
+    expect(out).toContain("1.5K")
+  })
+
+  test("exactly 1000000 displays as 1.0M", () => {
+    const stats = emptyStats()
+    stats.totalTokens.input = 1_000_000
+    const out = captureOutput(() => displayStats(stats))
+    expect(out).toContain("1.0M")
+  })
+
+  test("2500000 displays as 2.5M", () => {
+    const stats = emptyStats()
+    stats.totalTokens.input = 2_500_000
+    const out = captureOutput(() => displayStats(stats))
+    expect(out).toContain("2.5M")
+  })
+
+  test("zero displays as 0", () => {
+    const stats = emptyStats()
+    const out = captureOutput(() => displayStats(stats))
+    // Input line should show 0, not "0K" or empty
+    expect(out).toMatch(/Input\s+0\s/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// displayStats: cost and NaN safety
+// ---------------------------------------------------------------------------
+
+describe("stats: cost display safety", () => {
+  test("zero cost renders as $0.00, never NaN", () => {
+    const stats = emptyStats()
+    const out = captureOutput(() => displayStats(stats))
+    expect(out).not.toContain("NaN")
+    expect(out).toContain("$0.00")
+  })
+
+  test("fractional cost renders with two decimal places", () => {
+    const stats = emptyStats()
+    stats.totalCost = 1.234
+    stats.costPerDay = 0.617
+    const out = captureOutput(() => displayStats(stats))
+    expect(out).toContain("$1.23")
+    expect(out).toContain("$0.62")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// displayStats: tool usage rendering
+// ---------------------------------------------------------------------------
+
+describe("stats: tool usage display", () => {
+  test("tool usage shows bar chart with percentages", () => {
+    const stats = emptyStats()
+    stats.toolUsage = { read: 50, write: 30, bash: 20 }
+    const out = captureOutput(() => displayStats(stats))
+    expect(out).toContain("TOOL USAGE")
+    expect(out).toContain("read")
+    expect(out).toContain("write")
+    expect(out).toContain("bash")
+    // Percentages should be present
+    expect(out).toContain("%")
+  })
+
+  test("tool limit restricts number of tools shown", () => {
+    const stats = emptyStats()
+    stats.toolUsage = { read: 50, write: 30, bash: 20, edit: 10, glob: 5 }
+    const out = captureOutput(() => displayStats(stats, 2))
+    // Only top 2 tools should appear (read and write by count)
+    expect(out).toContain("read")
+    expect(out).toContain("write")
+    expect(out).not.toContain("glob")
+  })
+
+  test("empty tool usage omits TOOL USAGE section", () => {
+    const stats = emptyStats()
+    stats.toolUsage = {}
+    const out = captureOutput(() => displayStats(stats))
+    expect(out).not.toContain("TOOL USAGE")
+  })
+
+  test("long tool names are truncated", () => {
+    const stats = emptyStats()
+    stats.toolUsage = { "a_very_long_tool_name_that_exceeds_limit": 10 }
+    const out = captureOutput(() => displayStats(stats))
+    // Tool name should be truncated to fit the column
+    expect(out).toContain("..")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// displayStats: overview section
+// ---------------------------------------------------------------------------
+
+describe("stats: overview section", () => {
+  test("renders session and message counts", () => {
+    const stats = emptyStats()
+    stats.totalSessions = 42
+    stats.totalMessages = 1337
+    const out = captureOutput(() => displayStats(stats))
+    expect(out).toContain("OVERVIEW")
+    expect(out).toContain("42")
+    expect(out).toContain("1,337")
+  })
+
+  test("renders box-drawing borders", () => {
+    const stats = emptyStats()
+    const out = captureOutput(() => displayStats(stats))
+    expect(out).toContain("┌")
+    expect(out).toContain("┘")
+    expect(out).toContain("│")
+  })
+})

--- a/packages/opencode/test/mcp/oauth-callback.test.ts
+++ b/packages/opencode/test/mcp/oauth-callback.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for MCP OAuth callback server — XSS prevention and HTTP behavior.
+ *
+ * The OAuth callback page renders error messages from external MCP servers.
+ * If escapeHtml (module-private) fails to sanitize these strings, a malicious
+ * server could inject scripts into the user's browser via error_description.
+ *
+ * Tests exercise the server at the HTTP level since escapeHtml is not exported.
+ */
+import { describe, test, expect, afterEach, beforeEach } from "bun:test"
+
+const { McpOAuthCallback } = await import("../../src/mcp/oauth-callback")
+const { OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_PATH } = await import("../../src/mcp/oauth-provider")
+
+const BASE_URL = `http://127.0.0.1:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`
+
+beforeEach(async () => {
+  // Ensure clean state — stop any leftover server
+  await McpOAuthCallback.stop()
+  await McpOAuthCallback.ensureRunning()
+})
+
+afterEach(async () => {
+  await McpOAuthCallback.stop()
+})
+
+// ---------------------------------------------------------------------------
+// XSS prevention
+// ---------------------------------------------------------------------------
+
+describe("OAuth callback: XSS prevention in error page", () => {
+  test("escapes <script> tags in error_description", async () => {
+    const xss = "<script>alert(1)</script>"
+    const url = `${BASE_URL}?error=access_denied&error_description=${encodeURIComponent(xss)}&state=test-state`
+    const res = await fetch(url)
+    const body = await res.text()
+
+    // The raw <script> must never appear in the response
+    expect(body).not.toContain("<script>")
+    expect(body).toContain("&lt;script&gt;")
+  })
+
+  test("escapes HTML entities in error_description", async () => {
+    const payload = 'foo & bar < baz > "qux"'
+    const url = `${BASE_URL}?error=access_denied&error_description=${encodeURIComponent(payload)}&state=test-state`
+    const res = await fetch(url)
+    const body = await res.text()
+
+    expect(body).toContain("foo &amp; bar")
+    expect(body).toContain("&lt; baz &gt;")  // < and > escaped
+    expect(body).toContain("&quot;qux&quot;")
+  })
+
+  test("escapes img onerror XSS vector", async () => {
+    const xss = '<img src=x onerror="alert(1)">'
+    const url = `${BASE_URL}?error=access_denied&error_description=${encodeURIComponent(xss)}&state=test-state`
+    const res = await fetch(url)
+    const body = await res.text()
+
+    expect(body).not.toContain("<img")
+    expect(body).toContain("&lt;img")
+  })
+
+  test("escapes event handler injection", async () => {
+    const xss = '" onmouseover="alert(1)" data-x="'
+    const url = `${BASE_URL}?error=access_denied&error_description=${encodeURIComponent(xss)}&state=test-state`
+    const res = await fetch(url)
+    const body = await res.text()
+
+    // Double quotes must be escaped
+    expect(body).toContain("&quot;")
+    expect(body).not.toContain('onmouseover="alert')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// HTTP behavior
+// ---------------------------------------------------------------------------
+
+describe("OAuth callback: HTTP behavior", () => {
+  test("returns 404 for non-callback paths", async () => {
+    const res = await fetch(`http://127.0.0.1:${OAUTH_CALLBACK_PORT}/not-a-callback`)
+    expect(res.status).toBe(404)
+  })
+
+  test("returns 400 when state parameter is missing", async () => {
+    const url = `${BASE_URL}?error=access_denied&error_description=test`
+    const res = await fetch(url)
+    expect(res.status).toBe(400)
+    const body = await res.text()
+    expect(body).toContain("Missing required state parameter")
+  })
+
+  test("returns 400 when code is missing (no error)", async () => {
+    const url = `${BASE_URL}?state=some-state`
+    const res = await fetch(url)
+    expect(res.status).toBe(400)
+    const body = await res.text()
+    expect(body).toContain("No authorization code")
+  })
+
+  test("returns HTML content type for error pages", async () => {
+    const url = `${BASE_URL}?error=access_denied&error_description=test&state=test-state`
+    const res = await fetch(url)
+    expect(res.headers.get("content-type")).toContain("text/html")
+  })
+
+  test("invalid state returns error about CSRF", async () => {
+    // Register no pending auth, so any state is invalid
+    const url = `${BASE_URL}?code=test-code&state=unknown-state`
+    const res = await fetch(url)
+    expect(res.status).toBe(400)
+    const body = await res.text()
+    expect(body).toContain("Invalid or expired state")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Server lifecycle
+// ---------------------------------------------------------------------------
+
+describe("OAuth callback: server lifecycle", () => {
+  test("isRunning returns true after ensureRunning", () => {
+    expect(McpOAuthCallback.isRunning()).toBe(true)
+  })
+
+  test("isRunning returns false after stop", async () => {
+    await McpOAuthCallback.stop()
+    expect(McpOAuthCallback.isRunning()).toBe(false)
+  })
+
+  test("ensureRunning is idempotent", async () => {
+    // Server already running from beforeEach
+    await McpOAuthCallback.ensureRunning()
+    expect(McpOAuthCallback.isRunning()).toBe(true)
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Adds first-ever test coverage for two completely untested modules: the `altimate-code stats` CLI output formatter and the MCP OAuth callback server's HTML escaping (XSS prevention boundary).

**1. `displayStats` and `formatNumber` — `src/cli/cmd/stats.ts`** (14 new tests)

The `altimate-code stats` command had zero test coverage. `formatNumber` (module-private) converts token counts to human-readable K/M suffixes, and `displayStats` renders the full terminal output with box-drawing, tool usage bar charts, and cost summaries. Tests exercise these via the exported `displayStats` function with mock `SessionStats` objects. Coverage includes:

- `formatNumber` rendering: values under 1000, exactly 1000 (→ "1.0K"), 1500 (→ "1.5K"), 1M, 2.5M, and zero
- Cost display: NaN safety for zero costs, fractional cost rounding
- Tool usage: bar chart rendering with percentages, tool limit enforcement, empty tool list omission, long tool name truncation
- Overview section: session/message counts, box-drawing borders

**2. `escapeHtml` + HTTP behavior — `src/mcp/oauth-callback.ts`** (12 new tests)

The OAuth callback server renders error messages from external MCP servers in an HTML page. The `escapeHtml` function (module-private) is the XSS prevention boundary — if it fails, a malicious MCP server could inject scripts via `error_description`. Tests exercise the server at the HTTP level (since `escapeHtml` is not exported). Coverage includes:

- XSS prevention: `<script>` tag escaping, HTML entity escaping (`&`, `<`, `>`, `"`), `<img onerror>` vector, event handler injection via double-quote breakout
- HTTP behavior: 404 for non-callback paths, 400 for missing state parameter (CSRF protection), 400 for missing auth code, HTML content-type headers, invalid state rejection
- Server lifecycle: `isRunning` after start/stop, idempotent `ensureRunning`

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage from automated test discovery

### How did you verify your code works?

```
bun test test/cli/stats.test.ts          # 14 pass, 27 assertions
bun test test/mcp/oauth-callback.test.ts # 12 pass, 20 assertions
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for CLI stats output formatting, token/cost rendering, and tool usage display.
  * Added test suite for OAuth callback server functionality, including XSS prevention validation and HTTP error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->