### PR TITLE
fix: normalize `mcpServers` config key to `mcp` and transform external MCP formats

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1385,8 +1385,11 @@ export namespace Config {
     if (result.mcp && typeof result.mcp === "object" && !Array.isArray(result.mcp)) {
       const servers = { ...(result.mcp as Record<string, any>) }
       for (const [name, entry] of Object.entries(servers)) {
-        if (!entry || typeof entry !== "object") continue
-        // Build a normalized entry — Handles both untyped and typed entries with external fields
+        if (!entry || typeof entry !== "object") {
+          delete servers[name]
+          continue
+        }
+        // Build a normalized entry — handles both untyped and typed entries with external fields
         if (entry.command || entry.args) {
           const cmd = Array.isArray(entry.command)
             ? entry.command.map(String)

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -487,6 +487,249 @@ test("normalizes typed entry with external field names", async () => {
   })
 })
 
+// --- Adversarial tests for mcpServers normalization ---
+
+test("mcpServers normalization: empty mcpServers object loads without error", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, { mcpServers: {} })
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      // Empty mcp is fine — no servers, no crash
+      expect(config.mcp).toEqual({})
+    },
+  })
+})
+
+test("mcpServers normalization: non-object mcpServers value is ignored", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, { mcpServers: "not-an-object" })
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      // String value for mcp will fail schema validation (expects record)
+      await expect(Config.get()).rejects.toThrow()
+    },
+  })
+})
+
+test("mcpServers normalization: null/undefined server entries are removed", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, {
+        mcpServers: {
+          valid: { command: "node", args: ["server.js"] },
+          nullEntry: null,
+        },
+      })
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.mcp).toBeDefined()
+      // Valid entry normalized, null entry removed
+      const valid = config.mcp!.valid as any
+      expect(valid.type).toBe("local")
+      expect(valid.command).toEqual(["node", "server.js"])
+      expect((config.mcp! as any).nullEntry).toBeUndefined()
+    },
+  })
+})
+
+test("mcpServers normalization: special characters in server names are handled", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, {
+        mcpServers: {
+          "my-server_v2.0": { command: "node", args: ["server.js"] },
+          "server@prod": { url: "https://prod.example.com/mcp" },
+        },
+      })
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.mcp).toBeDefined()
+      const local = config.mcp!["my-server_v2.0"] as any
+      expect(local.type).toBe("local")
+      expect(local.command).toEqual(["node", "server.js"])
+      const remote = config.mcp!["server@prod"] as any
+      expect(remote.type).toBe("remote")
+      expect(remote.url).toBe("https://prod.example.com/mcp")
+      // Object prototype should not be polluted
+      expect(({} as any).command).toBeUndefined()
+    },
+  })
+})
+
+test("mcpServers normalization: numeric and boolean args are coerced to strings", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, {
+        mcpServers: {
+          myserver: {
+            command: "node",
+            args: [42, true, "normal"],
+          },
+        },
+      })
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      const server = config.mcp!.myserver as any
+      expect(server.command).toEqual(["node", "42", "true", "normal"])
+    },
+  })
+})
+
+test("mcpServers normalization: string args field is wrapped in array", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, {
+        mcpServers: {
+          myserver: {
+            command: "npx",
+            args: "--verbose",
+          },
+        },
+      })
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      const server = config.mcp!.myserver as any
+      expect(server.command).toEqual(["npx", "--verbose"])
+    },
+  })
+})
+
+test("mcpServers normalization: disabled server entry is valid", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, {
+        mcpServers: {
+          disabled: { enabled: false },
+          valid: { command: "node", args: ["server.js"] },
+        },
+      })
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      // Both entries are valid — disabled is a valid schema shape
+      const valid = config.mcp!.valid as any
+      expect(valid.type).toBe("local")
+      const disabled = config.mcp!.disabled as any
+      expect(disabled.enabled).toBe(false)
+    },
+  })
+})
+
+test("mcpServers normalization: environment takes precedence over env when both present", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, {
+        mcpServers: {
+          myserver: {
+            command: "node",
+            args: ["server.js"],
+            env: { FROM_ENV: "old" },
+            environment: { FROM_ENVIRONMENT: "new" },
+          },
+        },
+      })
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      const server = config.mcp!.myserver as any
+      // environment should win over env since it's checked second
+      expect(server.environment).toEqual({ FROM_ENVIRONMENT: "new" })
+    },
+  })
+})
+
+test("mcpServers normalization: timeout and enabled are preserved", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, {
+        mcpServers: {
+          myserver: {
+            command: "node",
+            args: ["server.js"],
+            timeout: 10000,
+            enabled: false,
+          },
+        },
+      })
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      const server = config.mcp!.myserver as any
+      expect(server.timeout).toBe(10000)
+      expect(server.enabled).toBe(false)
+    },
+  })
+})
+
+test("mcpServers normalization: mixed local and remote servers", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, {
+        mcpServers: {
+          localServer: {
+            command: "npx",
+            args: ["-y", "@mcp/server-fs"],
+            env: { HOME: "/tmp" },
+          },
+          remoteServer: {
+            url: "https://api.example.com/mcp",
+            headers: { "X-Api-Key": "secret" },
+          },
+        },
+      })
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      const local = config.mcp!.localServer as any
+      expect(local.type).toBe("local")
+      expect(local.command).toEqual(["npx", "-y", "@mcp/server-fs"])
+      expect(local.environment).toEqual({ HOME: "/tmp" })
+
+      const remote = config.mcp!.remoteServer as any
+      expect(remote.type).toBe("remote")
+      expect(remote.url).toBe("https://api.example.com/mcp")
+      expect(remote.headers).toEqual({ "X-Api-Key": "secret" })
+    },
+  })
+})
+
 test("validates config schema and throws on invalid fields", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
### What does this PR do?

Fixes the config validation error when users or LLMs write MCP server config using the `mcpServers` key (common in Claude Code, Cursor, `.mcp.json` format). The strict config schema rejected this with `Unrecognized key: "mcpServers"`, preventing the app from starting.

This PR adds a `normalizeMcpConfig` function that:
- Auto-normalizes top-level `mcpServers` → `mcp` with a warning log
- Transforms external MCP server format: string `command` + `args` + `env` → array `command` + `environment`
- Handles remote servers without explicit `type` field (infers from `url` presence)
- Always deletes `mcpServers` to prevent strict schema rejection (even when `mcp` already exists)
- Normalizes typed entries that use external field names (`env`, string `command`)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #638 (reported in #619)

### How did you verify your code works?

- 5 new tests covering: string command format, array command format, both-keys conflict resolution, remote server normalization, typed entry with external field names
- All 7217 existing tests pass (0 failures)
- Typecheck passes
- Marker Guard passes (`bun run script/upstream/analyze.ts --markers --base main --strict`)
- Multi-model code review (6 models: Claude, GPT 5.2 Codex, Gemini 3.1 Pro, Kimi K2.5, MiniMax M2.5, GLM-5) — all critical/major findings addressed

### Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have added `altimate_change` markers to upstream-shared files

🤖 Generated with [Claude Code](https://claude.com/claude-code)