### PR TITLE
fix: pass warehouse dialect to altimate-core tools instead of hardcoding snowflake

### DIFF
--- a/packages/opencode/src/altimate/native/altimate-core.ts
+++ b/packages/opencode/src/altimate/native/altimate-core.ts
@@ -197,7 +197,7 @@ export function registerAll(): void {
   // 8. altimate_core.policy
   register("altimate_core.policy", async (params) => {
     try {
-      const schema = schemaOrEmpty(params.schema_path, params.schema_context)
+      const schema = schemaOrEmpty(params.schema_path, params.schema_context, params.dialect)
       const raw = await core.checkPolicy(params.sql, schema, params.policy_json)
       const data = toData(raw)
       return ok(true, data)

--- a/packages/opencode/src/altimate/native/altimate-core.ts
+++ b/packages/opencode/src/altimate/native/altimate-core.ts
@@ -88,7 +88,7 @@ export function registerAll(): void {
   // 1. altimate_core.validate
   register("altimate_core.validate", async (params) => {
     try {
-      const schema = schemaOrEmpty(params.schema_path, params.schema_context)
+      const schema = schemaOrEmpty(params.schema_path, params.schema_context, params.dialect)
       const raw = await core.validate(params.sql, schema)
       const data = toData(raw)
       return ok(true, data)
@@ -167,7 +167,7 @@ export function registerAll(): void {
   // 6. altimate_core.check — composite: validate + lint + scan_sql
   register("altimate_core.check", async (params) => {
     try {
-      const schema = schemaOrEmpty(params.schema_path, params.schema_context)
+      const schema = schemaOrEmpty(params.schema_path, params.schema_context, params.dialect)
       const validation = await core.validate(params.sql, schema)
       const lintResult = core.lint(params.sql, schema)
       const safety = core.scanSql(params.sql)
@@ -185,7 +185,7 @@ export function registerAll(): void {
   // 7. altimate_core.fix
   register("altimate_core.fix", async (params) => {
     try {
-      const schema = schemaOrEmpty(params.schema_path, params.schema_context)
+      const schema = schemaOrEmpty(params.schema_path, params.schema_context, params.dialect)
       const raw = await core.fix(params.sql, schema, params.max_iterations ?? undefined)
       const data = toData(raw)
       return ok(true, data)
@@ -209,7 +209,7 @@ export function registerAll(): void {
   // 9. altimate_core.semantics
   register("altimate_core.semantics", async (params) => {
     try {
-      const schema = schemaOrEmpty(params.schema_path, params.schema_context)
+      const schema = schemaOrEmpty(params.schema_path, params.schema_context, params.dialect)
       const raw = await core.checkSemantics(params.sql, schema)
       const data = toData(raw)
       return ok(true, data)
@@ -232,7 +232,7 @@ export function registerAll(): void {
   // 11. altimate_core.equivalence
   register("altimate_core.equivalence", async (params) => {
     try {
-      const schema = schemaOrEmpty(params.schema_path, params.schema_context)
+      const schema = schemaOrEmpty(params.schema_path, params.schema_context, params.dialect)
       const raw = await core.checkEquivalence(params.sql1, params.sql2, schema)
       const data = toData(raw)
       return ok(true, data)
@@ -280,7 +280,7 @@ export function registerAll(): void {
   // 15. altimate_core.correct
   register("altimate_core.correct", async (params) => {
     try {
-      const schema = schemaOrEmpty(params.schema_path, params.schema_context)
+      const schema = schemaOrEmpty(params.schema_path, params.schema_context, params.dialect)
       const raw = await core.correct(params.sql, schema)
       const data = toData(raw)
       return ok(true, data)

--- a/packages/opencode/src/altimate/native/schema-resolver.ts
+++ b/packages/opencode/src/altimate/native/schema-resolver.ts
@@ -111,12 +111,15 @@ export function resolveSchema(
 /**
  * Resolve a Schema, falling back to a minimal empty schema when none is provided.
  * Use this for functions that require a non-null Schema argument.
+ * When a dialect is provided, it is passed to Schema.fromDdl() so the fallback
+ * empty schema uses the correct SQL dialect for validation/analysis.
  */
 export function schemaOrEmpty(
   schemaPath?: string,
   schemaContext?: Record<string, any>,
+  dialect?: string,
 ): Schema {
   const s = resolveSchema(schemaPath, schemaContext)
   if (s !== null) return s
-  return Schema.fromDdl("CREATE TABLE _empty_ (id INT);")
+  return Schema.fromDdl("CREATE TABLE _empty_ (id INT);", dialect || undefined)
 }

--- a/packages/opencode/src/altimate/native/types.ts
+++ b/packages/opencode/src/altimate/native/types.ts
@@ -775,6 +775,7 @@ export interface SchemaDiffResult {
 
 export interface AltimateCoreValidateParams {
   sql: string
+  dialect?: string
   schema_path?: string
   schema_context?: Record<string, any>
 }
@@ -803,6 +804,7 @@ export interface AltimateCoreExplainParams {
 
 export interface AltimateCoreCheckParams {
   sql: string
+  dialect?: string
   schema_path?: string
   schema_context?: Record<string, any>
 }
@@ -817,6 +819,7 @@ export interface AltimateCoreResult {
 
 export interface AltimateCoreFixParams {
   sql: string
+  dialect?: string
   schema_path?: string
   schema_context?: Record<string, any>
   max_iterations?: number
@@ -824,6 +827,7 @@ export interface AltimateCoreFixParams {
 
 export interface AltimateCorePolicyParams {
   sql: string
+  dialect?: string
   policy_json: string
   schema_path?: string
   schema_context?: Record<string, any>
@@ -831,6 +835,7 @@ export interface AltimateCorePolicyParams {
 
 export interface AltimateCoreSemanticsParams {
   sql: string
+  dialect?: string
   schema_path?: string
   schema_context?: Record<string, any>
 }
@@ -846,6 +851,7 @@ export interface AltimateCoreTestgenParams {
 export interface AltimateCoreEquivalenceParams {
   sql1: string
   sql2: string
+  dialect?: string
   schema_path?: string
   schema_context?: Record<string, any>
 }
@@ -871,6 +877,7 @@ export interface AltimateCoreRewriteParams {
 
 export interface AltimateCoreCorrectParams {
   sql: string
+  dialect?: string
   schema_path?: string
   schema_context?: Record<string, any>
 }

--- a/packages/opencode/src/altimate/tools/altimate-core-check.ts
+++ b/packages/opencode/src/altimate/tools/altimate-core-check.ts
@@ -8,6 +8,11 @@ export const AltimateCoreCheckTool = Tool.define("altimate_core_check", {
     "Run full analysis pipeline: validate + lint + safety scan + PII check. Single call for comprehensive SQL analysis. Provide schema_context or schema_path for accurate table/column resolution.",
   parameters: z.object({
     sql: z.string().describe("SQL query to analyze"),
+    dialect: z
+      .string()
+      .optional()
+      .default("snowflake")
+      .describe("SQL dialect (snowflake, postgres, bigquery, duckdb, etc.)"),
     schema_path: z.string().optional().describe("Path to YAML/JSON schema file"),
     schema_context: z.record(z.string(), z.any()).optional().describe("Inline schema definition"),
   }),
@@ -16,6 +21,7 @@ export const AltimateCoreCheckTool = Tool.define("altimate_core_check", {
     try {
       const result = await Dispatcher.call("altimate_core.check", {
         sql: args.sql,
+        dialect: args.dialect,
         schema_path: args.schema_path ?? "",
         schema_context: args.schema_context,
       })
@@ -40,6 +46,7 @@ export const AltimateCoreCheckTool = Tool.define("altimate_core_check", {
         title: `Check: ${formatCheckTitle(data)}`,
         metadata: {
           success: result.success,
+          dialect: args.dialect,
           has_schema: hasSchema,
           ...(error && { error }),
           ...(findings.length > 0 && { findings }),
@@ -50,7 +57,7 @@ export const AltimateCoreCheckTool = Tool.define("altimate_core_check", {
       const msg = e instanceof Error ? e.message : String(e)
       return {
         title: "Check: ERROR",
-        metadata: { success: false, has_schema: hasSchema, error: msg },
+        metadata: { success: false, dialect: args.dialect, has_schema: hasSchema, error: msg },
         output: `Failed: ${msg}`,
       }
     }

--- a/packages/opencode/src/altimate/tools/altimate-core-correct.ts
+++ b/packages/opencode/src/altimate/tools/altimate-core-correct.ts
@@ -8,6 +8,11 @@ export const AltimateCoreCorrectTool = Tool.define("altimate_core_correct", {
     "Iteratively correct SQL using a propose-verify-refine loop. More thorough than fix — applies multiple correction rounds to produce valid SQL. Provide schema_context or schema_path for accurate table/column resolution.",
   parameters: z.object({
     sql: z.string().describe("SQL query to correct"),
+    dialect: z
+      .string()
+      .optional()
+      .default("snowflake")
+      .describe("SQL dialect (snowflake, postgres, bigquery, duckdb, etc.)"),
     schema_path: z.string().optional().describe("Path to YAML/JSON schema file"),
     schema_context: z.record(z.string(), z.any()).optional().describe("Inline schema definition"),
   }),
@@ -16,6 +21,7 @@ export const AltimateCoreCorrectTool = Tool.define("altimate_core_correct", {
     try {
       const result = await Dispatcher.call("altimate_core.correct", {
         sql: args.sql,
+        dialect: args.dialect,
         schema_path: args.schema_path ?? "",
         schema_context: args.schema_context,
       })
@@ -32,6 +38,7 @@ export const AltimateCoreCorrectTool = Tool.define("altimate_core_correct", {
         metadata: {
           success: result.success,
           iterations: data.iterations,
+          dialect: args.dialect,
           has_schema: hasSchema,
           ...(error && { error }),
           ...(findings.length > 0 && { findings }),
@@ -42,7 +49,7 @@ export const AltimateCoreCorrectTool = Tool.define("altimate_core_correct", {
       const msg = e instanceof Error ? e.message : String(e)
       return {
         title: "Correct: ERROR",
-        metadata: { success: false, iterations: 0, has_schema: hasSchema, error: msg },
+        metadata: { success: false, iterations: 0, dialect: args.dialect, has_schema: hasSchema, error: msg },
         output: `Failed: ${msg}`,
       }
     }

--- a/packages/opencode/src/altimate/tools/altimate-core-equivalence.ts
+++ b/packages/opencode/src/altimate/tools/altimate-core-equivalence.ts
@@ -24,7 +24,7 @@ export const AltimateCoreEquivalenceTool = Tool.define("altimate_core_equivalenc
         "No schema provided. Provide schema_context or schema_path so table/column references can be resolved."
       return {
         title: "Equivalence: NO SCHEMA",
-        metadata: { success: false, equivalent: false, has_schema: false, error },
+        metadata: { success: false, equivalent: false, dialect: args.dialect, has_schema: false, error },
         output: `Error: ${error}`,
       }
     }

--- a/packages/opencode/src/altimate/tools/altimate-core-equivalence.ts
+++ b/packages/opencode/src/altimate/tools/altimate-core-equivalence.ts
@@ -9,6 +9,11 @@ export const AltimateCoreEquivalenceTool = Tool.define("altimate_core_equivalenc
   parameters: z.object({
     sql1: z.string().describe("First SQL query"),
     sql2: z.string().describe("Second SQL query"),
+    dialect: z
+      .string()
+      .optional()
+      .default("snowflake")
+      .describe("SQL dialect (snowflake, postgres, bigquery, duckdb, etc.)"),
     schema_path: z.string().optional().describe("Path to YAML/JSON schema file"),
     schema_context: z.record(z.string(), z.any()).optional().describe("Inline schema definition"),
   }),
@@ -27,6 +32,7 @@ export const AltimateCoreEquivalenceTool = Tool.define("altimate_core_equivalenc
       const result = await Dispatcher.call("altimate_core.equivalence", {
         sql1: args.sql1,
         sql2: args.sql2,
+        dialect: args.dialect,
         schema_path: args.schema_path ?? "",
         schema_context: args.schema_context,
       })
@@ -48,6 +54,7 @@ export const AltimateCoreEquivalenceTool = Tool.define("altimate_core_equivalenc
         metadata: {
           success: !isRealFailure,
           equivalent: data.equivalent,
+          dialect: args.dialect,
           has_schema: hasSchema,
           ...(error && { error }),
           ...(findings.length > 0 && { findings }),
@@ -58,7 +65,7 @@ export const AltimateCoreEquivalenceTool = Tool.define("altimate_core_equivalenc
       const msg = e instanceof Error ? e.message : String(e)
       return {
         title: "Equivalence: ERROR",
-        metadata: { success: false, equivalent: false, has_schema: hasSchema, error: msg },
+        metadata: { success: false, equivalent: false, dialect: args.dialect, has_schema: hasSchema, error: msg },
         output: `Failed: ${msg}`,
       }
     }

--- a/packages/opencode/src/altimate/tools/altimate-core-fix.ts
+++ b/packages/opencode/src/altimate/tools/altimate-core-fix.ts
@@ -8,6 +8,11 @@ export const AltimateCoreFixTool = Tool.define("altimate_core_fix", {
     "Auto-fix SQL errors using fuzzy matching and iterative re-validation. Corrects syntax errors, typos, and schema reference issues. IMPORTANT: Provide schema_context or schema_path — without schema, table/column references cannot be resolved or fixed.",
   parameters: z.object({
     sql: z.string().describe("SQL query to fix"),
+    dialect: z
+      .string()
+      .optional()
+      .default("snowflake")
+      .describe("SQL dialect (snowflake, postgres, bigquery, duckdb, etc.)"),
     schema_path: z.string().optional().describe("Path to YAML/JSON schema file"),
     schema_context: z.record(z.string(), z.any()).optional().describe("Inline schema definition"),
     max_iterations: z.number().optional().describe("Maximum fix iterations (default: 5)"),
@@ -17,6 +22,7 @@ export const AltimateCoreFixTool = Tool.define("altimate_core_fix", {
     try {
       const result = await Dispatcher.call("altimate_core.fix", {
         sql: args.sql,
+        dialect: args.dialect,
         schema_path: args.schema_path ?? "",
         schema_context: args.schema_context,
         max_iterations: args.max_iterations ?? 5,
@@ -40,6 +46,7 @@ export const AltimateCoreFixTool = Tool.define("altimate_core_fix", {
         metadata: {
           success,
           fixed: !!data.fixed_sql,
+          dialect: args.dialect,
           has_schema: hasSchema,
           ...(error && { error }),
           ...(findings.length > 0 && { findings }),
@@ -50,7 +57,7 @@ export const AltimateCoreFixTool = Tool.define("altimate_core_fix", {
       const msg = e instanceof Error ? e.message : String(e)
       return {
         title: "Fix: ERROR",
-        metadata: { success: false, fixed: false, has_schema: hasSchema, error: msg },
+        metadata: { success: false, fixed: false, dialect: args.dialect, has_schema: hasSchema, error: msg },
         output: `Failed: ${msg}`,
       }
     }

--- a/packages/opencode/src/altimate/tools/altimate-core-policy.ts
+++ b/packages/opencode/src/altimate/tools/altimate-core-policy.ts
@@ -8,6 +8,11 @@ export const AltimateCorePolicyTool = Tool.define("altimate_core_policy", {
     "Check SQL against YAML-based governance policy guardrails. Validates compliance with custom rules like allowed tables, forbidden operations, and data access restrictions. Provide schema_context or schema_path for accurate table/column resolution.",
   parameters: z.object({
     sql: z.string().describe("SQL query to check against policy"),
+    dialect: z
+      .string()
+      .optional()
+      .default("snowflake")
+      .describe("SQL dialect (snowflake, postgres, bigquery, duckdb, etc.)"),
     policy_json: z.string().describe("JSON string defining the policy rules"),
     schema_path: z.string().optional().describe("Path to YAML/JSON schema file"),
     schema_context: z.record(z.string(), z.any()).optional().describe("Inline schema definition"),
@@ -17,6 +22,7 @@ export const AltimateCorePolicyTool = Tool.define("altimate_core_policy", {
     try {
       const result = await Dispatcher.call("altimate_core.policy", {
         sql: args.sql,
+        dialect: args.dialect,
         policy_json: args.policy_json,
         schema_path: args.schema_path ?? "",
         schema_context: args.schema_context,
@@ -34,6 +40,7 @@ export const AltimateCorePolicyTool = Tool.define("altimate_core_policy", {
         metadata: {
           success: true, // engine ran — violations are findings, not failures
           pass: data.pass,
+          dialect: args.dialect,
           has_schema: hasSchema,
           ...(error && { error }),
           ...(findings.length > 0 && { findings }),
@@ -44,7 +51,7 @@ export const AltimateCorePolicyTool = Tool.define("altimate_core_policy", {
       const msg = e instanceof Error ? e.message : String(e)
       return {
         title: "Policy: ERROR",
-        metadata: { success: false, pass: false, has_schema: hasSchema, error: msg },
+        metadata: { success: false, pass: false, dialect: args.dialect, has_schema: hasSchema, error: msg },
         output: `Failed: ${msg}`,
       }
     }

--- a/packages/opencode/src/altimate/tools/altimate-core-semantics.ts
+++ b/packages/opencode/src/altimate/tools/altimate-core-semantics.ts
@@ -8,6 +8,11 @@ export const AltimateCoreSemanticsTool = Tool.define("altimate_core_semantics", 
     "Run semantic validation rules against SQL. Detects logical issues like cartesian products, wrong JOIN conditions, NULL misuse, and type mismatches that syntax checking alone misses. Provide schema_context or schema_path for accurate table/column resolution.",
   parameters: z.object({
     sql: z.string().describe("SQL query to validate semantically"),
+    dialect: z
+      .string()
+      .optional()
+      .default("snowflake")
+      .describe("SQL dialect (snowflake, postgres, bigquery, duckdb, etc.)"),
     schema_path: z.string().optional().describe("Path to YAML/JSON schema file"),
     schema_context: z.record(z.string(), z.any()).optional().describe("Inline schema definition"),
   }),
@@ -25,6 +30,7 @@ export const AltimateCoreSemanticsTool = Tool.define("altimate_core_semantics", 
     try {
       const result = await Dispatcher.call("altimate_core.semantics", {
         sql: args.sql,
+        dialect: args.dialect,
         schema_path: args.schema_path ?? "",
         schema_context: args.schema_context,
       })
@@ -44,6 +50,7 @@ export const AltimateCoreSemanticsTool = Tool.define("altimate_core_semantics", 
           success: true, // engine ran — semantic issues are findings, not failures
           valid: data.valid,
           issue_count: issueCount,
+          dialect: args.dialect,
           has_schema: hasSchema,
           ...(error && { error }),
           ...(findings.length > 0 && { findings }),
@@ -54,7 +61,7 @@ export const AltimateCoreSemanticsTool = Tool.define("altimate_core_semantics", 
       const msg = e instanceof Error ? e.message : String(e)
       return {
         title: "Semantics: ERROR",
-        metadata: { success: false, valid: false, issue_count: 0, has_schema: hasSchema, error: msg },
+        metadata: { success: false, valid: false, issue_count: 0, dialect: args.dialect, has_schema: hasSchema, error: msg },
         output: `Failed: ${msg}`,
       }
     }

--- a/packages/opencode/src/altimate/tools/altimate-core-semantics.ts
+++ b/packages/opencode/src/altimate/tools/altimate-core-semantics.ts
@@ -23,7 +23,7 @@ export const AltimateCoreSemanticsTool = Tool.define("altimate_core_semantics", 
         "No schema provided. Provide schema_context or schema_path so table/column references can be resolved."
       return {
         title: "Semantics: NO SCHEMA",
-        metadata: { success: false, valid: false, issue_count: 0, has_schema: false, error },
+        metadata: { success: false, valid: false, issue_count: 0, dialect: args.dialect, has_schema: false, error },
         output: `Error: ${error}`,
       }
     }

--- a/packages/opencode/src/altimate/tools/altimate-core-validate.ts
+++ b/packages/opencode/src/altimate/tools/altimate-core-validate.ts
@@ -8,6 +8,11 @@ export const AltimateCoreValidateTool = Tool.define("altimate_core_validate", {
     "Validate SQL syntax and schema references. Checks if tables/columns exist in the schema and if SQL is valid for the target dialect. If no schema_path or schema_context is provided, validation still runs but schema-dependent checks (table/column existence) are skipped — syntax and dialect checks still apply. For full validation, run `schema_inspect` first on the referenced tables or pass `schema_context` inline.",
   parameters: z.object({
     sql: z.string().describe("SQL query to validate"),
+    dialect: z
+      .string()
+      .optional()
+      .default("snowflake")
+      .describe("SQL dialect (snowflake, postgres, bigquery, duckdb, etc.)"),
     schema_path: z.string().optional().describe("Path to YAML/JSON schema file"),
     schema_context: z.record(z.string(), z.any()).optional().describe("Inline schema definition"),
   }),
@@ -16,6 +21,7 @@ export const AltimateCoreValidateTool = Tool.define("altimate_core_validate", {
     try {
       const result = await Dispatcher.call("altimate_core.validate", {
         sql: args.sql,
+        dialect: args.dialect,
         schema_path: args.schema_path ?? "",
         schema_context: args.schema_context,
       })
@@ -32,6 +38,7 @@ export const AltimateCoreValidateTool = Tool.define("altimate_core_validate", {
         metadata: {
           success: true, // engine ran — validation errors are findings, not failures
           valid: data.valid,
+          dialect: args.dialect,
           has_schema: hasSchema,
           ...(error && { error }),
           ...(findings.length > 0 && { findings }),
@@ -42,7 +49,7 @@ export const AltimateCoreValidateTool = Tool.define("altimate_core_validate", {
       const msg = e instanceof Error ? e.message : String(e)
       return {
         title: "Validate: ERROR",
-        metadata: { success: false, valid: false, has_schema: hasSchema, error: msg, error_class: "engine_failure" },
+        metadata: { success: false, valid: false, dialect: args.dialect, has_schema: hasSchema, error: msg, error_class: "engine_failure" },
         output: `Failed: ${msg}`,
       }
     }

--- a/packages/opencode/src/altimate/tools/impact-analysis.ts
+++ b/packages/opencode/src/altimate/tools/impact-analysis.ts
@@ -37,7 +37,7 @@ export const ImpactAnalysisTool = Tool.define("impact_analysis", {
       if (!manifest.models || manifest.models.length === 0) {
         return {
           title: "Impact: NO MANIFEST",
-          metadata: { success: false },
+          metadata: { success: false, dialect: args.dialect },
           output: `No models found in manifest at ${args.manifest_path}. Run \`dbt compile\` first to generate the manifest.`,
         }
       }
@@ -54,7 +54,7 @@ export const ImpactAnalysisTool = Tool.define("impact_analysis", {
           .join(", ")
         return {
           title: "Impact: MODEL NOT FOUND",
-          metadata: { success: false },
+          metadata: { success: false, dialect: args.dialect },
           output: `Model "${args.model}" not found in manifest. Available models: ${available}${manifest.models.length > 10 ? ` (+${manifest.models.length - 10} more)` : ""}`,
         }
       }

--- a/packages/opencode/src/altimate/tools/impact-analysis.ts
+++ b/packages/opencode/src/altimate/tools/impact-analysis.ts
@@ -139,6 +139,7 @@ export const ImpactAnalysisTool = Tool.define("impact_analysis", {
           transitive_count: transitive.length,
           test_count: affectedTestCount,
           column_impact: columnImpact.length,
+          dialect: args.dialect,
           has_schema: false,
           ...(findings.length > 0 && { findings }),
         },
@@ -148,7 +149,7 @@ export const ImpactAnalysisTool = Tool.define("impact_analysis", {
       const msg = e instanceof Error ? e.message : String(e)
       return {
         title: "Impact: ERROR",
-        metadata: { success: false, has_schema: false, error: msg },
+        metadata: { success: false, dialect: args.dialect, has_schema: false, error: msg },
         output: `Failed to analyze impact: ${msg}\n\nEnsure the dbt manifest exists (run \`dbt compile\`) and the dispatcher is running.`,
       }
     }

--- a/packages/opencode/test/altimate/e2e-tool-errors.ts
+++ b/packages/opencode/test/altimate/e2e-tool-errors.ts
@@ -174,7 +174,7 @@ async function main() {
   await check(
     "validate: no schema → early return with 'No schema provided'",
     async () => {
-      return validateTool.execute({ sql: testSql }, stubCtx())
+      return validateTool.execute({ sql: testSql, dialect: "snowflake" }, stubCtx())
     },
     { metadataSuccess: false, metadataErrorContains: "No schema provided", noUnknownError: true },
   )
@@ -182,7 +182,7 @@ async function main() {
   await check(
     "validate: with schema_context (flat) → success",
     async () => {
-      return validateTool.execute({ sql: testSql, schema_context: flatSchema }, stubCtx())
+      return validateTool.execute({ sql: testSql, dialect: "snowflake", schema_context: flatSchema }, stubCtx())
     },
     { metadataSuccess: true },
   )
@@ -190,7 +190,7 @@ async function main() {
   await check(
     "validate: with schema_path (JSON file) → success",
     async () => {
-      return validateTool.execute({ sql: testSql, schema_path: schemaJsonPath }, stubCtx())
+      return validateTool.execute({ sql: testSql, dialect: "snowflake", schema_path: schemaJsonPath }, stubCtx())
     },
     { metadataSuccess: true },
   )
@@ -198,7 +198,7 @@ async function main() {
   await check(
     "validate: with schema_path (YAML file) → success",
     async () => {
-      return validateTool.execute({ sql: testSql, schema_path: schemaYamlPath }, stubCtx())
+      return validateTool.execute({ sql: testSql, dialect: "snowflake", schema_path: schemaYamlPath }, stubCtx())
     },
     { metadataSuccess: true },
   )
@@ -206,7 +206,7 @@ async function main() {
   await check(
     "validate: with schema_path (nonexistent file) → error",
     async () => {
-      return validateTool.execute({ sql: testSql, schema_path: "/tmp/nonexistent-schema-abc123.json" }, stubCtx())
+      return validateTool.execute({ sql: testSql, dialect: "snowflake", schema_path: "/tmp/nonexistent-schema-abc123.json" }, stubCtx())
     },
     { metadataSuccess: false, noUnknownError: true },
   )
@@ -214,7 +214,7 @@ async function main() {
   await check(
     "validate: syntax error SQL with schema → error propagated",
     async () => {
-      return validateTool.execute({ sql: badSql, schema_context: flatSchema }, stubCtx())
+      return validateTool.execute({ sql: badSql, dialect: "snowflake", schema_context: flatSchema }, stubCtx())
     },
     { metadataSuccess: true, metadataErrorContains: "Syntax error", noUnknownError: true },
   )
@@ -230,7 +230,7 @@ async function main() {
   await check(
     "semantics: no schema → early return with 'No schema provided'",
     async () => {
-      return semanticsTool.execute({ sql: testSql }, stubCtx())
+      return semanticsTool.execute({ sql: testSql, dialect: "snowflake" }, stubCtx())
     },
     { metadataSuccess: false, metadataErrorContains: "No schema provided", noUnknownError: true },
   )
@@ -238,7 +238,7 @@ async function main() {
   await check(
     "semantics: with schema_context → runs (may find issues)",
     async () => {
-      return semanticsTool.execute({ sql: testSql, schema_context: flatSchema }, stubCtx())
+      return semanticsTool.execute({ sql: testSql, dialect: "snowflake", schema_context: flatSchema }, stubCtx())
     },
     { noUnknownError: true },
   )
@@ -246,7 +246,7 @@ async function main() {
   await check(
     "semantics: with schema_path → runs",
     async () => {
-      return semanticsTool.execute({ sql: testSql, schema_path: schemaJsonPath }, stubCtx())
+      return semanticsTool.execute({ sql: testSql, dialect: "snowflake", schema_path: schemaJsonPath }, stubCtx())
     },
     { noUnknownError: true },
   )
@@ -264,7 +264,7 @@ async function main() {
   await check(
     "equivalence: no schema → early return with 'No schema provided'",
     async () => {
-      return equivTool.execute({ sql1: testSql, sql2 }, stubCtx())
+      return equivTool.execute({ sql1: testSql, sql2, dialect: "snowflake" }, stubCtx())
     },
     { metadataSuccess: false, metadataErrorContains: "No schema provided", noUnknownError: true },
   )
@@ -272,7 +272,7 @@ async function main() {
   await check(
     "equivalence: with schema_context → runs",
     async () => {
-      return equivTool.execute({ sql1: testSql, sql2, schema_context: flatSchema }, stubCtx())
+      return equivTool.execute({ sql1: testSql, sql2, dialect: "snowflake", schema_context: flatSchema }, stubCtx())
     },
     { noUnknownError: true },
   )
@@ -280,7 +280,7 @@ async function main() {
   await check(
     "equivalence: with schema_path → runs",
     async () => {
-      return equivTool.execute({ sql1: testSql, sql2, schema_path: schemaJsonPath }, stubCtx())
+      return equivTool.execute({ sql1: testSql, sql2, dialect: "snowflake", schema_path: schemaJsonPath }, stubCtx())
     },
     { noUnknownError: true },
   )
@@ -296,7 +296,7 @@ async function main() {
   await check(
     "fix: unfixable syntax error → error propagated",
     async () => {
-      return fixTool.execute({ sql: badSql }, stubCtx())
+      return fixTool.execute({ sql: badSql, dialect: "snowflake" }, stubCtx())
     },
     { metadataSuccess: true, noUnknownError: true },
   )
@@ -304,7 +304,7 @@ async function main() {
   await check(
     "fix: valid SQL → success (already valid)",
     async () => {
-      return fixTool.execute({ sql: "SELECT 1", schema_context: flatSchema }, stubCtx())
+      return fixTool.execute({ sql: "SELECT 1", dialect: "snowflake", schema_context: flatSchema }, stubCtx())
     },
     { metadataSuccess: true },
   )
@@ -320,7 +320,7 @@ async function main() {
   await check(
     "correct: unfixable syntax error → error propagated",
     async () => {
-      return correctTool.execute({ sql: badSql }, stubCtx())
+      return correctTool.execute({ sql: badSql, dialect: "snowflake" }, stubCtx())
     },
     { metadataSuccess: true, noUnknownError: true },
   )
@@ -470,7 +470,7 @@ async function main() {
   await check(
     "schema_path: empty string → treated as no schema",
     async () => {
-      return validateTool.execute({ sql: testSql, schema_path: "" }, stubCtx())
+      return validateTool.execute({ sql: testSql, dialect: "snowflake", schema_path: "" }, stubCtx())
     },
     { metadataSuccess: false, metadataErrorContains: "No schema provided", noUnknownError: true },
   )
@@ -478,7 +478,7 @@ async function main() {
   await check(
     "schema_context: empty object → treated as no schema",
     async () => {
-      return validateTool.execute({ sql: testSql, schema_context: {} }, stubCtx())
+      return validateTool.execute({ sql: testSql, dialect: "snowflake", schema_context: {} }, stubCtx())
     },
     { metadataSuccess: false, metadataErrorContains: "No schema provided", noUnknownError: true },
   )
@@ -489,6 +489,7 @@ async function main() {
       return validateTool.execute(
         {
           sql: "SELECT id FROM users",
+          dialect: "snowflake",
           schema_context: {
             users: [
               { name: "id", type: "INTEGER" },
@@ -508,6 +509,7 @@ async function main() {
       return validateTool.execute(
         {
           sql: "SELECT id FROM users",
+          dialect: "snowflake",
           schema_context: {
             tables: {
               users: {

--- a/packages/opencode/test/altimate/tool-error-propagation.test.ts
+++ b/packages/opencode/test/altimate/tool-error-propagation.test.ts
@@ -64,7 +64,7 @@ describe("altimate_core_validate error propagation", () => {
 
     const { AltimateCoreValidateTool } = await import("../../src/altimate/tools/altimate-core-validate")
     const tool = await AltimateCoreValidateTool.init()
-    const result = await tool.execute({ sql: "SELECT * FROM users" }, stubCtx())
+    const result = await tool.execute({ sql: "SELECT * FROM users", dialect: "snowflake" }, stubCtx())
 
     // The engine ran (success=true), schema-less mode is flagged, and the
     // output warns the caller that existence checks were skipped.
@@ -97,7 +97,7 @@ describe("altimate_core_validate error propagation", () => {
     const { AltimateCoreValidateTool } = await import("../../src/altimate/tools/altimate-core-validate")
     const tool = await AltimateCoreValidateTool.init()
     const result = await tool.execute(
-      { sql: "SELECT * FROM users", schema_context: { orders: { id: "INT" } } },
+      { sql: "SELECT * FROM users", dialect: "snowflake", schema_context: { orders: { id: "INT" } } },
       stubCtx(),
     )
 
@@ -119,7 +119,7 @@ describe("altimate_core_semantics error propagation", () => {
   test("returns early with clear error when no schema provided", async () => {
     const { AltimateCoreSemanticsTool } = await import("../../src/altimate/tools/altimate-core-semantics")
     const tool = await AltimateCoreSemanticsTool.init()
-    const result = await tool.execute({ sql: "SELECT * FROM users" }, stubCtx())
+    const result = await tool.execute({ sql: "SELECT * FROM users", dialect: "snowflake" }, stubCtx())
 
     expect(result.metadata.success).toBe(false)
     expect(result.metadata.error).toContain("No schema provided")
@@ -142,7 +142,7 @@ describe("altimate_core_semantics error propagation", () => {
     const { AltimateCoreSemanticsTool } = await import("../../src/altimate/tools/altimate-core-semantics")
     const tool = await AltimateCoreSemanticsTool.init()
     const result = await tool.execute(
-      { sql: "SELECT * FROM users", schema_context: { orders: { id: "INT" } } },
+      { sql: "SELECT * FROM users", dialect: "snowflake", schema_context: { orders: { id: "INT" } } },
       stubCtx(),
     )
 
@@ -162,7 +162,7 @@ describe("altimate_core_equivalence error propagation", () => {
   test("returns early with clear error when no schema provided", async () => {
     const { AltimateCoreEquivalenceTool } = await import("../../src/altimate/tools/altimate-core-equivalence")
     const tool = await AltimateCoreEquivalenceTool.init()
-    const result = await tool.execute({ sql1: "SELECT * FROM users", sql2: "SELECT * FROM users" }, stubCtx())
+    const result = await tool.execute({ sql1: "SELECT * FROM users", sql2: "SELECT * FROM users", dialect: "snowflake" }, stubCtx())
 
     expect(result.metadata.success).toBe(false)
     expect(result.metadata.error).toContain("No schema provided")
@@ -184,7 +184,7 @@ describe("altimate_core_equivalence error propagation", () => {
     const { AltimateCoreEquivalenceTool } = await import("../../src/altimate/tools/altimate-core-equivalence")
     const tool = await AltimateCoreEquivalenceTool.init()
     const result = await tool.execute(
-      { sql1: "SELECT * FROM users", sql2: "SELECT * FROM users", schema_context: { orders: { id: "INT" } } },
+      { sql1: "SELECT * FROM users", sql2: "SELECT * FROM users", dialect: "snowflake", schema_context: { orders: { id: "INT" } } },
       stubCtx(),
     )
 
@@ -228,7 +228,7 @@ describe("altimate_core_fix error propagation", () => {
 
     const { AltimateCoreFixTool } = await import("../../src/altimate/tools/altimate-core-fix")
     const tool = await AltimateCoreFixTool.init()
-    const result = await tool.execute({ sql: "SELCT * FORM users" }, stubCtx())
+    const result = await tool.execute({ sql: "SELCT * FORM users", dialect: "snowflake" }, stubCtx())
 
     expect(result.metadata.error).toContain("Syntax error")
     expect(telemetryWouldExtract(result.metadata)).not.toBe("unknown error")
@@ -269,7 +269,7 @@ describe("altimate_core_correct error propagation", () => {
 
     const { AltimateCoreCorrectTool } = await import("../../src/altimate/tools/altimate-core-correct")
     const tool = await AltimateCoreCorrectTool.init()
-    const result = await tool.execute({ sql: "SELCT * FORM users" }, stubCtx())
+    const result = await tool.execute({ sql: "SELCT * FORM users", dialect: "snowflake" }, stubCtx())
 
     expect(result.metadata.error).toContain("Syntax error")
     expect(telemetryWouldExtract(result.metadata)).not.toBe("unknown error")
@@ -488,7 +488,7 @@ describe("extractors handle empty message fields", () => {
     const { AltimateCoreValidateTool } = await import("../../src/altimate/tools/altimate-core-validate")
     const tool = await AltimateCoreValidateTool.init()
     const result = await tool.execute(
-      { sql: "SELECT * FROM nonexistent_table", schema_context: { users: { id: "INT" } } },
+      { sql: "SELECT * FROM nonexistent_table", dialect: "snowflake", schema_context: { users: { id: "INT" } } },
       stubCtx(),
     )
     // The error should never be empty string — .filter(Boolean) removes it

--- a/packages/opencode/test/altimate/tools/altimate-core-validate.test.ts
+++ b/packages/opencode/test/altimate/tools/altimate-core-validate.test.ts
@@ -189,7 +189,7 @@ describe("AltimateCoreValidateTool.execute", () => {
     })
 
     const tool = await AltimateCoreValidateTool.init()
-    const result = await tool.execute({ sql: "SELECT 1" }, ctx as any)
+    const result = await tool.execute({ sql: "SELECT 1", dialect: "snowflake" }, ctx as any)
 
     // The engine ran, so success should be true.
     expect(result.metadata.success).toBe(true)
@@ -211,6 +211,7 @@ describe("AltimateCoreValidateTool.execute", () => {
     const result = await tool.execute(
       {
         sql: "SELECT id FROM users",
+        dialect: "snowflake",
         schema_context: {
           users: { id: "INTEGER", name: "VARCHAR" },
         },
@@ -233,7 +234,7 @@ describe("AltimateCoreValidateTool.execute", () => {
 
     const tool = await AltimateCoreValidateTool.init()
     const result = await tool.execute(
-      { sql: "SELECT 1", schema_path: "/tmp/schema.yaml" },
+      { sql: "SELECT 1", dialect: "snowflake", schema_path: "/tmp/schema.yaml" },
       ctx as any,
     )
 
@@ -247,7 +248,7 @@ describe("AltimateCoreValidateTool.execute", () => {
     })
 
     const tool = await AltimateCoreValidateTool.init()
-    const result = await tool.execute({ sql: "SELECT 1", schema_context: {} }, ctx as any)
+    const result = await tool.execute({ sql: "SELECT 1", dialect: "snowflake", schema_context: {} }, ctx as any)
 
     expect(result.metadata.has_schema).toBe(false)
   })
@@ -268,6 +269,7 @@ describe("AltimateCoreValidateTool.execute", () => {
     const result = await tool.execute(
       {
         sql: "SELECT xyz FROOM users",
+        dialect: "snowflake",
         schema_context: { users: { id: "INTEGER" } },
       },
       ctx as any,
@@ -292,7 +294,7 @@ describe("AltimateCoreValidateTool.execute", () => {
     })
 
     const tool = await AltimateCoreValidateTool.init()
-    const result = await tool.execute({ sql: "SELECT 1" }, ctx as any)
+    const result = await tool.execute({ sql: "SELECT 1", dialect: "snowflake" }, ctx as any)
 
     expect(result.metadata.success).toBe(false)
     expect(result.metadata.error_class).toBe("engine_failure")
@@ -308,7 +310,7 @@ describe("AltimateCoreValidateTool.execute", () => {
     )
 
     const tool = await AltimateCoreValidateTool.init()
-    await tool.execute({ sql: "SELECT 1" }, ctx as any)
+    await tool.execute({ sql: "SELECT 1", dialect: "snowflake" }, ctx as any)
 
     expect(spy).toHaveBeenCalledTimes(1)
     spy.mockRestore()


### PR DESCRIPTION
## Summary

Fixes #455 — Adds optional `dialect` parameter (default: `"snowflake"`) to all 8 altimate-core tools that were hardcoding it:

- `altimate-core-validate.ts`, `fix.ts`, `correct.ts`, `semantics.ts`, `equivalence.ts`, `policy.ts`, `check.ts`
- `impact-analysis.ts`

Each tool now accepts `dialect` via zod schema, passes it to the Dispatcher call, and includes it in telemetry metadata. Follows the pattern already established in `sql-analyze.ts`, `sql-optimize.ts`, and `schema-diff.ts`.

Type interfaces updated in `types.ts`. Tests updated to pass dialect explicitly.

## Test Plan

- [x] `bun turbo typecheck` — 5/5 packages pass
- [x] `bun test test/altimate/schema-finops-dbt.test.ts` — 56 pass
- [x] `bun test test/altimate/tool-error-propagation.test.ts` — 22 pass
- [ ] Manual: run tools with `dialect: "postgres"` and verify it reaches telemetry

## Checklist

- [x] Follows existing pattern from sql-analyze/optimize/schema-diff
- [x] Default value preserves backward compatibility
- [x] No breaking changes
- [x] Tests updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Altimate tools (validate, check, fix, correct, policy, semantics, equivalence) accept an optional dialect parameter (default "snowflake").
  * Tool responses/metadata now include the provided dialect for all outcomes (success, failure, and error paths).
  * Schema resolution fallback parsing now respects the provided dialect for consistent SQL parsing/validation.

* **Tests**
  * Tests updated to include and assert dialect handling across affected tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->