### PR TITLE
fix: resolve env-var references in MCP server environment config (closes #656)

### DIFF
--- a/packages/opencode/src/mcp/discover.ts
+++ b/packages/opencode/src/mcp/discover.ts
@@ -117,6 +117,18 @@ async function readJsonSafe(filePath: string): Promise<any | undefined> {
   } catch {
     return undefined
   }
+  // altimate_change start — apply env-var interpolation to external MCP configs
+  // External configs (Claude Code, Cursor, Copilot, Gemini) may contain ${VAR}
+  // or {env:VAR} references that need resolving before JSON parsing.
+  // Uses ConfigPaths.parseText which runs substitute() then parses JSONC.
+  try {
+    const { ConfigPaths } = await import("../config/paths")
+    return await ConfigPaths.parseText(text, filePath, "empty")
+  } catch {
+    // Substitution or parse failure — fall back to direct parse without interpolation
+    log.debug("env-var interpolation failed for external MCP config, falling back to direct parse", { file: filePath })
+  }
+  // altimate_change end
   const errors: any[] = []
   const result = parseJsonc(text, errors, { allowTrailingComma: true })
   if (errors.length > 0) {

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -31,7 +31,7 @@ import { Telemetry } from "@/telemetry"
 const ENV_VAR_PATTERN =
   /\$\$(\{[A-Za-z_][A-Za-z0-9_]*(?::-[^}]*)?\})|(?<!\$)\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}|\{env:([^}]+)\}/g
 
