### PR TITLE
test: docker discovery + copilot provider compatibility

### DIFF
--- a/packages/opencode/test/altimate/docker-discovery.test.ts
+++ b/packages/opencode/test/altimate/docker-discovery.test.ts
@@ -1,0 +1,131 @@
+import { describe, test, expect } from "bun:test"
+import { containerToConfig } from "../../src/altimate/native/connections/docker-discovery"
+import type { DockerContainer } from "../../src/altimate/native/types"
+
+describe("containerToConfig: full container with all fields", () => {
+  test("converts a complete DockerContainer to ConnectionConfig", () => {
+    const container: DockerContainer = {
+      container_id: "abc123def456",
+      name: "my-postgres",
+      image: "postgres:15-alpine",
+      db_type: "postgres",
+      host: "127.0.0.1",
+      port: 5433,
+      user: "myuser",
+      password: "secret",
+      database: "mydb",
+      status: "running",
+    }
+
+    const config = containerToConfig(container)
+
+    expect(config).toEqual({
+      type: "postgres",
+      host: "127.0.0.1",
+      port: 5433,
+      user: "myuser",
+      password: "secret",
+      database: "mydb",
+    })
+  })
+
+  test("omits optional fields when not present on container", () => {
+    const container: DockerContainer = {
+      container_id: "abc123",
+      name: "bare-mysql",
+      image: "mysql:8",
+      db_type: "mysql",
+      host: "127.0.0.1",
+      port: 3306,
+      status: "running",
+    }
+
+    const config = containerToConfig(container)
+
+    // Should only have type, host, port — no user, password, database
+    expect(Object.keys(config).sort()).toEqual(["host", "port", "type"])
+    expect(config.type).toBe("mysql")
+    expect(config.host).toBe("127.0.0.1")
+    expect(config.port).toBe(3306)
+  })
+
+  test("preserves db_type as config.type for all supported databases", () => {
+    const dbTypes = ["postgres", "mysql", "sqlserver", "oracle", "duckdb", "sqlite", "mongodb"]
+
+    for (const dbType of dbTypes) {
+      const container: DockerContainer = {
+        container_id: "x",
+        name: `test-${dbType}`,
+        image: `${dbType}:latest`,
+        db_type: dbType,
+        host: "127.0.0.1",
+        port: 5432,
+        status: "running",
+      }
+      const config = containerToConfig(container)
+      expect(config.type).toBe(dbType)
+    }
+  })
+
+  test("includes user but not password when only user is set", () => {
+    const container: DockerContainer = {
+      container_id: "x",
+      name: "pg-no-pass",
+      image: "postgres:15",
+      db_type: "postgres",
+      host: "127.0.0.1",
+      port: 5432,
+      user: "postgres",
+      status: "running",
+    }
+
+    const config = containerToConfig(container)
+
+    expect(config.user).toBe("postgres")
+    expect(config.password).toBeUndefined()
+    expect(Object.keys(config).sort()).toEqual(["host", "port", "type", "user"])
+  })
+
+  test("includes database but not user/password when only database is set", () => {
+    const container: DockerContainer = {
+      container_id: "x",
+      name: "pg-db-only",
+      image: "postgres:15",
+      db_type: "postgres",
+      host: "127.0.0.1",
+      port: 5432,
+      database: "analytics",
+      status: "running",
+    }
+
+    const config = containerToConfig(container)
+
+    expect(config.database).toBe("analytics")
+    expect(config.user).toBeUndefined()
+    expect(config.password).toBeUndefined()
+  })
+
+  test("does not include container_id, name, image, or status in config", () => {
+    const container: DockerContainer = {
+      container_id: "abc123def456",
+      name: "my-container",
+      image: "postgres:15",
+      db_type: "postgres",
+      host: "127.0.0.1",
+      port: 5432,
+      user: "pg",
+      password: "pass",
+      database: "db",
+      status: "running",
+    }
+
+    const config = containerToConfig(container)
+
+    // These Docker-specific fields should NOT leak into the ConnectionConfig
+    expect((config as any).container_id).toBeUndefined()
+    expect((config as any).name).toBeUndefined()
+    expect((config as any).image).toBeUndefined()
+    expect((config as any).status).toBeUndefined()
+    expect((config as any).db_type).toBeUndefined()
+  })
+})

