### PR TITLE
test: bus — publish/subscribe/once/unsubscribe mechanics

### DIFF
--- a/packages/opencode/test/bus/bus.test.ts
+++ b/packages/opencode/test/bus/bus.test.ts
@@ -1,0 +1,127 @@
+import { describe, test, expect } from "bun:test"
+import z from "zod"
+import { Bus } from "../../src/bus"
+import { BusEvent } from "../../src/bus/bus-event"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+
+const TestEvent = BusEvent.define("__test_bus_pub_sub", z.object({ value: z.string() }))
+const OtherEvent = BusEvent.define("__test_bus_other_type", z.object({ n: z.number() }))
+
+describe("Bus: publish and subscribe", () => {
+  test("subscriber receives published event", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const received: any[] = []
+        const unsub = Bus.subscribe(TestEvent, (e) => received.push(e))
+        await Bus.publish(TestEvent, { value: "hello" })
+        expect(received).toHaveLength(1)
+        expect(received[0].properties.value).toBe("hello")
+        unsub()
+      },
+    })
+  })
+
+  test("unsubscribe stops receiving events", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const received: any[] = []
+        const unsub = Bus.subscribe(TestEvent, (e) => received.push(e))
+        await Bus.publish(TestEvent, { value: "first" })
+        unsub()
+        await Bus.publish(TestEvent, { value: "second" })
+        expect(received).toHaveLength(1)
+      },
+    })
+  })
+
+  test("multiple subscribers receive the same event", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const a: any[] = []
+        const b: any[] = []
+        const unsub1 = Bus.subscribe(TestEvent, (e) => a.push(e))
+        const unsub2 = Bus.subscribe(TestEvent, (e) => b.push(e))
+        await Bus.publish(TestEvent, { value: "shared" })
+        expect(a).toHaveLength(1)
+        expect(b).toHaveLength(1)
+        unsub1()
+        unsub2()
+      },
+    })
+  })
+
+  test("subscriber only receives matching event type", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const received: any[] = []
+        const unsub = Bus.subscribe(TestEvent, (e) => received.push(e))
+        await Bus.publish(OtherEvent, { n: 42 })
+        expect(received).toHaveLength(0)
+        unsub()
+      },
+    })
+  })
+})
+
+describe("Bus: subscribeAll wildcard", () => {
+  test("wildcard subscriber receives all event types", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const received: any[] = []
+        const unsub = Bus.subscribeAll((e) => received.push(e))
+        await Bus.publish(TestEvent, { value: "a" })
+        await Bus.publish(OtherEvent, { n: 1 })
+        expect(received).toHaveLength(2)
+        unsub()
+      },
+    })
+  })
+})
+
+describe("Bus: once", () => {
+  test("once unsubscribes after callback returns 'done'", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        let count = 0
+        Bus.once(TestEvent, () => {
+          count++
+          return "done"
+        })
+        await Bus.publish(TestEvent, { value: "first" })
+        await Bus.publish(TestEvent, { value: "second" })
+        expect(count).toBe(1)
+      },
+    })
+  })
+
+  test("once continues if callback returns undefined", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        let count = 0
+        Bus.once(TestEvent, () => {
+          count++
+          return count >= 2 ? "done" : undefined
+        })
+        await Bus.publish(TestEvent, { value: "1" })
+        await Bus.publish(TestEvent, { value: "2" })
+        await Bus.publish(TestEvent, { value: "3" })
+        expect(count).toBe(2)
+      },
+    })
+  })
+})


### PR DESCRIPTION
### What does this PR do?

**1. `Bus` publish/subscribe/once/unsubscribe — `src/bus/index.ts`** (7 new tests)

The core event Bus powers session updates, permission prompts, file watcher notifications, and SSE delivery to the TUI. **Zero dedicated unit tests existed** — Bus was only tested indirectly as a side-channel in session/edit/pty tests. A regression in `subscribe()`, the `splice`-based unsubscribe, `once()` auto-removal, or wildcard (`*`) delivery would silently break every event-driven feature.

New coverage includes:
- **Subscriber delivery**: published events reach registered subscribers with correct payload
- **Unsubscribe correctness**: calling the returned unsub function stops delivery; no leaked subscriptions
- **Multiple subscribers**: two subscribers on the same event type both receive the event
- **Type isolation**: subscriber for event A does not receive events of type B
- **Wildcard subscribeAll**: `subscribeAll` receives events of all types
- **Bus.once with immediate done**: callback returning `"done"` on first call unsubscribes automatically
- **Bus.once with deferred done**: callback returning `undefined` continues receiving until it returns `"done"`

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage for core infrastructure with zero existing dedicated tests.

### How did you verify your code works?

```
bun test test/bus/bus.test.ts       # 7 pass, 9 expect() calls
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01GchE7rUZayV1ouLEseVndK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for bus publish/subscribe behavior, including single and multiple subscribers, event type filtering, wildcard subscriptions, and one-time subscription semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->