### PR TITLE
test: session compaction — observation mask and arg truncation

### DIFF
--- a/packages/opencode/test/session/compaction-mask.test.ts
+++ b/packages/opencode/test/session/compaction-mask.test.ts
@@ -1,0 +1,168 @@
+import { describe, test, expect } from "bun:test"
+import { SessionCompaction } from "../../src/session/compaction"
+import type { MessageV2 } from "../../src/session/message-v2"
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeCompletedPart(overrides: {
+  tool?: string
+  input?: Record<string, any>
+  output?: string
+}): MessageV2.ToolPart {
+  return {
+    id: "part-1",
+    sessionID: "session-1",
+    messageID: "msg-1",
+    type: "tool",
+    callID: "call-1",
+    tool: overrides.tool ?? "read",
+    state: {
+      status: "completed",
+      input: overrides.input ?? {},
+      output: overrides.output ?? "",
+      title: "test",
+      metadata: {},
+      time: { start: 1000, end: 2000 },
+    },
+  } as MessageV2.ToolPart
+}
+
+function makePendingPart(overrides?: { tool?: string }): MessageV2.ToolPart {
+  return {
+    id: "part-1",
+    sessionID: "session-1",
+    messageID: "msg-1",
+    type: "tool",
+    callID: "call-1",
+    tool: overrides?.tool ?? "bash",
+    state: {
+      status: "pending",
+      input: { command: "ls -la" },
+      raw: '{"command":"ls -la"}',
+    },
+  } as MessageV2.ToolPart
+}
+
+// ─── createObservationMask: completed tool parts ────────────────────────────
+
+describe("SessionCompaction.createObservationMask", () => {
+  test("includes tool name, args, line count, byte size, and fingerprint for completed part", () => {
+    const part = makeCompletedPart({
+      tool: "bash",
+      input: { command: "git status" },
+      output: "On branch main\nnothing to commit, working tree clean\n",
+    })
+    const mask = SessionCompaction.createObservationMask(part)
+
+    expect(mask).toContain("[Tool output cleared")
+    expect(mask).toContain("bash(")
+    expect(mask).toContain('command: "git status"')
+    expect(mask).toContain("3 lines")
+    expect(mask).toContain("— \"On branch main\"")
+    // Byte size should be present
+    expect(mask).toMatch(/\d+ B/)
+  })
+
+  test("omits fingerprint when output is empty", () => {
+    const part = makeCompletedPart({ tool: "read", output: "" })
+    const mask = SessionCompaction.createObservationMask(part)
+
+    expect(mask).toContain("read()")
+    expect(mask).toContain("1 lines")
+    expect(mask).toContain("0 B")
+    // No fingerprint: the mask should end with the byte size then ] (no trailing — "...")
+    expect(mask).not.toContain('— "')
+    expect(mask).toMatch(/0 B\]$/)
+  })
+
+  test("shows empty args for pending status (falls through to {} path)", () => {
+    const part = makePendingPart({ tool: "bash" })
+    const mask = SessionCompaction.createObservationMask(part)
+
+    // Pending status → output is "" (since only completed reads output)
+    // Pending status → args from {} (not from input)
+    expect(mask).toContain("bash()")
+    expect(mask).toContain("1 lines")
+    expect(mask).toContain("0 B")
+  })
+
+  test("handles completed part with multi-line output", () => {
+    const lines = Array.from({ length: 100 }, (_, i) => `line ${i + 1}`)
+    const output = lines.join("\n")
+    const part = makeCompletedPart({ tool: "grep", output })
+    const mask = SessionCompaction.createObservationMask(part)
+
+    expect(mask).toContain("100 lines")
+    expect(mask).toContain("— \"line 1\"")
+  })
+
+  test("truncates long args with ellipsis", () => {
+    const longValue = "x".repeat(200)
+    const part = makeCompletedPart({
+      tool: "write",
+      input: { file_path: "/some/file.ts", content: longValue },
+      output: "ok",
+    })
+    const mask = SessionCompaction.createObservationMask(part)
+
+    // Args should be truncated (maxLen=80) and end with "…"
+    expect(mask).toContain("write(")
+    expect(mask).toContain("…")
+    // The full 200-char value should NOT appear
+    expect(mask).not.toContain(longValue)
+  })
+
+  test("handles unserializable input gracefully", () => {
+    // Create a circular reference that JSON.stringify can't handle
+    const circular: Record<string, any> = { key: "value" }
+    circular.self = circular
+
+    const part = makeCompletedPart({
+      tool: "bash",
+      input: circular,
+      output: "result",
+    })
+    const mask = SessionCompaction.createObservationMask(part)
+
+    expect(mask).toContain("bash([unserializable])")
+  })
+
+  test("formats byte size in KB for larger outputs", () => {
+    // 2048 bytes → should display as "2.0 KB"
+    const output = "a".repeat(2048)
+    const part = makeCompletedPart({ tool: "read", output })
+    const mask = SessionCompaction.createObservationMask(part)
+
+    expect(mask).toContain("2.0 KB")
+  })
+
+  test("formats byte size in MB for very large outputs", () => {
+    // 1.5 MB output
+    const output = "b".repeat(1024 * 1024 + 512 * 1024)
+    const part = makeCompletedPart({ tool: "read", output })
+    const mask = SessionCompaction.createObservationMask(part)
+
+    expect(mask).toContain("1.5 MB")
+  })
+
+  test("correctly counts bytes for multi-byte UTF-8 characters", () => {
+    // Each CJK character is 3 bytes in UTF-8
+    const output = "你好世界" // 4 chars × 3 bytes = 12 bytes
+    const part = makeCompletedPart({ tool: "read", output })
+    const mask = SessionCompaction.createObservationMask(part)
+
+    expect(mask).toContain("12 B")
+    expect(mask).toContain("— \"你好世界\"")
+  })
+
+  test("fingerprint is capped at 80 characters", () => {
+    const longFirstLine = "z".repeat(200)
+    const part = makeCompletedPart({ tool: "bash", output: longFirstLine })
+    const mask = SessionCompaction.createObservationMask(part)
+
+    // The fingerprint should contain the first 80 chars, not all 200
+    const fingerprint80 = "z".repeat(80)
+    expect(mask).toContain(`— "${fingerprint80}"`)
+    expect(mask).not.toContain("z".repeat(81))
+  })
+})


