### PR TITLE
test: agent — .env read protection and analyst write denial

### DIFF
--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -810,3 +810,52 @@ test("analyst prompt contains /data-viz skill", async () => {
     },
   })
 })
+
+// --- .env read protection tests ---
+
+test("builder agent asks for .env file reads but allows regular files", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const builder = await Agent.get("builder")
+      expect(builder).toBeDefined()
+      // .env files require user approval (security: prevents accidental secret exposure)
+      expect(PermissionNext.evaluate("read", ".env", builder!.permission).action).toBe("ask")
+      expect(PermissionNext.evaluate("read", ".env.local", builder!.permission).action).toBe("ask")
+      expect(PermissionNext.evaluate("read", ".env.production", builder!.permission).action).toBe("ask")
+      expect(PermissionNext.evaluate("read", "config/.env.staging", builder!.permission).action).toBe("ask")
+      // Regular files are allowed without prompting
+      expect(PermissionNext.evaluate("read", "src/index.ts", builder!.permission).action).toBe("allow")
+      expect(PermissionNext.evaluate("read", "package.json", builder!.permission).action).toBe("allow")
+      // .env.example is explicitly allowed (safe to share)
+      expect(PermissionNext.evaluate("read", ".env.example", builder!.permission).action).toBe("allow")
+    },
+  })
+})
+
+// --- analyst agent write denial tests ---
+
+test("analyst agent denies file modification and todo tools", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const analyst = await Agent.get("analyst")
+      expect(analyst).toBeDefined()
+      // Analyst is read-only — file modification tools should be denied.
+      // The analyst config starts with "*": "deny" then selectively allows
+      // read-only tools. edit/write/todowrite are not in the allow list,
+      // so they fall through to the catch-all deny.
+      expect(evalPerm(analyst, "edit")).toBe("deny")
+      expect(evalPerm(analyst, "write")).toBe("deny")
+      expect(evalPerm(analyst, "todowrite")).toBe("deny")
+      expect(evalPerm(analyst, "todoread")).toBe("deny")
+      // Read operations are explicitly allowed after the "*": "deny" base,
+      // so last-match-wins produces "allow"
+      expect(evalPerm(analyst, "read")).toBe("allow")
+      expect(evalPerm(analyst, "grep")).toBe("allow")
+      expect(evalPerm(analyst, "glob")).toBe("allow")
+    },
+  })
+})


### PR DESCRIPTION
## Summary

Proactive test coverage for two security-relevant agent permission gaps discovered during exhaustive test-discovery analysis.

**1. Builder agent `.env` read protection** — `src/agent/agent.ts` (lines 72-77) (7 new assertions)

The agent defaults configure `read: { "*": "allow", "*.env": "ask", "*.env.*": "ask", "*.env.example": "allow" }` to prevent accidental secret exposure when reading `.env` files. While other permission defaults (edit, bash, doom_loop, external_directory, sql_execute_write) had dedicated tests, the `.env` read protection was never verified. A regression removing the `*.env` ask rule would go undetected.

New coverage includes:
- `.env`, `.env.local`, `.env.production`, and nested `config/.env.staging` all require "ask"
- Regular files (`src/index.ts`, `package.json`) remain "allow"
- `.env.example` is explicitly "allow" (safe to share)

**2. Analyst agent file modification denial** — `src/agent/agent.ts` (lines 161-207) (7 new assertions)

The analyst agent is documented as "Read-only data exploration and analysis. Cannot modify files." Existing tests verified `sql_execute_write` denial and specific bash command restrictions, but never checked that core file-modification tools (`edit`, `write`, `todowrite`, `todoread`) are denied. A regression adding these tools to the analyst's allow list would go undetected.

New coverage includes:
- `edit`, `write`, `todowrite`, `todoread` all evaluate to "deny"
- `read`, `grep`, `glob` remain "allow" (analyst's explicit overrides after the catch-all deny)

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage from test-discovery analysis

### How did you verify your code works?

```
bun test test/agent/agent.test.ts       # 45 pass (43 existing + 2 new)
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01Wp9YaEvw6jAAL73VVdXFxA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for agent permission and access control validation, including verification of file read/write permissions and environment-specific file handling across different agent types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->