### PR TITLE
fix: restore `does not exist` to validation error keywords

### DIFF
--- a/packages/opencode/src/altimate/telemetry/index.ts
+++ b/packages/opencode/src/altimate/telemetry/index.ts
@@ -795,7 +795,7 @@ export namespace Telemetry {
       keywords: ["status code: 4", "status code: 5", "request failed with status", "http 404", "http 410", "http 429", "http 451", "http 403"],
     },
     // altimate_change end
-    // altimate_change start — split file_stale out of validation; remove "does not exist" (was catching HTTP 404s)
+    // altimate_change start — split file_stale out of validation for cleaner triage
     {
       class: "file_stale",
       keywords: [
@@ -811,6 +811,7 @@ export namespace Telemetry {
         "invalid",
         "missing",
         "required",
+        "does not exist",
       ],
     },
     // altimate_change end

--- a/packages/opencode/test/telemetry/telemetry.test.ts
+++ b/packages/opencode/test/telemetry/telemetry.test.ts
@@ -1628,13 +1628,15 @@ describe("telemetry.classifyError", () => {
     expect(Telemetry.classifyError("Invalid dialect specified")).toBe("validation")
     expect(Telemetry.classifyError("Missing required field")).toBe("validation")
     expect(Telemetry.classifyError("Required parameter 'query' not provided")).toBe("validation")
-    // altimate_change start — file_stale split out from validation; "does not exist" moved to http_error
+    // altimate_change start — file_stale split out from validation
     // These are now classified as file_stale, not validation
     expect(Telemetry.classifyError("You must read file /path/to/file before overwriting it")).toBe("file_stale")
     expect(Telemetry.classifyError("File has been modified since it was last read")).toBe("file_stale")
     expect(Telemetry.classifyError("You must read file before overwriting it. Use the Read tool first")).toBe("file_stale")
-    // HTTP 404 "does not exist" is now http_error
+    // HTTP 404 "does not exist" matches http_error first (pattern priority), not validation
     expect(Telemetry.classifyError("HTTP 404: https://example.com/page does not exist")).toBe("http_error")
+    // SQL "does not exist" matches validation (no http_error keywords present)
+    expect(Telemetry.classifyError("error: column foo does not exist")).toBe("validation")
     // altimate_change end
   })
 


### PR DESCRIPTION
### What does this PR do?

Restores `"does not exist"` to the `validation` error classification keywords. It was removed in #611 to prevent HTTP 404 misclassification, but the pattern reordering in the same PR already handles that — `http_error` now has priority over `validation`. The removal caused SQL errors like `"column foo does not exist"` to fall through to `unknown`.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #613

### How did you verify your code works?

- 195/195 tests pass (`telemetry.test.ts`, `time.test.ts`, `edit.test.ts`, `write.test.ts`)
- New test case: `"error: column foo does not exist"` → `validation`
- Existing test: `"HTTP 404: ... does not exist"` → `http_error` (still works via pattern priority)
- Upstream marker check passes (`--markers --base main --strict`)

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)