### PR TITLE
ci: add Verdaccio sanity suite to CI and release workflows

### DIFF
--- a/.github/meta/commit.txt
+++ b/.github/meta/commit.txt
@@ -1,6 +1,17 @@
-fix: remove flaky `setTimeout` in todo bus event test
+ci: add Verdaccio sanity suite to CI and release workflows
 
-`Bus.publish` is synchronous — the event is delivered immediately,
-no 50ms delay needed. Removes resource contention risk in parallel CI.
+Adds the Verdaccio-based sanity suite (real `npm install -g` flow)
+to both CI and release pipelines:
+
+**CI (`ci.yml`):**
+- New `sanity-verdaccio` job on push to main
+- Builds linux-x64 binary + dbt-tools, runs full Docker Compose suite
+- Independent of other jobs (doesn't block PRs)
+
+**Release (`release.yml`):**
+- New `sanity-verdaccio` job between build and npm publish
+- Downloads linux-x64 artifact from build matrix
+- **Blocks `publish-npm`** — broken install flow prevents release
+- Dependency chain: build → sanity-verdaccio → publish-npm → github-release
 
 Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,53 @@ jobs:
           DBT_E2E_VERSIONS: "1.8,1.10,1.11"
           DBT_RESOLVE_SCENARIOS: "venv,uv,system"
 
+  # ---------------------------------------------------------------------------
+  # Verdaccio sanity suite — tests the real `npm install -g` flow.
+  # Only on push to main (too slow for PRs, needs Docker Compose).
+  # Catches publish-pipeline bugs: missing files, broken symlinks, wrong bin
+  # field, dependency resolution failures, postinstall script issues.
+  # ---------------------------------------------------------------------------
+  sanity-verdaccio:
+    name: Sanity (Verdaccio)
+    needs: changes
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2
+        with:
+          bun-version: "1.3.10"
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build CLI binary
+        run: bun run packages/opencode/script/build.ts --target-index=1
+        env:
+          OPENCODE_VERSION: 0.0.0-sanity-${{ github.sha }}
+          MODELS_DEV_API_JSON: test/tool/fixtures/models-api.json
+
+      - name: Build dbt-tools
+        run: bun run build
+        working-directory: packages/dbt-tools
+
+      - name: Run Verdaccio sanity suite
+        run: |
+          docker compose -f test/sanity/docker-compose.verdaccio.yml up \
+            --build --abort-on-container-exit --exit-code-from sanity
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
   marker-guard:
     name: Marker Guard
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,9 +125,54 @@ jobs:
           path: packages/opencode/dist/
           compression-level: 1
 
+  # ---------------------------------------------------------------------------
+  # Verdaccio sanity suite — tests the real `npm install -g` flow BEFORE
+  # publishing to npm. Catches broken symlinks, missing files, postinstall
+  # failures, and dependency resolution issues that smoke tests miss.
+  # ---------------------------------------------------------------------------
+  sanity-verdaccio:
+    name: Sanity (Verdaccio)
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2
+        with:
+          bun-version: "1.3.10"
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Download linux-x64 build artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist-linux-x64
+          path: packages/opencode/dist/
+
+      - name: Build dbt-tools
+        run: bun run build
+        working-directory: packages/dbt-tools
+
+      - name: Run Verdaccio sanity suite
+        run: |
+          docker compose -f test/sanity/docker-compose.verdaccio.yml up \
+            --build --abort-on-container-exit --exit-code-from sanity
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
   publish-npm:
     name: Publish to npm
-    needs: build
+    needs: [build, sanity-verdaccio]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
### What does this PR do?

Adds the Verdaccio-based sanity suite (real `npm install -g` flow) to both CI and release pipelines. Previously this only ran locally via `docker compose`.

**CI (`ci.yml`):**
- New `sanity-verdaccio` job runs on push to main
- Builds linux-x64 binary + dbt-tools, then runs full Docker Compose Verdaccio suite
- Independent of other jobs — doesn't slow down PR checks

**Release (`release.yml`):**
- New `sanity-verdaccio` job runs between `build` and `publish-npm`
- Downloads linux-x64 artifact from the build matrix
- **Blocks npm publish** — if the install flow is broken, the release stops
- Dependency chain: `build → sanity-verdaccio → publish-npm → github-release`

This catches publish-pipeline bugs before they reach users: missing files in tarballs, broken symlinks, postinstall failures, dependency resolution issues, wrong bin field.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Test coverage
- [ ] Documentation
- [ ] Refactoring
- [x] Infrastructure

### Issue for this PR

Closes #559

### How did you verify your code works?

- YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`
- Dependency chain verified: `sanity-verdaccio` needs `build`, `publish-npm` needs `[build, sanity-verdaccio]`
- CI job correctly gated with `if: github.event_name == 'push'` (main only)
- Verdaccio suite tested locally: `docker compose -f test/sanity/docker-compose.verdaccio.yml up --build`

### Checklist

- [x] YAML syntax validated
- [x] Release workflow dependency chain correct (sanity blocks publish)
- [x] CI job only runs on push to main (not PRs)
- [x] Uses same action versions and cache keys as existing jobs
- [x] No secrets exposed (ANTHROPIC_API_KEY passed via `secrets` context)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated sanity testing to the continuous integration pipeline
  * Updated release workflow to include additional validation checks before package publication
  * Enhanced CI and release processes with Docker Compose-based testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->