### PR TITLE
test: project-scan — ClickHouse env var detection and DATABASE_URL scheme parsing

### DIFF
--- a/packages/opencode/test/tool/project-scan.test.ts
+++ b/packages/opencode/test/tool/project-scan.test.ts
@@ -312,6 +312,8 @@ describe("detectEnvVars", () => {
       "PGHOST", "PGPORT", "PGDATABASE", "PGUSER", "PGPASSWORD", "DATABASE_URL",
       "MYSQL_HOST", "MYSQL_TCP_PORT", "MYSQL_DATABASE", "MYSQL_USER", "MYSQL_PASSWORD",
       "REDSHIFT_HOST", "REDSHIFT_PORT", "REDSHIFT_DATABASE", "REDSHIFT_USER", "REDSHIFT_PASSWORD",
+      "CLICKHOUSE_HOST", "CLICKHOUSE_URL", "CLICKHOUSE_PORT", "CLICKHOUSE_DB",
+      "CLICKHOUSE_DATABASE", "CLICKHOUSE_USER", "CLICKHOUSE_USERNAME", "CLICKHOUSE_PASSWORD",
     ]
     for (const v of vars) {
       delete process.env[v]
@@ -500,6 +502,62 @@ describe("detectEnvVars", () => {
     expect(rs!.config.host).toBe("redshift-cluster.abc.us-east-1.redshift.amazonaws.com")
     expect(rs!.config.database).toBe("warehouse")
     expect(rs!.config.user).toBe("admin")
+  })
+
+  test("detects ClickHouse via CLICKHOUSE_HOST", async () => {
+    clearWarehouseEnvVars()
+    process.env.CLICKHOUSE_HOST = "clickhouse.example.com"
+    process.env.CLICKHOUSE_PORT = "8443"
+    process.env.CLICKHOUSE_DATABASE = "analytics"
+    process.env.CLICKHOUSE_USER = "default"
+    process.env.CLICKHOUSE_PASSWORD = "secret"
+
+    const result = await detectEnvVars()
+    const ch = result.find((r) => r.type === "clickhouse")
+    expect(ch).toBeDefined()
+    expect(ch!.name).toBe("env_clickhouse")
+    expect(ch!.source).toBe("env-var")
+    expect(ch!.signal).toBe("CLICKHOUSE_HOST")
+    expect(ch!.config.host).toBe("clickhouse.example.com")
+    expect(ch!.config.port).toBe("8443")
+    expect(ch!.config.database).toBe("analytics")
+    expect(ch!.config.user).toBe("default")
+    expect(ch!.config.password).toBe("***")
+  })
+
+  test("detects ClickHouse via CLICKHOUSE_URL", async () => {
+    clearWarehouseEnvVars()
+    process.env.CLICKHOUSE_URL = "https://clickhouse.example.com:8443"
+
+    const result = await detectEnvVars()
+    const ch = result.find((r) => r.type === "clickhouse")
+    expect(ch).toBeDefined()
+    expect(ch!.signal).toBe("CLICKHOUSE_URL")
+    expect(ch!.config.connection_string).toBe("***")
+  })
+
+  test("detects ClickHouse via DATABASE_URL with clickhouse scheme", async () => {
+    clearWarehouseEnvVars()
+    process.env.DATABASE_URL = "clickhouse://default:pass@clickhouse.example.com:8443/analytics"
+
+    const result = await detectEnvVars()
+    const ch = result.find((r) => r.type === "clickhouse")
+    expect(ch).toBeDefined()
+    expect(ch!.signal).toBe("DATABASE_URL")
+    expect(ch!.config.connection_string).toBe("***")
+  })
+
+  test("detects ClickHouse via DATABASE_URL with clickhouse+http and clickhouse+https schemes", async () => {
+    for (const scheme of ["clickhouse+http", "clickhouse+https"]) {
+      clearWarehouseEnvVars()
+      process.env.DATABASE_URL = `${scheme}://default:pass@clickhouse.example.com:8443/analytics`
+
+      const result = await detectEnvVars()
+      const ch = result.find((r) => r.type === "clickhouse")
+      expect(ch).toBeDefined()
+      expect(ch!.signal).toBe("DATABASE_URL")
+      expect(ch!.type).toBe("clickhouse")
+    }
   })
 
   test("detects multiple warehouses simultaneously", async () => {


### PR DESCRIPTION
## Summary

**`detectEnvVars()` — `src/altimate/tools/project-scan.ts`** (4 new tests)

The ClickHouse warehouse driver was added in PR #574, which included new env var detection entries (`CLICKHOUSE_HOST`, `CLICKHOUSE_URL`) and new `DATABASE_URL` scheme mappings (`clickhouse://`, `clickhouse+http://`, `clickhouse+https://`) in `detectEnvVars()`. However, no tests were added for these code paths. All other warehouse types (Snowflake, BigQuery, Databricks, Postgres, MySQL, Redshift) had detection tests — ClickHouse was the only gap.

**Why it matters:** Without these tests, a regression that removes or breaks the ClickHouse entries in `detectEnvVars()` would go undetected. Users with `CLICKHOUSE_HOST` or `DATABASE_URL=clickhouse://...` set would get no auto-detection during `project_scan`, breaking the "just works" onboarding experience. The `DATABASE_URL` scheme tests are especially important because a missing scheme entry silently falls through to the `"postgres"` default — a silent misclassification.

**Specific scenarios covered:**
- ClickHouse detection via `CLICKHOUSE_HOST` with full config (host, port, database, user, password masking)
- ClickHouse detection via `CLICKHOUSE_URL` (connection_string signal path)
- `DATABASE_URL` with `clickhouse://` scheme → correctly classified as `clickhouse` (not `postgres`)
- `DATABASE_URL` with `clickhouse+http://` and `clickhouse+https://` schemes → both classified as `clickhouse`

**Also fixed:** Updated `clearWarehouseEnvVars()` test helper to clear all 8 `CLICKHOUSE_*` env vars, ensuring test isolation.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage for ClickHouse driver added in #574

### How did you verify your code works?

```
bun test test/tool/project-scan.test.ts    # 77 pass (73 existing + 4 new)
bun run script/upstream/analyze.ts --markers --base main --strict   # ok
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_014pS7RRkb53MH36pc6qhSBT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for ClickHouse database detection across multiple environment variable formats.
  * Added validation for proper environment variable masking in ClickHouse configuration detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->