### PR TITLE
fix: address ClickHouse driver review findings

### DIFF
--- a/packages/drivers/test/clickhouse-unit.test.ts
+++ b/packages/drivers/test/clickhouse-unit.test.ts
@@ -203,6 +203,38 @@ describe("ClickHouse driver unit tests", () => {
       await connector.execute("SELECT 'it''s -- LIMIT 5' FROM t", 10)
       expect(mockQueryCalls[0].query).toContain("LIMIT 11")
     })
+
+    test("leading block comment does NOT bypass LIMIT injection", async () => {
+      mockQueryResult = [{ id: 1 }]
+      await connector.execute("/* analytics query */ SELECT * FROM t", 10)
+      expect(mockQueryCalls[0].query).toContain("LIMIT 11")
+    })
+
+    test("multi-line block comment before SELECT does NOT bypass LIMIT", async () => {
+      mockQueryResult = [{ id: 1 }]
+      await connector.execute("/*\n * Report query\n * Author: test\n */\nSELECT * FROM t", 10)
+      expect(mockQueryCalls[0].query).toContain("LIMIT 11")
+    })
+
+    test("backslash-escaped string does NOT break LIMIT check", async () => {
+      mockQueryResult = [{ id: 1 }]
+      await connector.execute("SELECT 'path\\\\to\\'s -- LIMIT 5' FROM t", 10)
+      expect(mockQueryCalls[0].query).toContain("LIMIT 11")
+    })
+
+    test("leading comment does NOT misroute SELECT as DDL", async () => {
+      mockQueryResult = [{ id: 1 }]
+      await connector.execute("-- INSERT note\nSELECT * FROM t", 10)
+      expect(mockQueryCalls.length).toBe(1)
+      expect(mockCommandCalls.length).toBe(0)
+    })
+
+    test("block comment containing DDL keyword does NOT misroute SELECT", async () => {
+      mockQueryResult = [{ id: 1 }]
+      await connector.execute("/* DROP TABLE note */ SELECT * FROM t", 10)
+      expect(mockQueryCalls.length).toBe(1)
+      expect(mockCommandCalls.length).toBe(0)
+    })
   })
 
   // --- Truncation detection ---
@@ -282,6 +314,31 @@ describe("ClickHouse driver unit tests", () => {
 
     test("LowCardinality(String) is NOT nullable", async () => {
       mockQueryResult = [{ name: "col1", type: "LowCardinality(String)" }]
+      const cols = await connector.describeTable("default", "t")
+      expect(cols[0].nullable).toBe(false)
+    })
+
+    test("LowCardinality(Nullable(FixedString(32))) IS nullable — nested inner type", async () => {
+      mockQueryResult = [{ name: "col1", type: "LowCardinality(Nullable(FixedString(32)))" }]
+      const cols = await connector.describeTable("default", "t")
+      expect(cols[0].nullable).toBe(true)
+    })
+
+    test("Map(String, Nullable(UInt32)) is NOT nullable at column level", async () => {
+      // The map values are nullable, but the column itself is not
+      mockQueryResult = [{ name: "col1", type: "Map(String, Nullable(UInt32))" }]
+      const cols = await connector.describeTable("default", "t")
+      expect(cols[0].nullable).toBe(false)
+    })
+
+    test("Tuple(Nullable(String), UInt32) is NOT nullable at column level", async () => {
+      mockQueryResult = [{ name: "col1", type: "Tuple(Nullable(String), UInt32)" }]
+      const cols = await connector.describeTable("default", "t")
+      expect(cols[0].nullable).toBe(false)
+    })
+
+    test("handles empty/missing type gracefully", async () => {
+      mockQueryResult = [{ name: "col1", type: undefined }]
       const cols = await connector.describeTable("default", "t")
       expect(cols[0].nullable).toBe(false)
     })


### PR DESCRIPTION
## Summary
- Add 9 edge-case tests covering all 4 findings from the 6-model code review panel (#592)
- **Nullable regression**: verify `LowCardinality(Nullable(FixedString(32)))` is nullable, `Map`/`Tuple` wrappers are not, and `undefined` type falls back to non-nullable
- **SQL parsing**: verify leading block comments, multi-line block comments, backslash-escaped strings, and DDL keywords inside comments don't bypass LIMIT injection or misroute queries

Fixes #592

## Test Plan
- All 55 tests pass (`bun test clickhouse-unit`)
- Typecheck clean (only pre-existing `@clickhouse/client` module error)

## Checklist
- [x] Tests cover all 4 review findings (nullable, trailing comment, leading comment, string literals)
- [x] Edge cases: nested types, multi-line comments, escaped strings, DDL in comments
- [x] No source changes needed — PR #591 already fixed the driver code, these tests confirm correctness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Extended coverage to ensure LIMIT injection protection still appends LIMIT when SQL has leading single-line or block comments, multi-line comments, or escaped-quote sequences containing comment-like text.
  * Added assertions that SELECT statements are executed via the correct query path even when comments include DDL-like keywords.
  * Expanded nullable/type detection tests for nested nullable, map/tuple patterns, and undefined type handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->