### PR TITLE
fix: escalating circuit breaker for doom loops in headless mode

### DIFF
--- a/packages/opencode/src/altimate/telemetry/index.ts
+++ b/packages/opencode/src/altimate/telemetry/index.ts
@@ -243,6 +243,9 @@ export namespace Telemetry {
         session_id: string
         tool_name: string
         repeat_count: number
+        // altimate_change start — escalation level for distinguishing ask/warn/stop in analytics
+        escalation_level?: number
+        // altimate_change end
       }
     | {
         type: "environment_census"

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -254,6 +254,7 @@ export namespace SessionProcessor {
                         })
                         blocked = true
                         toolCallCounts[value.toolName] = 0
+                        toolLoopHits[value.toolName] = 0
                         break
                       }
 
@@ -270,7 +271,7 @@ export namespace SessionProcessor {
                           messageID: input.assistantMessage.id,
                           sessionID: input.assistantMessage.sessionID,
                           type: "text",
-                          synthetic: false,
+                          synthetic: true,
                           text:
                             `⚠️ altimate-code: \`${value.toolName}\` has been called ${totalCalls} times this session. ` +
                             `You appear to be stuck in a loop. Stop repeating the same approach. ` +

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -248,7 +248,7 @@ export namespace SessionProcessor {
                           type: "text",
                           synthetic: true,
                           text:
-                            `⚠️ altimate-code: session stopped — \`${value.toolName}\` was called ${totalCalls}+ times, ` +
+                            `⚠️ altimate-code: session stopped — \`${value.toolName}\` was called ${totalCalls} times, ` +
                             `indicating the agent is stuck in a loop. Please start a new session with a revised prompt.`,
                           time: { start: Date.now(), end: Date.now() },
                         })
@@ -270,9 +270,9 @@ export namespace SessionProcessor {
                           messageID: input.assistantMessage.id,
                           sessionID: input.assistantMessage.sessionID,
                           type: "text",
-                          // synthetic: false so the LLM actually sees this warning and can course-correct
+                          synthetic: false,
                           text:
-                            `⚠️ altimate-code: \`${value.toolName}\` has been called ${totalCalls}+ times this session. ` +
+                            `⚠️ altimate-code: \`${value.toolName}\` has been called ${totalCalls} times this session. ` +
                             `You appear to be stuck in a loop. Stop repeating the same approach. ` +
                             `Either try a fundamentally different strategy or explain to the user what is blocking you. ` +
                             `The session will be force-stopped if this continues.`,
@@ -281,6 +281,8 @@ export namespace SessionProcessor {
                       }
 
                       // Escalation level 1: ask permission (existing behavior)
+                      // Reset before ask so denial/exception doesn't leave count at threshold
+                      toolCallCounts[value.toolName] = 0
                       const agent = await Agent.get(input.assistantMessage.agent)
                       await PermissionNext.ask({
                         permission: "doom_loop",
@@ -294,7 +296,6 @@ export namespace SessionProcessor {
                         always: [value.toolName],
                         ruleset: agent.permission,
                       })
-                      toolCallCounts[value.toolName] = 0
                     }
                     // altimate_change end
                   }

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -27,6 +27,15 @@ export namespace SessionProcessor {
   // 30 catches pathological patterns while avoiding false positives for power users.
   const TOOL_REPEAT_THRESHOLD = 30
   // altimate_change end
+  // altimate_change start — escalating circuit breaker for doom loops
+  // When the repeat threshold is hit and auto-accepted (headless, config allow), the
+  // counter resets and the loop continues indefinitely. Escalation levels:
+  //   1st hit (30 calls):  ask permission (existing behavior)
+  //   2nd hit (60 calls):  ask + inject synthetic warning telling model to change approach
+  //   3rd hit (90 calls):  force-stop the session — the model is stuck
+  const DOOM_LOOP_WARN_ESCALATION = 2 // hits before injecting warning
+  const DOOM_LOOP_STOP_ESCALATION = 3 // hits before force-stopping
+  // altimate_change end
   const log = Log.create({ service: "session.processor" })
 
   export type Info = Awaited<ReturnType<typeof create>>
@@ -41,6 +50,9 @@ export namespace SessionProcessor {
     const toolcalls: Record<string, MessageV2.ToolPart> = {}
     // altimate_change start — per-tool call counter for varied-input loop detection
     const toolCallCounts: Record<string, number> = {}
+    // altimate_change end
+    // altimate_change start — escalation counter: how many times each tool has hit TOOL_REPEAT_THRESHOLD
+    const toolLoopHits: Record<string, number> = {}
     // altimate_change end
     let snapshot: string | undefined
     let blocked = false
@@ -201,20 +213,74 @@ export namespace SessionProcessor {
                       })
                     }
 
