### PR TITLE
proposal: log telemetry initialization failures

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -123,7 +123,7 @@ let cli = yargs(hideBin(process.argv))
     // altimate_change start - telemetry init
     // Initialize telemetry early so events from MCP, engine, auth are captured.
     // init() is idempotent — safe to call again later in session prompt.
-    Telemetry.init().catch(() => {})
+    Telemetry.init().catch((e) => Log.Default.warn("Telemetry initialization failed", { error: String(e) }))
     // altimate_change end
 
     // altimate_change start - welcome banner on first run after install/upgrade


### PR DESCRIPTION
## Proposal

**Repo:** altimate-code
**Category:** error-swallowing
**Severity:** medium
**Files:** `packages/opencode/src/index.ts`

## What I Found
At CLI startup (line 126), `Telemetry.init().catch(() => {})` silently swallows all telemetry initialization failures. This means:

- If telemetry fails to initialize, no events are captured for the entire session
- There's no log entry to indicate telemetry is offline — makes it hard to diagnose missing telemetry data
- The `Log` utility is already imported and used throughout the file

## Fix
Replaced `.catch(() => {})` with `.catch((e) => Log.Default.warn("Telemetry initialization failed", { error: String(e) }))` using the existing `Log` utility that's already imported in this file.

---
*Auto-generated by QA Autopilot Proposal Monitor. Open for 30-day human review.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a warning log when telemetry initialization fails at CLI startup. Prevents silent loss of events and makes telemetry outages visible.

- **Bug Fixes**
  - Replaced `Telemetry.init().catch(() => {})` with `Telemetry.init().catch((e) => Log.Default.warn("Telemetry initialization failed", { error: String(e) }))`.

<sup>Written for commit 2459d8cae7a127e5f0ef40b632d9747abec3cc3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error visibility by logging telemetry initialization failures instead of silently ignoring them, enabling better error tracking and diagnosis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->