### PR DESCRIPTION
## Summary

### What does this PR do?

**1. `SessionCompaction.createObservationMask()` — `src/session/compaction.ts`** (10 new tests)

This function generates the replacement text that substitutes pruned tool outputs during session compaction. When a long session triggers pruning, old tool call results are replaced with a compact summary like `[Tool output cleared — bash(command: "git status") returned 3 lines, 45 B — "On branch main"]`. Zero tests existed for this function or its internal helpers (`truncateArgs`, `formatBytes`).

**Why it matters:** Every long-running session that triggers compaction relies on these masks to preserve context about what tools were previously called. A malformed mask means the model loses track of prior work — causing it to re-read files, re-run commands, or lose context about the task.

**Scenarios covered:**
- Full mask format verification (tool name, args, line count, byte size, fingerprint)
- Empty output produces no fingerprint suffix
- Pending status falls through to empty args path (not completed/running/error)
- Multi-line output counts lines correctly
- Long args are truncated at 80 chars with "…" suffix
- Circular/unserializable input gracefully returns `[unserializable]`
- KB formatting for ~2KB outputs
- MB formatting for ~1.5MB outputs
- Multi-byte UTF-8 characters (CJK) counted correctly in bytes
- Fingerprint capped at 80 characters from first output line

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage discovered via test-discovery rotation (session area)

### How did you verify your code works?

```
bun test test/session/compaction-mask.test.ts   # 10 pass, 26 expect() calls
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for observation mask generation functionality, covering various scenarios including tool execution handling, output formatting, size calculations, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->