-                    // altimate_change start — per-tool repeat counter (catches varied-input loops like todowrite 2,080x)
+                    // altimate_change start — per-tool repeat counter with escalating circuit breaker
                     // Counter is scoped to the processor lifetime (create() call), so it accumulates
                     // across multiple process() invocations within a session. This is intentional:
                     // cross-turn accumulation catches slow-burn loops that stay under the threshold
                     // per-turn but add up over the session.
                     toolCallCounts[value.toolName] = (toolCallCounts[value.toolName] ?? 0) + 1
                     if (toolCallCounts[value.toolName] >= TOOL_REPEAT_THRESHOLD) {
+                      toolLoopHits[value.toolName] = (toolLoopHits[value.toolName] ?? 0) + 1
+                      const hits = toolLoopHits[value.toolName]
+                      const totalCalls = hits * TOOL_REPEAT_THRESHOLD
+
                       Telemetry.track({
                         type: "doom_loop_detected",
                         timestamp: Date.now(),
                         session_id: input.sessionID,
                         tool_name: value.toolName,
-                        repeat_count: toolCallCounts[value.toolName],
+                        repeat_count: totalCalls,
+                        escalation_level: hits,
                       })
+
+                      // Escalation level 3+: force-stop — the model is irretrievably stuck
+                      if (hits >= DOOM_LOOP_STOP_ESCALATION) {
+                        log.warn("doom loop circuit breaker: force-stopping session", {
+                          tool: value.toolName,
+                          totalCalls,
+                          hits,
+                          sessionID: input.sessionID,
+                        })
+                        await Session.updatePart({
+                          id: PartID.ascending(),
+                          messageID: input.assistantMessage.id,
+                          sessionID: input.assistantMessage.sessionID,
+                          type: "text",
+                          synthetic: true,
+                          text:
+                            `⚠️ altimate-code: session stopped — \`${value.toolName}\` was called ${totalCalls}+ times, ` +
+                            `indicating the agent is stuck in a loop. Please start a new session with a revised prompt.`,
+                          time: { start: Date.now(), end: Date.now() },
+                        })
+                        blocked = true
+                        toolCallCounts[value.toolName] = 0
+                        break
+                      }
+
+                      // Escalation level 2: warn the model via synthetic message
+                      if (hits >= DOOM_LOOP_WARN_ESCALATION) {
+                        log.warn("doom loop escalation: injecting warning", {
+                          tool: value.toolName,
+                          totalCalls,
+                          hits,
+                          sessionID: input.sessionID,
+                        })
+                        await Session.updatePart({
+                          id: PartID.ascending(),
+                          messageID: input.assistantMessage.id,
+                          sessionID: input.assistantMessage.sessionID,
+                          type: "text",
+                          // synthetic: false so the LLM actually sees this warning and can course-correct
+                          text:
+                            `⚠️ altimate-code: \`${value.toolName}\` has been called ${totalCalls}+ times this session. ` +
+                            `You appear to be stuck in a loop. Stop repeating the same approach. ` +
+                            `Either try a fundamentally different strategy or explain to the user what is blocking you. ` +
+                            `The session will be force-stopped if this continues.`,
+                          time: { start: Date.now(), end: Date.now() },
+                        })
+                      }
+
+                      // Escalation level 1: ask permission (existing behavior)
                       const agent = await Agent.get(input.assistantMessage.agent)
                       await PermissionNext.ask({
                         permission: "doom_loop",
@@ -223,7 +289,7 @@ export namespace SessionProcessor {
                         metadata: {
                           tool: value.toolName,
                           input: value.input,
-                          repeat_count: toolCallCounts[value.toolName],
+                          repeat_count: totalCalls,
                         },
                         always: [value.toolName],
                         ruleset: agent.permission,
@@ -478,6 +544,9 @@ export namespace SessionProcessor {
                   continue
               }
               if (needsCompaction) break
+              // altimate_change start — exit stream loop immediately on doom loop force-stop
+              if (blocked) break
+              // altimate_change end
             }
           } catch (e: any) {
             log.error("process", {


### PR DESCRIPTION
### What does this PR do?

Adds an escalating circuit breaker to the doom loop detection system. When `doom_loop` permission is auto-accepted (headless mode or `doom_loop: "allow"` config), the per-tool repeat counter previously reset every 30 calls, allowing loops to run indefinitely. Observed in production: 10,943 `apply_patch` calls and 1,791 `todowrite` calls in a single 4-hour session.

**Escalation levels:**
- **30 calls** (hit 1): ask permission (existing behavior, unchanged)
- **60 calls** (hit 2): inject non-synthetic warning the LLM sees + ask permission
- **90 calls** (hit 3): force-stop the session

**Additional fixes from 9-model code review:**
- Level 2 warning uses `synthetic: false` so the LLM actually sees the "stop looping" instruction
- `if (blocked) break` after the switch to exit the stream loop immediately on force-stop
- `escalation_level` added to `doom_loop_detected` telemetry event

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #657

### How did you verify your code works?

- All 46 existing processor tests pass
- Marker Guard check passes (`bun run script/upstream/analyze.ts --markers --base main --strict`)
- Turbo typecheck passes (5/5 packages)
- 9-model consensus code review (Claude, GPT 5.4, Gemini 3.1 Pro, Kimi K2.5, MiniMax M2.7, GLM-5, Qwen 3.6 Plus, DeepSeek V3.2, MiMo-V2-Pro)

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an escalating circuit breaker to stop doom loops when `doom_loop` is auto-accepted. Prevents unbounded tool calls in headless mode and force-stops stuck sessions.

- **Bug Fixes**
  - 30 calls: ask permission; 60: ask + inject in-session warning; 90: force-stop.
  - Counter resets before the ask; force-stop exits the stream loop immediately.
  - Telemetry: `doom_loop_detected` now records `escalation_level` and cumulative `repeat_count`.

<sup>Written for commit ac01755e50aedf0ab3c3cdcca8184ed90b3da459. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of recurring tool-call loops with graduated escalation.
  * Added in-session warning messages as repeats increase.
  * Sessions now automatically halt when repetitive tool calls persist to prevent runaway behavior.

* **Telemetry**
  * Telemetry now records escalation level and repeat metrics for detected loop events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->