-function resolveEnvVars(environment: Record<string, string>): Record<string, string> {
+export function resolveEnvVars(environment: Record<string, string>): Record<string, string> {
   const resolved: Record<string, string> = {}
   for (const [key, value] of Object.entries(environment)) {
     resolved[key] = value.replace(ENV_VAR_PATTERN, (match, escaped, dollarVar, dollarDefault, braceVar) => {

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -25,6 +25,29 @@ import { TuiEvent } from "@/cli/cmd/tui/event"
 import open from "open"
 import { Telemetry } from "@/telemetry"
 
+// altimate_change start — resolve env-var references in MCP environment values
+// Handles ${VAR}, ${VAR:-default}, and {env:VAR} patterns that may have survived
+// config parsing (e.g. discovered external configs, config updates via updateGlobal).
+const ENV_VAR_PATTERN =
+  /\$\$(\{[A-Za-z_][A-Za-z0-9_]*(?::-[^}]*)?\})|(?<!\$)\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}|\{env:([^}]+)\}/g
+
+function resolveEnvVars(environment: Record<string, string>): Record<string, string> {
+  const resolved: Record<string, string> = {}
+  for (const [key, value] of Object.entries(environment)) {
+    resolved[key] = value.replace(ENV_VAR_PATTERN, (match, escaped, dollarVar, dollarDefault, braceVar) => {
+      if (escaped !== undefined) return "$" + escaped
+      if (dollarVar !== undefined) {
+        const envValue = process.env[dollarVar]
+        return envValue !== undefined && envValue !== "" ? envValue : (dollarDefault ?? "")
+      }
+      if (braceVar !== undefined) return process.env[braceVar] || ""
+      return match
+    })
+  }
+  return resolved
+}
+// altimate_change end
+
 export namespace MCP {
   const log = Log.create({ service: "mcp" })
   const DEFAULT_TIMEOUT = 30_000
@@ -509,7 +532,9 @@ export namespace MCP {
         env: {
           ...process.env,
           ...(cmd === "altimate" || cmd === "altimate-code" ? { BUN_BE_BUN: "1" } : {}),
-          ...mcp.environment,
+          // altimate_change start — resolve ${VAR} / {env:VAR} patterns that survived config parsing
+          ...(mcp.environment ? resolveEnvVars(mcp.environment) : {}),
+          // altimate_change end
         },
       })
       transport.stderr?.on("data", (chunk: Buffer) => {

--- a/packages/opencode/test/mcp/env-var-interpolation.test.ts
+++ b/packages/opencode/test/mcp/env-var-interpolation.test.ts
@@ -1,0 +1,229 @@
+// altimate_change start — tests for MCP env-var interpolation (closes #656)
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { mkdtemp, rm, mkdir, writeFile } from "fs/promises"
+import { tmpdir } from "os"
+import path from "path"
+
+// -------------------------------------------------------------------------
+// resolveEnvVars — safety-net resolver at MCP launch site
+// -------------------------------------------------------------------------
+
+// Import the module to access resolveEnvVars indirectly via the env spread.
+// Since resolveEnvVars is a module-level function (not inside the MCP namespace),
+// we test it directly by importing the file and extracting the function.
+// For now, inline the same logic here for unit testing.
+
+const ENV_VAR_PATTERN =
+  /\$\$(\{[A-Za-z_][A-Za-z0-9_]*(?::-[^}]*)?\})|(?<!\$)\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}|\{env:([^}]+)\}/g
+
+function resolveEnvVars(environment: Record<string, string>): Record<string, string> {
+  const resolved: Record<string, string> = {}
+  for (const [key, value] of Object.entries(environment)) {
+    resolved[key] = value.replace(ENV_VAR_PATTERN, (match, escaped, dollarVar, dollarDefault, braceVar) => {
+      if (escaped !== undefined) return "$" + escaped
+      if (dollarVar !== undefined) {
+        const envValue = process.env[dollarVar]
+        return envValue !== undefined && envValue !== "" ? envValue : (dollarDefault ?? "")
+      }
+      if (braceVar !== undefined) return process.env[braceVar] || ""
+      return match
+    })
+  }
+  return resolved
+}
+
+describe("resolveEnvVars", () => {
+  const ORIGINAL_ENV = { ...process.env }
+
+  beforeEach(() => {
+    process.env["TEST_TOKEN"] = "secret-123"
+    process.env["TEST_HOST"] = "gitlab.example.com"
+  })
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  test("resolves ${VAR} syntax", () => {
+    const result = resolveEnvVars({
+      API_TOKEN: "${TEST_TOKEN}",
+      HOST: "${TEST_HOST}",
+    })
+    expect(result.API_TOKEN).toBe("secret-123")
+    expect(result.HOST).toBe("gitlab.example.com")
+  })
+
+  test("resolves {env:VAR} syntax", () => {
+    const result = resolveEnvVars({
+      API_TOKEN: "{env:TEST_TOKEN}",
+    })
+    expect(result.API_TOKEN).toBe("secret-123")
+  })
+
+  test("resolves ${VAR:-default} with fallback when unset", () => {
+    const result = resolveEnvVars({
+      MODE: "${UNSET_VAR:-production}",
+    })
+    expect(result.MODE).toBe("production")
+  })
+
+  test("resolves ${VAR:-default} to env value when set", () => {
+    const result = resolveEnvVars({
+      TOKEN: "${TEST_TOKEN:-fallback}",
+    })
+    expect(result.TOKEN).toBe("secret-123")
+  })
+
+  test("preserves $${VAR} as literal ${VAR}", () => {
+    const result = resolveEnvVars({
+      TEMPLATE: "$${TEST_TOKEN}",
+    })
+    expect(result.TEMPLATE).toBe("${TEST_TOKEN}")
+  })
+
+  test("resolves unset variable to empty string", () => {
+    const result = resolveEnvVars({
+      MISSING: "${COMPLETELY_UNSET_VAR_XYZ}",
+    })
+    expect(result.MISSING).toBe("")
+  })
+
+  test("passes through plain values without modification", () => {
+    const result = resolveEnvVars({
+      PLAIN: "just-a-string",
+      URL: "https://gitlab.com/api/v4",
+    })
+    expect(result.PLAIN).toBe("just-a-string")
+    expect(result.URL).toBe("https://gitlab.com/api/v4")
+  })
+
+  test("resolves multiple variables in a single value", () => {
+    const result = resolveEnvVars({
+      URL: "https://${TEST_HOST}/api?token=${TEST_TOKEN}",
+    })
+    expect(result.URL).toBe("https://gitlab.example.com/api?token=secret-123")
+  })
+
+  test("handles mixed resolved and plain entries", () => {
+    const result = resolveEnvVars({
+      TOKEN: "${TEST_TOKEN}",
+      STATIC_URL: "https://gitlab.com/api/v4",
+      HOST: "{env:TEST_HOST}",
+    })
+    expect(result.TOKEN).toBe("secret-123")
+    expect(result.STATIC_URL).toBe("https://gitlab.com/api/v4")
+    expect(result.HOST).toBe("gitlab.example.com")
+  })
+
+  test("does not interpolate bare $VAR without braces", () => {
+    const result = resolveEnvVars({
+      TOKEN: "$TEST_TOKEN",
+    })
+    expect(result.TOKEN).toBe("$TEST_TOKEN")
+  })
+
+  test("handles empty environment object", () => {
+    const result = resolveEnvVars({})
+    expect(result).toEqual({})
+  })
+})
+
+// -------------------------------------------------------------------------
+// Discovery integration — env vars in external MCP configs
+// -------------------------------------------------------------------------
+
+describe("discoverExternalMcp with env-var interpolation", () => {
+  let tempDir: string
+  const ORIGINAL_ENV = { ...process.env }
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "mcp-envvar-"))
+    process.env["TEST_MCP_TOKEN"] = "glpat-secret-token"
+    process.env["TEST_MCP_HOST"] = "https://gitlab.internal.com"
+  })
+
+  afterEach(async () => {
+    process.env = { ...ORIGINAL_ENV }
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  test("resolves ${VAR} in discovered .vscode/mcp.json environment", async () => {
+    await mkdir(path.join(tempDir, ".vscode"), { recursive: true })
+    await writeFile(
+      path.join(tempDir, ".vscode/mcp.json"),
+      JSON.stringify({
+        servers: {
+          gitlab: {
+            command: "node",
+            args: ["gitlab-server.js"],
+            env: {
+              GITLAB_TOKEN: "${TEST_MCP_TOKEN}",
+              GITLAB_HOST: "${TEST_MCP_HOST}",
+              STATIC_VALUE: "no-interpolation-needed",
+            },
+          },
+        },
+      }),
+    )
+
+    const { discoverExternalMcp } = await import("../../src/mcp/discover")
+    const { servers } = await discoverExternalMcp(tempDir)
+
+    expect(servers["gitlab"]).toBeDefined()
+    expect(servers["gitlab"].type).toBe("local")
+    const env = (servers["gitlab"] as any).environment
+    expect(env.GITLAB_TOKEN).toBe("glpat-secret-token")
+    expect(env.GITLAB_HOST).toBe("https://gitlab.internal.com")
+    expect(env.STATIC_VALUE).toBe("no-interpolation-needed")
+  })
+
+  test("resolves {env:VAR} in discovered .cursor/mcp.json environment", async () => {
+    await mkdir(path.join(tempDir, ".cursor"), { recursive: true })
+    await writeFile(
+      path.join(tempDir, ".cursor/mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          "my-tool": {
+            command: "npx",
+            args: ["-y", "my-mcp-tool"],
+            env: {
+              API_KEY: "{env:TEST_MCP_TOKEN}",
+            },
+          },
+        },
+      }),
+    )
+
+    const { discoverExternalMcp } = await import("../../src/mcp/discover")
+    const { servers } = await discoverExternalMcp(tempDir)
+
+    expect(servers["my-tool"]).toBeDefined()
+    const env = (servers["my-tool"] as any).environment
+    expect(env.API_KEY).toBe("glpat-secret-token")
+  })
+
+  test("resolves ${VAR:-default} with fallback in discovered config", async () => {
+    await mkdir(path.join(tempDir, ".vscode"), { recursive: true })
+    await writeFile(
+      path.join(tempDir, ".vscode/mcp.json"),
+      JSON.stringify({
+        servers: {
+          svc: {
+            command: "node",
+            args: ["svc.js"],
+            env: {
+              MODE: "${UNSET_VAR_ABC:-production}",
+            },
+          },
+        },
+      }),
+    )
+
+    const { discoverExternalMcp } = await import("../../src/mcp/discover")
+    const { servers } = await discoverExternalMcp(tempDir)
+
+    const env = (servers["svc"] as any).environment
+    expect(env.MODE).toBe("production")
+  })
+})
+// altimate_change end

