### PR TITLE
proposal: log warning when stream error parsing fails

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -995,7 +995,9 @@ export namespace MessageV2 {
               },
             ).toObject()
           }
-        } catch {}
+        } catch (parseErr) {
+          console.warn("[message-v2] Failed to parse stream error:", parseErr)
+        }
         return new NamedError.Unknown({ message: JSON.stringify(e) }, { cause: e }).toObject()
     }
   }


### PR DESCRIPTION
## Proposal

**Repo:** altimate-code
**Category:** error-swallowing
**Severity:** medium
**Files:** `packages/opencode/src/session/message-v2.ts`

## What I Found
In the `toError()` method (line 998), when `ProviderError.parseStreamError(e)` throws an exception during error parsing, the failure is silently caught with `catch {}`. This means:

- If the error parser itself fails, there's no visibility into what went wrong
- The code falls through to `NamedError.Unknown` which is correct fallback behavior, but the parsing failure is invisible
- Debugging error handling regressions requires guessing whether errors are unparseable or if the parser is broken

## Fix
Changed `catch {}` to `catch (parseErr) { console.warn("[message-v2] Failed to parse stream error:", parseErr) }` to log the parsing failure while preserving the existing fallback to `NamedError.Unknown`.

---
*Auto-generated by QA Autopilot Proposal Monitor. Open for 30-day human review.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a warning when stream error parsing fails in `packages/opencode/src/session/message-v2.ts` (`MessageV2.toError()`). This improves visibility while keeping the fallback to `NamedError.Unknown` unchanged.

<sup>Written for commit 8a771b92843a1f2ade2eaa71bf65d391492e67c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error diagnostics by capturing and logging stream parsing failures, enabling better troubleshooting of error handling issues while maintaining existing error recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->