### PR TITLE
test: lazy utility and credential-store — error retry, reset, sensitive field coverage

### DIFF
--- a/packages/opencode/test/altimate/connections.test.ts
+++ b/packages/opencode/test/altimate/connections.test.ts
@@ -248,6 +248,17 @@ describe("CredentialStore", () => {
     expect(CredentialStore.isSensitiveField("authenticator")).toBe(false)
   })
 
+  // altimate_change start — cover remaining SENSITIVE_FIELDS entries not in the test above
+  test("isSensitiveField covers BigQuery, SSL, and SSH credential fields", () => {
+    expect(CredentialStore.isSensitiveField("credentials_json")).toBe(true)
+    expect(CredentialStore.isSensitiveField("keyfile_json")).toBe(true)
+    expect(CredentialStore.isSensitiveField("ssl_key")).toBe(true)
+    expect(CredentialStore.isSensitiveField("ssl_cert")).toBe(true)
+    expect(CredentialStore.isSensitiveField("ssl_ca")).toBe(true)
+    expect(CredentialStore.isSensitiveField("ssh_password")).toBe(true)
+  })
+  // altimate_change end
+
   test("saveConnection strips inline private_key as sensitive", async () => {
     const config = { type: "snowflake", private_key: "-----BEGIN PRIVATE KEY-----\nMIIE..." } as any
     const { sanitized, warnings } = await CredentialStore.saveConnection("sf_keypair", config)

--- a/packages/opencode/test/util/lazy.test.ts
+++ b/packages/opencode/test/util/lazy.test.ts
@@ -34,6 +34,49 @@ describe("util.lazy", () => {
     expect(result1).toBe(result2)
   })
 
+  // altimate_change start — test reset() and error-retry behavior
+  test("reset() clears cached value and re-invokes factory", () => {
+    let count = 0
+    const getValue = lazy(() => ++count)
+
+    expect(getValue()).toBe(1)
+    expect(getValue()).toBe(1) // cached
+
+    getValue.reset()
+
+    expect(getValue()).toBe(2) // re-invoked
+    expect(getValue()).toBe(2) // cached again
+  })
+
+  test("factory error is not cached — retries on next call", () => {
+    let shouldFail = true
+    const getValue = lazy(() => {
+      if (shouldFail) throw new Error("transient failure")
+      return "success"
+    })
+
+    expect(() => getValue()).toThrow("transient failure")
+
+    shouldFail = false
+    expect(getValue()).toBe("success") // retries and succeeds
+    expect(getValue()).toBe("success") // now cached
+  })
+
+  test("reset() after error allows fresh initialization", () => {
+    let attempt = 0
+    const getValue = lazy(() => {
+      attempt++
+      if (attempt === 1) throw new Error("first call fails")
+      return `attempt-${attempt}`
+    })
+
+    expect(() => getValue()).toThrow("first call fails")
+
+    getValue.reset()
+    expect(getValue()).toBe("attempt-2")
+  })
+  // altimate_change end
+
   test("should work with different return types", () => {
     const lazyString = lazy(() => "string")
     const lazyNumber = lazy(() => 123)


### PR DESCRIPTION
### What does this PR do?

**1. `lazy()` — `src/util/lazy.ts`** (3 new tests)

The `lazy()` utility powers critical initialization paths including `Shell.preferred` and `Shell.acceptable` (which determine which shell is used for all tool execution). The existing 3 tests only covered basic memoization and type support — two important behaviors were completely untested:

- **Error non-caching:** When the factory function throws (e.g., a transient `which` failure during shell detection), the error must NOT be cached. The next call should retry the factory. Without this, a single transient failure would permanently break shell detection for the entire session.
- **`reset()` method:** Used in Shell tests' `beforeEach`/`afterEach` and by the file watcher, but never directly tested. Verifies that `reset()` clears both the cached value and the loaded flag, causing the factory to be re-invoked on the next call.

Specific scenarios covered:
- `reset()` clears cached value and re-invokes factory
- Factory error is not cached — retries on next call
- `reset()` after error allows fresh initialization

**2. `isSensitiveField` — `src/altimate/native/connections/credential-store.ts`** (1 new test)

The `SENSITIVE_FIELDS` set in `credential-store.ts` contains 20 field names that should be stripped from config files and stored in the OS keychain. The existing unit test for `isSensitiveField` covered 14 of 20 fields. This PR adds explicit assertions for the remaining 6 fields:

- `credentials_json` — BigQuery service account credentials
- `keyfile_json` — BigQuery keyfile content
- `ssl_key`, `ssl_cert`, `ssl_ca` — TLS/SSL connection credentials
- `ssh_password` — SSH tunnel authentication

These fields are already correctly handled by the implementation, but without explicit test coverage a future refactor could accidentally remove them from the set without any test failure.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage

### How did you verify your code works?

```
bun test test/util/lazy.test.ts           # 6 pass (3 existing + 3 new)
bun test test/altimate/connections.test.ts # 69 pass (68 existing + 1 new)
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01WoqeutgfwXNcktweCKoLwd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Enhanced test coverage for credential field security validation to ensure sensitive credential fields are properly protected
* Expanded test suite for lazy loading utilities, including reset functionality and error handling scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->