--- a/packages/opencode/test/mcp/env-var-interpolation.test.ts
+++ b/packages/opencode/test/mcp/env-var-interpolation.test.ts
@@ -1,9 +1,9 @@
 // altimate_change start — tests for MCP env-var interpolation (closes #656)
 import { describe, test, expect, beforeEach, afterEach } from "bun:test"
-import { mkdtemp, rm, mkdir, writeFile } from "fs/promises"
-import { tmpdir } from "os"
+import { mkdir, writeFile } from "fs/promises"
 import path from "path"
 import { resolveEnvVars } from "../../src/mcp"
+import { tmpdir } from "../fixture/fixture"
 
 // -------------------------------------------------------------------------
 // resolveEnvVars — safety-net resolver at MCP launch site
@@ -110,24 +110,23 @@ describe("resolveEnvVars", () => {
 // -------------------------------------------------------------------------
 
 describe("discoverExternalMcp with env-var interpolation", () => {
-  let tempDir: string
   const ORIGINAL_ENV = { ...process.env }
 
-  beforeEach(async () => {
-    tempDir = await mkdtemp(path.join(tmpdir(), "mcp-envvar-"))
+  beforeEach(() => {
     process.env["TEST_MCP_TOKEN"] = "glpat-secret-token"
     process.env["TEST_MCP_HOST"] = "https://gitlab.internal.com"
   })
 
-  afterEach(async () => {
+  afterEach(() => {
     process.env = { ...ORIGINAL_ENV }
-    await rm(tempDir, { recursive: true, force: true })
   })
 
   test("resolves ${VAR} in discovered .vscode/mcp.json environment", async () => {
-    await mkdir(path.join(tempDir, ".vscode"), { recursive: true })
+    await using tmp = await tmpdir()
+    const dir = tmp.path
+    await mkdir(path.join(dir, ".vscode"), { recursive: true })
     await writeFile(
-      path.join(tempDir, ".vscode/mcp.json"),
+      path.join(dir, ".vscode/mcp.json"),
       JSON.stringify({
         servers: {
           gitlab: {
@@ -144,7 +143,7 @@ describe("discoverExternalMcp with env-var interpolation", () => {
     )
 
     const { discoverExternalMcp } = await import("../../src/mcp/discover")
-    const { servers } = await discoverExternalMcp(tempDir)
+    const { servers } = await discoverExternalMcp(dir)
 
     expect(servers["gitlab"]).toBeDefined()
     expect(servers["gitlab"].type).toBe("local")
@@ -155,9 +154,11 @@ describe("discoverExternalMcp with env-var interpolation", () => {
   })
 
   test("resolves {env:VAR} in discovered .cursor/mcp.json environment", async () => {
-    await mkdir(path.join(tempDir, ".cursor"), { recursive: true })
+    await using tmp = await tmpdir()
+    const dir = tmp.path
+    await mkdir(path.join(dir, ".cursor"), { recursive: true })
     await writeFile(
-      path.join(tempDir, ".cursor/mcp.json"),
+      path.join(dir, ".cursor/mcp.json"),
       JSON.stringify({
         mcpServers: {
           "my-tool": {
@@ -172,7 +173,7 @@ describe("discoverExternalMcp with env-var interpolation", () => {
     )
 
     const { discoverExternalMcp } = await import("../../src/mcp/discover")
-    const { servers } = await discoverExternalMcp(tempDir)
+    const { servers } = await discoverExternalMcp(dir)
 
     expect(servers["my-tool"]).toBeDefined()
     const env = (servers["my-tool"] as any).environment
@@ -180,9 +181,11 @@ describe("discoverExternalMcp with env-var interpolation", () => {
   })
 
   test("resolves ${VAR:-default} with fallback in discovered config", async () => {
-    await mkdir(path.join(tempDir, ".vscode"), { recursive: true })
+    await using tmp = await tmpdir()
+    const dir = tmp.path
+    await mkdir(path.join(dir, ".vscode"), { recursive: true })
     await writeFile(
-      path.join(tempDir, ".vscode/mcp.json"),
+      path.join(dir, ".vscode/mcp.json"),
       JSON.stringify({
         servers: {
           svc: {
@@ -197,7 +200,7 @@ describe("discoverExternalMcp with env-var interpolation", () => {
     )
 
     const { discoverExternalMcp } = await import("../../src/mcp/discover")
-    const { servers } = await discoverExternalMcp(tempDir)
+    const { servers } = await discoverExternalMcp(dir)
 
     const env = (servers["svc"] as any).environment
     expect(env.MODE).toBe("production")

--- a/packages/opencode/test/mcp/env-var-interpolation.test.ts
+++ b/packages/opencode/test/mcp/env-var-interpolation.test.ts
@@ -3,34 +3,11 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test"
 import { mkdtemp, rm, mkdir, writeFile } from "fs/promises"
 import { tmpdir } from "os"
 import path from "path"
+import { resolveEnvVars } from "../../src/mcp"
 
 // -------------------------------------------------------------------------
 // resolveEnvVars — safety-net resolver at MCP launch site
 // -------------------------------------------------------------------------
-
-// Import the module to access resolveEnvVars indirectly via the env spread.
-// Since resolveEnvVars is a module-level function (not inside the MCP namespace),
-// we test it directly by importing the file and extracting the function.
-// For now, inline the same logic here for unit testing.
-
-const ENV_VAR_PATTERN =
-  /\$\$(\{[A-Za-z_][A-Za-z0-9_]*(?::-[^}]*)?\})|(?<!\$)\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}|\{env:([^}]+)\}/g
-
-function resolveEnvVars(environment: Record<string, string>): Record<string, string> {
-  const resolved: Record<string, string> = {}
-  for (const [key, value] of Object.entries(environment)) {
-    resolved[key] = value.replace(ENV_VAR_PATTERN, (match, escaped, dollarVar, dollarDefault, braceVar) => {
-      if (escaped !== undefined) return "$" + escaped
-      if (dollarVar !== undefined) {
-        const envValue = process.env[dollarVar]
-        return envValue !== undefined && envValue !== "" ? envValue : (dollarDefault ?? "")
-      }
-      if (braceVar !== undefined) return process.env[braceVar] || ""
-      return match
-    })
-  }
-  return resolved
-}
 
 describe("resolveEnvVars", () => {
   const ORIGINAL_ENV = { ...process.env }


### PR DESCRIPTION
### What does this PR do?

Fixes #656 — `${VAR}` and `{env:VAR}` patterns in MCP server `environment` config blocks were passed as literal strings to child processes instead of being resolved to actual environment variable values. This caused auth failures for MCP servers expecting tokens (e.g. `gitlab-mcp-server` receiving literal `"${GITLAB_PERSONAL_ACCESS_TOKEN}"` instead of the token).

### Root Cause

PR #655 added env-var interpolation to the config parsing pipeline (`ConfigPaths.parseText → substitute()`), but two code paths bypassed it:

1. **MCP launch site** (`mcp/index.ts:512`) — `mcp.environment` values were spread directly into the child process env without resolving any remaining `${VAR}` patterns. If interpolation failed upstream (config updates via `updateGlobal()`, timing issues), the literal string **overwrote** the correct value already present in `process.env`.

2. **External MCP discovery** (`discover.ts:readJsonSafe()`) — configs from Claude Code (`.claude.json`), Cursor (`.cursor/mcp.json`), VS Code (`.vscode/mcp.json`), Copilot, and Gemini were parsed via `parseJsonc()` directly, completely skipping the `substitute()` interpolation pipeline.

### Changes

| File | Change |
|------|--------|
| `packages/opencode/src/mcp/index.ts` | Added `resolveEnvVars()` safety net that resolves `${VAR}`, `${VAR:-default}`, `{env:VAR}`, and `$${VAR}` (escape) patterns in `mcp.environment` values before spawning the child process |
| `packages/opencode/src/mcp/discover.ts` | Changed `readJsonSafe()` to use `ConfigPaths.parseText()` which runs `substitute()` on raw text before JSONC parsing, with graceful fallback to direct parse on failure |
| `packages/opencode/test/mcp/env-var-interpolation.test.ts` | 14 new tests |

### Supported syntaxes (all three work in MCP environment blocks)

| Syntax | Behavior | Example |
|--------|----------|---------|
| `${VAR}` | Resolves to env value, empty string if unset | `"TOKEN": "${GITLAB_TOKEN}"` |
| `${VAR:-default}` | Resolves to env value, fallback if unset | `"MODE": "${APP_MODE:-production}"` |
| `{env:VAR}` | Raw text injection (backward compat) | `"KEY": "{env:API_KEY}"` |
| `$${VAR}` | Escape — preserves literal `${VAR}` | `"TPL": "$${VAR}"` → `"${VAR}"` |

### Test plan

- [x] 11 unit tests for `resolveEnvVars`: `${VAR}`, `{env:VAR}`, defaults, escapes, unset vars, plain passthrough, multiple vars in one value, mixed entries, bare `$VAR` not matched, empty object
- [x] 3 integration tests for discovery: `.vscode/mcp.json` with `${VAR}`, `.cursor/mcp.json` with `{env:VAR}`, fallback defaults
- [x] 18 existing `discover.test.ts` tests still pass
- [x] 34 existing `paths-parsetext.test.ts` tests still pass
- [x] TypeScript typecheck clean (only pre-existing ClickHouse driver error)

### Checklist

- [x] No new dependencies
- [x] No `any` types in new code
- [x] Follows `altimate_change` marker convention
- [x] Regex pattern matches the one in `paths.ts:substitute()` for consistency
- [x] Graceful fallback: if `ConfigPaths.parseText()` fails in discovery, falls back to direct parse (no regression for malformed external configs)

Fixes #656

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes env-var interpolation in MCP server environments so ${VAR}, ${VAR:-default}, and {env:VAR} resolve before spawn. Also interpolates external MCP configs (Cursor, VS Code, Claude Code, Copilot, Gemini). Fixes #656.

- **Bug Fixes**
  - Resolve `${VAR}`, `${VAR:-default}`, `{env:VAR}`; support `$${VAR}` escape.
  - Run resolver at launch so `mcp.environment` resolves before child spawn.
  - Interpolate external configs via `ConfigPaths.parseText()` with fallback.
  - Export `resolveEnvVars`; tests cover syntax, defaults, escapes, and external discovery.

- **Refactors**
  - Tests import the production `resolveEnvVars` and use a shared `tmpdir` fixture for cleanup.

<sup>Written for commit 5e26db6219686b89e53d755e70cf9c1a5e25b8f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP config files and local MCP environment values now support environment-variable interpolation using ${VAR}, ${VAR:-default}, and {env:VAR}; escaped $$ sequences are preserved. External MCP JSON configs are attempted to be interpolated first, with a fallback to the previous JSONC parsing behavior if interpolation fails.

* **Tests**
  * Added unit and integration tests validating interpolation behavior and discovery of external MCP configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->