### PR TITLE
test: clickhouse — finops query history, dbt profiles, and registry error hints

### DIFF
--- a/packages/opencode/test/altimate/connections.test.ts
+++ b/packages/opencode/test/altimate/connections.test.ts
@@ -51,6 +51,36 @@ describe("ConnectionRegistry", () => {
     )
   })
 
+  test("cassandra gives helpful hint instead of generic unsupported error", async () => {
+    Registry.setConfigs({
+      mydb: { type: "cassandra", host: "localhost" },
+    })
+    await expect(Registry.get("mydb")).rejects.toThrow("not yet supported")
+    await expect(Registry.get("mydb")).rejects.toThrow("cqlsh")
+  })
+
+  test("cockroachdb suggests using postgres type", async () => {
+    Registry.setConfigs({
+      mydb: { type: "cockroachdb", host: "localhost" },
+    })
+    await expect(Registry.get("mydb")).rejects.toThrow("postgres")
+  })
+
+  test("timescaledb suggests using postgres type", async () => {
+    Registry.setConfigs({
+      mydb: { type: "timescaledb", host: "localhost" },
+    })
+    await expect(Registry.get("mydb")).rejects.toThrow("postgres")
+  })
+
+  test("truly unknown type gives generic unsupported error with supported list", async () => {
+    Registry.setConfigs({
+      mydb: { type: "neo4j", host: "localhost" },
+    })
+    await expect(Registry.get("mydb")).rejects.toThrow("Unsupported database type")
+    await expect(Registry.get("mydb")).rejects.toThrow("Supported:")
+  })
+
   test("getConfig returns config for known connection", () => {
     Registry.setConfigs({
       mydb: { type: "postgres", host: "localhost" },
@@ -604,6 +634,44 @@ trino_project:
       expect(connections).toHaveLength(1)
       expect(connections[0].type).toBe("postgres")
       expect(connections[0].config.type).toBe("postgres")
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true })
+    }
+  })
+
+  test("clickhouse adapter maps correctly from dbt profiles", async () => {
+    const fs = await import("fs")
+    const os = await import("os")
+    const path = await import("path")
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dbt-test-"))
+    const profilesPath = path.join(tmpDir, "profiles.yml")
+
+    fs.writeFileSync(
+      profilesPath,
+      `
+ch_project:
+  outputs:
+    dev:
+      type: clickhouse
+      host: clickhouse.example.com
+      port: 8443
+      user: default
+      password: secret
+      database: analytics
+      schema: default
+`,
+    )
+
+    try {
+      const connections = await parseDbtProfiles(profilesPath)
+      expect(connections).toHaveLength(1)
+      expect(connections[0].type).toBe("clickhouse")
+      expect(connections[0].config.type).toBe("clickhouse")
+      expect(connections[0].config.host).toBe("clickhouse.example.com")
+      expect(connections[0].config.port).toBe(8443)
+      expect(connections[0].config.user).toBe("default")
+      expect(connections[0].config.database).toBe("analytics")
     } finally {
       fs.rmSync(tmpDir, { recursive: true })
     }

--- a/packages/opencode/test/altimate/schema-finops-dbt.test.ts
+++ b/packages/opencode/test/altimate/schema-finops-dbt.test.ts
@@ -158,6 +158,53 @@ describe("FinOps: SQL template generation", () => {
       const built = HistoryTemplates.buildHistoryQuery("databricks", 7, 50)
       expect(built?.sql).toContain("system.query.history")
     })
+
+    test("builds ClickHouse history SQL with clamped integer days and limit", () => {
+      const built = HistoryTemplates.buildHistoryQuery("clickhouse", 7, 100)
+      expect(built).not.toBeNull()
+      expect(built?.sql).toContain("system.query_log")
+      expect(built?.sql).toContain("QueryFinish")
+      // Days and limit should be integer-substituted, not bind params
+      expect(built?.binds).toEqual([])
+      // Verify the clamped values are in the SQL
+      expect(built?.sql).toContain("today() - 7")
+      expect(built?.sql).toContain("LIMIT 100")
+    })
+
+    test("ClickHouse buildHistoryQuery clamps extreme days and limit values", () => {
+      // Days clamped to [1, 365]
+      const extremeDays = HistoryTemplates.buildHistoryQuery("clickhouse", 9999, 50)
+      expect(extremeDays?.sql).toContain("today() - 365")
+
+      const zeroDays = HistoryTemplates.buildHistoryQuery("clickhouse", 0, 50)
+      // Math.floor(0) || 30 = 30 (0 is falsy), then Math.max(1, Math.min(30, 365)) = 30
+      expect(zeroDays?.sql).toContain("today() - 30")
+
+      // Limit clamped to [1, 10000]
+      const extremeLimit = HistoryTemplates.buildHistoryQuery("clickhouse", 7, 999999)
+      expect(extremeLimit?.sql).toContain("LIMIT 10000")
+
+      const zeroLimit = HistoryTemplates.buildHistoryQuery("clickhouse", 7, 0)
+      // Math.floor(0) || 100 = 100 (0 is falsy), then Math.max(1, Math.min(100, 10000)) = 100
+      expect(zeroLimit?.sql).toContain("LIMIT 100")
+    })
+
+    test("ClickHouse buildHistoryQuery handles NaN and float inputs safely", () => {
+      // NaN days defaults to 30 via || 30 fallback
+      const nanDays = HistoryTemplates.buildHistoryQuery("clickhouse", NaN, 50)
+      expect(nanDays?.sql).toContain("today() - 30")
+      expect(nanDays?.sql).not.toContain("NaN")
+
+      // NaN limit defaults to 100 via || 100 fallback
+      const nanLimit = HistoryTemplates.buildHistoryQuery("clickhouse", 7, NaN)
+      expect(nanLimit?.sql).toContain("LIMIT 100")
+      expect(nanLimit?.sql).not.toContain("NaN")
+
+      // Float values should be floored
+      const floatInputs = HistoryTemplates.buildHistoryQuery("clickhouse", 7.9, 50.5)
+      expect(floatInputs?.sql).toContain("today() - 7")
+      expect(floatInputs?.sql).toContain("LIMIT 50")
+    })
   })
 
   describe("warehouse-advisor", () => {


### PR DESCRIPTION
## Summary

Cover ClickHouse paths added in PR #574 that had zero test coverage, plus registry error hint tests for known-unsupported database types.

**1. `buildHistoryQuery` ClickHouse branch — `src/altimate/native/finops/query-history.ts`** (3 new tests)

The ClickHouse finops query history path uses `__DAYS__`/`__LIMIT__` string interpolation (unlike other warehouses that use bind parameters), making input clamping correctness critical. Zero tests existed. New coverage includes:
- SQL template correctness (system.query_log, QueryFinish, empty binds)
- Integer clamping for extreme values (days clamped to [1, 365], limit to [1, 10000])
- NaN and float safety — prevents `today() - NaN` or `LIMIT 50.5` in generated SQL
- Falsy-zero fallback behavior (`0` triggers `|| 30` / `|| 100` defaults)

**2. `parseDbtProfiles` ClickHouse adapter — `src/altimate/native/connections/dbt-profiles.ts`** (1 new test)

The `clickhouse` entry was added to `ADAPTER_TYPE_MAP` but had no test verifying it maps correctly through the full `parseDbtProfiles` flow. A user with a ClickHouse adapter in their dbt `profiles.yml` would get silently skipped connections if this mapping broke. New coverage includes:
- Full YAML → ConnectionConfig round-trip for ClickHouse adapter type
- Field mapping correctness (host, port, user, database)

**3. Registry known-unsupported database hints — `src/altimate/native/connections/registry.ts`** (4 new tests)

The `KNOWN_UNSUPPORTED` map (cassandra, cockroachdb, timescaledb) provides friendlier error messages than the generic "Unsupported database type" error, but had zero test coverage. New coverage includes:
- Cassandra: helpful "not yet supported" + cqlsh hint
- CockroachDB: suggests using `type: postgres` instead
- TimescaleDB: suggests using `type: postgres` instead
- Truly unknown type (neo4j): generic error with supported type list

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage for ClickHouse paths added in PR #574

### How did you verify your code works?

```
bun test test/altimate/schema-finops-dbt.test.ts  # 59 pass (56 existing + 3 new)
bun test test/altimate/connections.test.ts         # 78 pass (73 existing + 5 new)
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01CB7m2CjEFJbJia3ZJKZpHN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for connection registry error messaging for unsupported database types.
  * Added test coverage for ClickHouse adapter support in dbt profiles parsing.
  * Added comprehensive tests for ClickHouse query history generation, including parameter validation and edge case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->