### PR TITLE
fix: re-trace system prompt on agent switch

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -325,6 +325,7 @@ export namespace SessionPrompt {
     let planHasWritten = false
     let planLastUserMsgId: string | undefined
     // altimate_change end
+    let tracedAgent = ""
     let emergencySessionEndFired = false
     // altimate_change start — quality signal, tool chain, error fingerprint tracking
     let lastToolCategory = ""
@@ -855,11 +856,10 @@ export namespace SessionPrompt {
         system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
       }
 
-      // altimate_change start - trace system prompt once per loop() call.
-      // The system prompt is functionally identical across steps within a single
-      // loop() invocation (same agent, same environment). Agent switches re-enter
-      // loop() with step reset to 0, so each agent's prompt is traced separately.
-      if (step === 1) {
+      // altimate_change start - trace system prompt once per agent.
+      // The step counter is never reset on agent switches, so we track the
+      // last-traced agent to ensure each agent's system prompt is logged.
+      if (step === 1 || agent.name !== tracedAgent) {
         Tracer.active?.logSpan({
           name: "system-prompt",
           startTime: Date.now(),
@@ -867,6 +867,7 @@ export namespace SessionPrompt {
           input: { agent: agent.name, step },
           output: { parts: system.length, content: system.join("\n\n") },
         })
+        tracedAgent = agent.name
       }
       // altimate_change end
 


### PR DESCRIPTION
## Summary

- The `step === 1` guard in `prompt.ts` only traced the first agent's system prompt because `step` increments continuously and is never reset on agent switches
- Added a `tracedAgent` variable to track the last-traced agent name, so each agent's system prompt is logged when it first becomes active
- Fixed the inaccurate comment that claimed agent switches reset step to 0

Fixes #291

## Test Plan

- [ ] Verify typecheck passes on `prompt.ts` (pre-existing test file failures are unrelated)
- [ ] Start a session, switch agents mid-conversation, confirm both agents' system prompts appear in trace output
- [ ] Confirm single-agent sessions still trace the system prompt exactly once

## Checklist

- [x] Change is minimal and focused on the reported issue
- [x] No functional behavior change — tracing/observability only
- [x] Comment updated to accurately describe the logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved session tracing so system-prompt entries are emitted on the initial step and whenever execution switches to a different agent. This reduces redundant trace noise, clarifies agent transitions in logs, and ensures each agent’s system prompt appears once per switch for cleaner, more readable session traces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->