### PR TITLE
fix: update remaining opencode references in help output and CLI

### DIFF
--- a/packages/opencode/src/cli/cmd/pr.ts
+++ b/packages/opencode/src/cli/cmd/pr.ts
@@ -82,15 +82,15 @@ export const PrCommand = cmd({
               })
             }
 
-            // Check for opencode session link in PR body
+            // Check for altimate-code session link in PR body
             if (prInfo && prInfo.body) {
               const sessionMatch = prInfo.body.match(/https:\/\/opncd\.ai\/s\/([a-zA-Z0-9_-]+)/)
               if (sessionMatch) {
                 const sessionUrl = sessionMatch[0]
-                UI.println(`Found opencode session: ${sessionUrl}`)
+                UI.println(`Found altimate-code session: ${sessionUrl}`)
                 UI.println(`Importing session...`)
 
-                const importResult = await Process.text(["opencode", "import", sessionUrl], {
+                const importResult = await Process.text(["altimate-code", "import", sessionUrl], {
                   nothrow: true,
                 })
                 if (importResult.code === 0) {
@@ -109,13 +109,13 @@ export const PrCommand = cmd({
 
         UI.println(`Successfully checked out PR #${prNumber} as branch '${localBranchName}'`)
         UI.println()
-        UI.println("Starting opencode...")
+        UI.println("Starting altimate-code...")
         UI.println()
 
-        // Launch opencode TUI with session ID if available
+        // Launch altimate-code TUI with session ID if available
         const { spawn } = await import("child_process")
         const opencodeArgs = sessionId ? ["-s", sessionId] : []
-        const opencodeProcess = spawn("opencode", opencodeArgs, {
+        const opencodeProcess = spawn("altimate-code", opencodeArgs, {
           stdio: "inherit",
           cwd: process.cwd(),
         })
@@ -123,7 +123,7 @@ export const PrCommand = cmd({
         await new Promise<void>((resolve, reject) => {
           opencodeProcess.on("exit", (code) => {
             if (code === 0) resolve()
-            else reject(new Error(`opencode exited with code ${code}`))
+            else reject(new Error(`altimate-code exited with code ${code}`))
           })
           opencodeProcess.on("error", reject)
         })

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -19,8 +19,8 @@ const options = {
   },
   "mdns-domain": {
     type: "string" as const,
-    describe: "custom domain name for mDNS service (default: opencode.local)",
-    default: "opencode.local",
+    describe: "custom domain name for mDNS service (default: altimate-code.local)",
+    default: "altimate-code.local",
   },
   cors: {
     type: "string" as const,

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -992,7 +992,7 @@ export namespace Config {
       port: z.number().int().positive().optional().describe("Port to listen on"),
       hostname: z.string().optional().describe("Hostname to listen on"),
       mdns: z.boolean().optional().describe("Enable mDNS service discovery"),
-      mdnsDomain: z.string().optional().describe("Custom domain name for mDNS service (default: opencode.local)"),
+      mdnsDomain: z.string().optional().describe("Custom domain name for mDNS service (default: altimate-code.local)"),
       cors: z.array(z.string()).optional().describe("Additional domains to allow for CORS"),
     })
     .strict()

--- a/packages/opencode/src/server/mdns.ts
+++ b/packages/opencode/src/server/mdns.ts
@@ -12,8 +12,8 @@ export namespace MDNS {
     if (bonjour) unpublish()
 
     try {
-      const host = domain ?? "opencode.local"
-      const name = `opencode-${port}`
+      const host = domain ?? "altimate-code.local"
+      const name = `altimate-code-${port}`
       bonjour = new Bonjour()
       const service = bonjour.publish({
         name,

--- a/packages/opencode/test/cli/tui/thread.test.ts
+++ b/packages/opencode/test/cli/tui/thread.test.ts
@@ -99,8 +99,8 @@ describe("tui thread", () => {
       port: 0,
       hostname: "127.0.0.1",
       mdns: false,
-      "mdns-domain": "opencode.local",
-      mdnsDomain: "opencode.local",
+      "mdns-domain": "altimate-code.local",
+      mdnsDomain: "altimate-code.local",
       cors: [],
     }
     return TuiThreadCommand.handler(args)

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1031,7 +1031,7 @@ export type ServerConfig = {
    */
   mdns?: boolean
   /**
-   * Custom domain name for mDNS service (default: opencode.local)
+   * Custom domain name for mDNS service (default: altimate-code.local)
    */
   mdnsDomain?: string
   /**


### PR DESCRIPTION
## Summary

Fixes #416 — Updates user-facing `opencode` references to `altimate-code` across help text, CLI commands, and mDNS discovery.

**Changed (8 files, 19 replacements):**
- `thread.ts` — TUI help descriptions
- `uninstall.ts` — uninstall command description
- `pr.ts` — user-facing messages + `spawn("opencode", ...)` → `spawn("altimate-code", ...)` (functional fix — old binary name fails on rebranded installs)
- `network.ts`, `config.ts`, `mdns.ts` — mDNS domain `opencode.local` → `altimate-code.local`
- `thread.test.ts` — test expectations for mDNS domain
- `types.gen.ts` — JSDoc mDNS domain reference

**Intentionally NOT changed:** Internal identifiers (`@opencode/Auth`, `ProviderID.opencode`, `OPENCODE_*` env vars), `@opencode-ai/*` package names, `.opencode` config directories, npm registry names in uninstall, `User-Agent`/`X-Title` protocol headers.

## Test Plan

- [x] `bun turbo typecheck` passes across all 5 packages
- [x] `bun test test/cli/tui/thread.test.ts` passes with updated mDNS expectations
- [ ] Manual: `altimate-code --help` shows no `opencode` in descriptions
- [ ] Manual: `altimate-code pr` messages reference `altimate-code`

## Checklist

- [x] Follows conventional commit format
- [x] No breaking changes to internal APIs or env vars
- [x] Tests updated for changed behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Default mDNS domain changed to altimate-code.local.
  * Service names and status messages now use the altimate-code prefix.
  * PR/CLI session flow now launches and displays altimate-code tooling/status text.

* **Tests**
  * Test inputs and mocks updated to use the new altimate-code mDNS domain and naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->