### PR TITLE
fix: log errors in GitHub workflow connection retry loop

### DIFF
--- a/github/index.ts
+++ b/github/index.ts
@@ -281,7 +281,9 @@ async function assertOpencodeConnected() {
       })
       connected = true
       break
-    } catch (e) {}
+    } catch (e) {
+      console.warn(`[assertOpencodeConnected] retry ${retry}/30 failed:`, e instanceof Error ? e.message : e)
+    }
     await sleep(300)
   } while (retry++ < 30)
 


### PR DESCRIPTION
## Proposal

**Repo:** altimate-code
**Category:** silent-catch
**Severity:** high
**Files:** `github/index.ts`

## What I Found
In `assertOpencodeConnected()` (line 284), the retry loop attempts to connect to the Altimate Code server up to 30 times with a 300ms delay, but the `catch (e) {}` block silently swallows all errors. This means:

- Network failures, authentication errors, and server errors are all indistinguishable
- Debugging connection issues in GitHub Actions workflows requires adding temporary logging
- When the retry loop eventually throws "Failed to connect to Altimate Code server", there's zero context about what went wrong

## Fix
Added `console.warn()` inside the catch block to log the retry attempt number and error message. The retry logic is preserved unchanged — this only adds visibility into failures.

---
*Auto-generated by QA Autopilot Proposal Monitor. Open for 30-day human review.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add warning logs in `assertOpencodeConnected()` so connection retries in GitHub workflows show error context instead of silently failing. Retry behavior is unchanged; each failed attempt now logs retry N/30 and the error message.

<sup>Written for commit 12c78f6ac570eab411e65a42cfba9242541260bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced connection error logging with attempt details to provide clearer diagnostics when troubleshooting connection issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->