### PR TITLE
fix: log errors in VSCode extension connection retry loop

### DIFF
--- a/sdks/vscode/src/extension.ts
+++ b/sdks/vscode/src/extension.ts
@@ -78,7 +78,9 @@ export function activate(context: vscode.ExtensionContext) {
         await fetch(`http://localhost:${port}/app`)
         connected = true
         break
-      } catch (e) {}
+      } catch (e) {
+        console.warn(`[opencode-vscode] connection attempt ${11 - tries}/10 failed:`, e instanceof Error ? e.message : e)
+      }
 
       tries--
     } while (tries > 0)


### PR DESCRIPTION
## Proposal

**Repo:** altimate-code
**Category:** silent-catch
**Severity:** high
**Files:** `sdks/vscode/src/extension.ts`

## What I Found
In the VSCode extension's `activate()` function (line 81), the retry loop that waits for the opencode terminal server to become ready silently swallows all fetch errors with `catch (e) {}`. The loop retries 10 times with 200ms delays, but if it fails:

- Users see no terminal output and no indication of what went wrong
- Network errors, port conflicts, and server startup failures are all invisible
- Debugging requires manually adding `console.log` to the extension source

## Fix
Added `console.warn()` inside the catch block to log the attempt number and error message. The retry logic and fallback behavior are preserved unchanged — this only adds visibility into connection failures via the VSCode Output panel.

---
*Auto-generated by QA Autopilot Proposal Monitor. Open for 30-day human review.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Logs connection errors during the VSCode extension’s startup retry loop so failures are visible in the Output panel. No change to retry behavior; this only adds diagnostics.

- **Bug Fixes**
  - Added `console.warn` in `sdks/vscode/src/extension.ts` `activate()` fetch loop to log attempt number and error when hitting `http://localhost:${port}/app`.

<sup>Written for commit 954f32132e9d48f8a44ff3d6026038ed8b1250fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Connection retry failures during startup are now reported to the console, displaying attempt numbers and error details to aid troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->