### PR TITLE
fix: use atomic writes in FileExporter.export() to prevent corrupted trace files

### DIFF
--- a/packages/opencode/src/altimate/observability/tracing.ts
+++ b/packages/opencode/src/altimate/observability/tracing.ts
@@ -172,12 +172,17 @@ export class FileExporter implements TraceExporter {
   }
 
   async export(trace: TraceFile): Promise<string | undefined> {
+    let tmpPath: string | undefined
     try {
       await fs.mkdir(this.dir, { recursive: true })
       // Sanitize sessionId for safe file name (defense-in-depth — also sanitized in Trace)
       const safeId = (trace.sessionId ?? "unknown").replace(/[/\\.:]/g, "_") || "unknown"
       const filePath = path.join(this.dir, `${safeId}.json`)
-      await fs.writeFile(filePath, JSON.stringify(trace, null, 2))
+      // Atomic write: write to temp file, then rename — prevents partial reads
+      // when concurrent snapshots or exports target the same file
+      tmpPath = filePath + `.tmp.${Date.now()}.${Math.random().toString(36).slice(2, 8)}`
+      await fs.writeFile(tmpPath, JSON.stringify(trace, null, 2))
+      await fs.rename(tmpPath, filePath)
 
       if (this.maxFiles > 0) {
         this.pruneOldTraces().catch(() => {})
@@ -185,6 +190,7 @@ export class FileExporter implements TraceExporter {
 
       return filePath
     } catch {
+      if (tmpPath) fs.unlink(tmpPath).catch(() => {})
       return undefined
     }
   }


### PR DESCRIPTION
### What does this PR do?

Fixes `FileExporter.export()` to use atomic writes (write to temp file, then rename) instead of direct `fs.writeFile()`. This prevents corrupted trace JSON when concurrent sessions or snapshots write to the same file.

**Root cause:** `snapshot()` already used atomic writes (tmp + rename), but `export()` used non-atomic `fs.writeFile()`. When both targeted the same file concurrently, the rename could race with the writeFile, producing truncated JSON.

Also adds temp file cleanup on failure (`fs.unlink(tmpPath)`) to match the existing `snapshot()` error handling pattern.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #644

### How did you verify your code works?

- All 82 tracing tests pass (including the previously failing `concurrent traces to same session ID overwrite cleanly`)
- 5 consecutive local runs confirmed stability (0 flakes)
- Full test suite: 6889 pass, 0 fail
- Typecheck passes
- Multi-model code review (8 models): unanimous APPROVE

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trace files are now written atomically using temporary staging files, ensuring clean writes with automatic cleanup if failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->