### PR TITLE
test: file — File.status() git changed file detection

### DIFF
--- a/packages/opencode/test/file/status.test.ts
+++ b/packages/opencode/test/file/status.test.ts
@@ -1,0 +1,122 @@
+import { describe, test, expect } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { $ } from "bun"
+import { File } from "../../src/file"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+
+describe("File.status()", () => {
+  test("detects modified files with line counts", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const filepath = path.join(tmp.path, "test.txt")
+    await fs.writeFile(filepath, "line1\nline2\n")
+    await $`git add test.txt && git commit -m "initial"`.cwd(tmp.path).quiet()
+
+    // Modify the file — append two lines
+    await fs.writeFile(filepath, "line1\nline2\nline3\nline4\n")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const changed = await File.status()
+        expect(changed.length).toBe(1)
+        expect(changed[0].path).toBe("test.txt")
+        expect(changed[0].status).toBe("modified")
+        expect(changed[0].added).toBe(2)
+        expect(changed[0].removed).toBe(0)
+      },
+    })
+  })
+
+  test("detects untracked (new) files", async () => {
+    await using tmp = await tmpdir({ git: true })
+    // No trailing newline so split("\n") gives exactly 2 elements
+    await fs.writeFile(path.join(tmp.path, "newfile.ts"), "const x = 1\nconst y = 2")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const changed = await File.status()
+        const added = changed.find((f) => f.path === "newfile.ts")
+        expect(added).toBeDefined()
+        expect(added!.status).toBe("added")
+        expect(added!.added).toBe(2) // "const x = 1\nconst y = 2".split("\n").length === 2
+      },
+    })
+  })
+
+  test("detects deleted files", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const filepath = path.join(tmp.path, "to-delete.txt")
+    await fs.writeFile(filepath, "content\n")
+    await $`git add to-delete.txt && git commit -m "add file"`.cwd(tmp.path).quiet()
+
+    // Delete the file
+    await fs.rm(filepath)
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const changed = await File.status()
+        // Deleted files appear in diff --numstat (as "modified") AND diff --diff-filter=D (as "deleted")
+        const deleted = changed.find((f) => f.path === "to-delete.txt" && f.status === "deleted")
+        expect(deleted).toBeDefined()
+        expect(deleted!.status).toBe("deleted")
+      },
+    })
+  })
+
+  test("returns empty array for clean working tree", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const changed = await File.status()
+        expect(changed).toEqual([])
+      },
+    })
+  })
+
+  test("handles binary files with dash line counts", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const filepath = path.join(tmp.path, "image.png")
+    // Write binary content with null bytes so git classifies it as binary
+    await fs.writeFile(filepath, Buffer.from([0x00, 0x89, 0x50, 0x4e, 0x47, 0x00]))
+    await $`git add image.png && git commit -m "add image"`.cwd(tmp.path).quiet()
+
+    // Modify the binary
+    await fs.writeFile(filepath, Buffer.from([0x00, 0x89, 0x50, 0x4e, 0x47, 0x00, 0xff, 0x00]))
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const changed = await File.status()
+        const binary = changed.find((f) => f.path === "image.png")
+        expect(binary).toBeDefined()
+        expect(binary!.status).toBe("modified")
+        // Binary files report "-" in diff --numstat, which gets parsed as 0
+        expect(binary!.added).toBe(0)
+        expect(binary!.removed).toBe(0)
+      },
+    })
+  })
+
+  test("normalizes paths to be relative", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await fs.mkdir(path.join(tmp.path, "src"), { recursive: true })
+    await fs.writeFile(path.join(tmp.path, "src", "app.ts"), "const x = 1\n")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const changed = await File.status()
+        for (const file of changed) {
+          // All paths should be relative, not absolute
+          expect(path.isAbsolute(file.path)).toBe(false)
+        }
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

**`File.status()` — `src/file/index.ts:421-502`** (6 new tests)

`File.status()` powers the TUI changed-file indicator that shows users which files have been modified, added, or deleted in their working tree. It parses `git diff --numstat HEAD` output, detects untracked files via `git ls-files --others`, and identifies deleted files via `git diff --diff-filter=D`. Despite being a core user-facing function, it had **zero direct test coverage** — only a single indirect call buried in `fsmonitor.test.ts`.

New coverage includes:

- **Modified file detection**: verifies correct `added`/`removed` line count parsing from `git diff --numstat` output
- **Untracked (new) file detection**: verifies status is `"added"` and line count matches `content.split("\n").length`
- **Deleted file detection**: verifies the `--diff-filter=D` code path correctly identifies removed files
- **Clean working tree**: verifies empty array is returned when no changes exist
- **Binary file handling**: verifies that `"-"` in numstat output (binary diffs) is correctly parsed as `0` for both `added` and `removed` — this is a real edge case where `parseInt("-", 10)` would return `NaN` without the explicit check
- **Path normalization**: verifies all returned paths are relative to the project directory, not absolute

### Why this matters

If `File.status()` breaks, the TUI shows incorrect changed-file data — users see wrong file counts, miss deleted files, or get `NaN` for binary modifications. The binary-dash parsing and deleted-file detection paths are especially fragile since they rely on specific git output formatting.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage via test-discovery

### How did you verify your code works?

```
bun test test/file/status.test.ts       # 6 pass, 0 fail (746ms)
```

Marker guard check also passes:
```
bun run script/upstream/analyze.ts --markers --base main --strict
# ok — All custom code in upstream-shared files is properly marked
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01P7m7yBWTz8L7Qz17mK9GPP

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 6 tests for `File.status()` to ensure reliable git changed-file detection and accurate TUI indicators. Covers modified numstat parsing, untracked additions, deletions, binary “-” counts parsed as 0, clean tree returning an empty list, and project-relative paths.

<sup>Written for commit dab9700e7ac537beabf2104b3d196bc2415e1573. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for file status detection, including validation of modified, untracked, deleted, and binary files within git repositories, ensuring accurate line counts and normalized file path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->