--- a/packages/opencode/test/provider/copilot-compat.test.ts
+++ b/packages/opencode/test/provider/copilot-compat.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect } from "bun:test"
+import { mapOpenAICompatibleFinishReason } from "../../src/provider/sdk/copilot/chat/map-openai-compatible-finish-reason"
+import { getResponseMetadata } from "../../src/provider/sdk/copilot/chat/get-response-metadata"
+
+describe("mapOpenAICompatibleFinishReason", () => {
+  test("maps 'stop' to 'stop'", () => {
+    expect(mapOpenAICompatibleFinishReason("stop")).toBe("stop")
+  })
+
+  test("maps 'length' to 'length'", () => {
+    expect(mapOpenAICompatibleFinishReason("length")).toBe("length")
+  })
+
+  test("maps 'content_filter' to 'content-filter'", () => {
+    expect(mapOpenAICompatibleFinishReason("content_filter")).toBe("content-filter")
+  })
+
+  test("maps 'function_call' to 'tool-calls'", () => {
+    expect(mapOpenAICompatibleFinishReason("function_call")).toBe("tool-calls")
+  })
+
+  test("maps 'tool_calls' to 'tool-calls'", () => {
+    expect(mapOpenAICompatibleFinishReason("tool_calls")).toBe("tool-calls")
+  })
+
+  test("maps null to 'unknown'", () => {
+    expect(mapOpenAICompatibleFinishReason(null)).toBe("unknown")
+  })
+
+  test("maps undefined to 'unknown'", () => {
+    expect(mapOpenAICompatibleFinishReason(undefined)).toBe("unknown")
+  })
+
+  test("maps unrecognized string to 'unknown'", () => {
+    expect(mapOpenAICompatibleFinishReason("cancelled")).toBe("unknown")
+    expect(mapOpenAICompatibleFinishReason("error")).toBe("unknown")
+    expect(mapOpenAICompatibleFinishReason("")).toBe("unknown")
+  })
+})
+
+describe("getResponseMetadata", () => {
+  test("converts all fields when present", () => {
+    const result = getResponseMetadata({
+      id: "chatcmpl-abc123",
+      model: "gpt-4",
+      created: 1700000000,
+    })
+
+    expect(result.id).toBe("chatcmpl-abc123")
+    expect(result.modelId).toBe("gpt-4")
+    expect(result.timestamp).toEqual(new Date(1700000000 * 1000))
+  })
+
+  test("returns undefined fields when inputs are null", () => {
+    const result = getResponseMetadata({
+      id: null,
+      model: null,
+      created: null,
+    })
+
+    expect(result.id).toBeUndefined()
+    expect(result.modelId).toBeUndefined()
+    expect(result.timestamp).toBeUndefined()
+  })
+
+  test("returns undefined fields when inputs are undefined", () => {
+    const result = getResponseMetadata({
+      id: undefined,
+      model: undefined,
+      created: undefined,
+    })
+
+    expect(result.id).toBeUndefined()
+    expect(result.modelId).toBeUndefined()
+    expect(result.timestamp).toBeUndefined()
+  })
+
+  test("handles empty input object", () => {
+    const result = getResponseMetadata({})
+
+    expect(result.id).toBeUndefined()
+    expect(result.modelId).toBeUndefined()
+    expect(result.timestamp).toBeUndefined()
+  })
+
+  test("converts created=0 to epoch Date (not undefined)", () => {
+    // created=0 is falsy but not null/undefined, so it should produce a Date
+    const result = getResponseMetadata({ created: 0 })
+    expect(result.timestamp).toEqual(new Date(0))
+  })
+
+  test("converts created timestamp correctly for recent dates", () => {
+    // 2026-01-15 12:00:00 UTC
+    const epoch = 1768478400
+    const result = getResponseMetadata({ created: epoch })
+    expect(result.timestamp?.getFullYear()).toBe(2026)
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Adds 20 new tests covering two previously untested modules discovered during proactive test discovery.

**1. `containerToConfig` — `src/altimate/native/connections/docker-discovery.ts`** (6 new tests)

This function converts discovered Docker containers into `ConnectionConfig` objects used to connect to databases. Zero tests existed. When users run warehouse auto-discovery with Docker, incorrect config generation would silently produce broken connections (wrong type, leaked Docker-specific fields, missing credentials).

New coverage includes:
- Full container conversion with all optional fields (user, password, database)
- Omission of optional fields when not present on the container
- Correct `db_type` → `config.type` mapping across all supported database types
- Partial field presence (user without password, database without credentials)
- Ensuring Docker-specific metadata (container_id, name, image, status) does not leak into ConnectionConfig

**2. `mapOpenAICompatibleFinishReason` and `getResponseMetadata` — `src/provider/sdk/copilot/chat/`** (14 new tests)

These utility functions power the GitHub Copilot provider integration. `mapOpenAICompatibleFinishReason` translates OpenAI-style finish reasons into the AI SDK's `LanguageModelV2FinishReason` enum. An incorrect mapping (e.g., `tool_calls` → `unknown` instead of `tool-calls`) would cause the system to misinterpret model responses, potentially dropping tool call results. `getResponseMetadata` converts Unix epoch timestamps to Date objects for response tracking.

New coverage includes:
- All five known finish reason mappings (`stop`, `length`, `content_filter`, `function_call`, `tool_calls`)
- Null, undefined, and unrecognized string inputs falling back to `unknown`
- Full metadata conversion with id, model, and timestamp
- Null/undefined/missing input handling for all metadata fields
- Edge case: `created=0` produces epoch Date (not undefined) — tests the `!= null` guard

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage

### How did you verify your code works?

```
bun test test/altimate/docker-discovery.test.ts   # 6 pass, 23 expect() calls
bun test test/provider/copilot-compat.test.ts      # 14 pass, 24 expect() calls
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01J8xz7ijLjbzEe3mu7ajdWh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for Docker container configuration conversion, validating proper field mapping and handling of optional parameters.
  * Added test coverage for Copilot SDK compatibility helpers, ensuring correct transformation of finish reasons and response metadata parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->