### PR TITLE
test: session todo — CRUD lifecycle with database persistence

### DIFF
--- a/packages/opencode/test/session/todo.test.ts
+++ b/packages/opencode/test/session/todo.test.ts
@@ -1,0 +1,162 @@
+import { describe, test, expect } from "bun:test"
+import path from "path"
+import { Session } from "../../src/session"
+import { Todo } from "../../src/session/todo"
+import { Bus } from "../../src/bus"
+import { Log } from "../../src/util/log"
+import { Instance } from "../../src/project/instance"
+
+const projectRoot = path.join(__dirname, "../..")
+Log.init({ print: false })
+
+describe("Todo: CRUD lifecycle", () => {
+  test("update then get returns todos in order", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({})
+        const todos = [
+          { content: "Fix SQL query", status: "pending", priority: "high" },
+          { content: "Add index", status: "in_progress", priority: "medium" },
+          { content: "Write docs", status: "completed", priority: "low" },
+        ]
+
+        Todo.update({ sessionID: session.id, todos })
+
+        const result = Todo.get(session.id)
+        expect(result).toHaveLength(3)
+        expect(result[0].content).toBe("Fix SQL query")
+        expect(result[0].status).toBe("pending")
+        expect(result[0].priority).toBe("high")
+        expect(result[1].content).toBe("Add index")
+        expect(result[2].content).toBe("Write docs")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("update with empty array clears all todos", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({})
+
+        Todo.update({
+          sessionID: session.id,
+          todos: [{ content: "Task A", status: "pending", priority: "high" }],
+        })
+        expect(Todo.get(session.id)).toHaveLength(1)
+
+        Todo.update({ sessionID: session.id, todos: [] })
+        expect(Todo.get(session.id)).toHaveLength(0)
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("update replaces previous todos entirely", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({})
+
+        Todo.update({
+          sessionID: session.id,
+          todos: [
+            { content: "Old task 1", status: "pending", priority: "high" },
+            { content: "Old task 2", status: "pending", priority: "medium" },
+          ],
+        })
+        expect(Todo.get(session.id)).toHaveLength(2)
+
+        Todo.update({
+          sessionID: session.id,
+          todos: [{ content: "New task", status: "in_progress", priority: "low" }],
+        })
+
+        const result = Todo.get(session.id)
+        expect(result).toHaveLength(1)
+        expect(result[0].content).toBe("New task")
+        expect(result[0].status).toBe("in_progress")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("get returns empty array for session with no todos", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({})
+
+        const result = Todo.get(session.id)
+        expect(result).toEqual([])
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("publishes Todo.Event.Updated on update", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({})
+        let eventReceived = false
+        let receivedTodos: Todo.Info[] = []
+
+        const unsub = Bus.subscribe(Todo.Event.Updated, (event) => {
+          if (event.properties.sessionID === session.id) {
+            eventReceived = true
+            receivedTodos = event.properties.todos
+          }
+        })
+
+        const todos = [{ content: "Emit test", status: "pending", priority: "high" }]
+        Todo.update({ sessionID: session.id, todos })
+
+        await new Promise((resolve) => setTimeout(resolve, 50))
+
+        unsub()
+
+        expect(eventReceived).toBe(true)
+        expect(receivedTodos).toHaveLength(1)
+        expect(receivedTodos[0].content).toBe("Emit test")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("todos are isolated between sessions", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session1 = await Session.create({})
+        const session2 = await Session.create({})
+
+        Todo.update({
+          sessionID: session1.id,
+          todos: [{ content: "Session 1 task", status: "pending", priority: "high" }],
+        })
+        Todo.update({
+          sessionID: session2.id,
+          todos: [
+            { content: "Session 2 task A", status: "pending", priority: "medium" },
+            { content: "Session 2 task B", status: "completed", priority: "low" },
+          ],
+        })
+
+        expect(Todo.get(session1.id)).toHaveLength(1)
+        expect(Todo.get(session1.id)[0].content).toBe("Session 1 task")
+        expect(Todo.get(session2.id)).toHaveLength(2)
+
+        await Session.remove(session1.id)
+        await Session.remove(session2.id)
+      },
+    })
+  })
+})


### PR DESCRIPTION
### What does this PR do?

**1. `Todo.update` and `Todo.get` — `src/session/todo.ts`** (6 new tests)

The `Todo` module manages the task tracking panel visible in the TUI. It persists todos to SQLite via a delete-then-insert transaction and publishes bus events for real-time TUI updates. **Zero tests existed** for this module despite it being directly user-facing — a bug here would cause phantom, stale, or missing tasks in the todo panel.

New coverage includes:
- **Insert/get round-trip**: verifies todos are persisted and returned with correct content, status, and priority
- **Position ordering**: confirms `Todo.get` returns items in the same order they were inserted (relies on `orderBy(asc(TodoTable.position))`)
- **Empty-array clear**: exercises the branch where `todos.length === 0` — only the delete runs, no insert
- **Replacement semantics**: verifies that calling `update` replaces all previous todos (no phantom rows from prior updates)
- **Bus event emission**: confirms `Todo.Event.Updated` is published with the correct sessionID and todo payload
- **Cross-session isolation**: ensures todos from one session don't leak into another session's `get()` results

### Why was this untested?

The `Todo` module was added as part of the session layer but had no corresponding test file. The database interaction (transactional delete + insert with position tracking) and bus event emission are exactly the kind of behavior that should be pinned by tests to prevent TUI regressions.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage from automated test discovery

### How did you verify your code works?

```
bun test test/session/todo.test.ts       # 6 pass, 19 expect() calls
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_017d5YhygKiAiYYF2EPdckKR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for todo CRUD operations, persistence per session, event publishing, and session isolation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->