### PR TITLE
test: dbt helpers — direct unit tests for shared manifest utilities

### DIFF
--- a/packages/opencode/test/altimate/dbt-helpers.test.ts
+++ b/packages/opencode/test/altimate/dbt-helpers.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Direct unit tests for dbt native helper functions in
+ * src/altimate/native/dbt/helpers.ts.
+ *
+ * These pure functions power dbt-lineage, dbt-unit-test-gen, and
+ * dbt-manifest handlers. Previously only tested indirectly through
+ * dbtLineage() in dbt-lineage-helpers.test.ts. Direct tests catch
+ * regressions in isolation: a broken findModel or detectDialect
+ * silently degrades multiple downstream tools.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import * as fs from "fs"
+import * as path from "path"
+import * as os from "os"
+
+import {
+  loadRawManifest,
+  findModel,
+  getUniqueId,
+  detectDialect,
+  buildSchemaContext,
+  extractColumns,
+  listModelNames,
+} from "../../src/altimate/native/dbt/helpers"
+
+// ---------- findModel ----------
+
+describe("findModel", () => {
+  const nodes: Record<string, any> = {
+    "model.project.orders": { resource_type: "model", name: "orders" },
+    "model.project.users": { resource_type: "model", name: "users" },
+    "source.project.raw.events": { resource_type: "source", name: "events" },
+    "test.project.not_null": { resource_type: "test", name: "not_null" },
+  }
+
+  test("finds model by exact unique_id key", () => {
+    expect(findModel(nodes, "model.project.orders")).toEqual(nodes["model.project.orders"])
+  })
+
+  test("finds model by name when unique_id does not match", () => {
+    expect(findModel(nodes, "users")).toEqual(nodes["model.project.users"])
+  })
+
+  test("returns null for source nodes (not resource_type=model)", () => {
+    expect(findModel(nodes, "events")).toBeNull()
+  })
+
+  test("returns null for nonexistent model", () => {
+    expect(findModel(nodes, "nonexistent")).toBeNull()
+  })
+
+  test("returns null for empty nodes", () => {
+    expect(findModel({}, "orders")).toBeNull()
+  })
+
+  test("returns a model when multiple models share the same name", () => {
+    const dupes: Record<string, any> = {
+      "model.a.orders": { resource_type: "model", name: "orders" },
+      "model.b.orders": { resource_type: "model", name: "orders" },
+    }
+    const result = findModel(dupes, "orders")
+    expect(result).not.toBeNull()
+    expect(result.resource_type).toBe("model")
+  })
+})
+
+// ---------- getUniqueId ----------
+
+describe("getUniqueId", () => {
+  const nodes: Record<string, any> = {
+    "model.project.orders": { resource_type: "model", name: "orders" },
+    "source.project.raw.events": { resource_type: "source", name: "events" },
+  }
+
+  test("returns key when exact unique_id exists and is a model", () => {
+    expect(getUniqueId(nodes, "model.project.orders")).toBe("model.project.orders")
+  })
+
+  test("returns unique_id when looked up by name", () => {
+    expect(getUniqueId(nodes, "orders")).toBe("model.project.orders")
+  })
+
+  test("returns undefined for source node (not resource_type=model)", () => {
+    expect(getUniqueId(nodes, "events")).toBeUndefined()
+  })
+
+  test("returns undefined for nonexistent model", () => {
+    expect(getUniqueId(nodes, "nonexistent")).toBeUndefined()
+  })
+})
+
+// ---------- detectDialect ----------
+
+describe("detectDialect", () => {
+  test("maps known adapter types to dialect strings", () => {
+    const cases: Array<[string, string]> = [
+      ["snowflake", "snowflake"],
+      ["bigquery", "bigquery"],
+      ["databricks", "databricks"],
+      ["spark", "spark"],
+      ["postgres", "postgres"],
+      ["redshift", "redshift"],
+      ["duckdb", "duckdb"],
+      ["clickhouse", "clickhouse"],
+      ["mysql", "mysql"],
+      ["sqlserver", "tsql"],
+      ["trino", "trino"],
+    ]
+    for (const [adapter, expected] of cases) {
+      expect(detectDialect({ metadata: { adapter_type: adapter } })).toBe(expected)
+    }
+  })
+
+  test("returns unmapped adapter type verbatim (truthy passthrough)", () => {
+    expect(detectDialect({ metadata: { adapter_type: "athena" } })).toBe("athena")
+  })
+
+  test("defaults to 'snowflake' when no metadata", () => {
+    expect(detectDialect({})).toBe("snowflake")
+  })
+
+  test("defaults to 'snowflake' when adapter_type is empty string", () => {
+    expect(detectDialect({ metadata: { adapter_type: "" } })).toBe("snowflake")
+  })
+
+  test("defaults to 'snowflake' when metadata is null", () => {
+    expect(detectDialect({ metadata: null })).toBe("snowflake")
+  })
+})
+
+// ---------- buildSchemaContext ----------
+
+describe("buildSchemaContext", () => {
+  const nodes: Record<string, any> = {
+    "model.project.upstream_a": {
+      resource_type: "model",
+      name: "upstream_a",
+      alias: "upstream_alias",
+      columns: {
+        id: { name: "id", data_type: "INTEGER" },
+        name: { name: "name", data_type: "VARCHAR" },
+      },
+    },
+    "model.project.upstream_b": {
+      resource_type: "model",
+      name: "upstream_b",
+      columns: {},
+    },
+  }
+  const sources: Record<string, any> = {
+    "source.project.raw.events": {
+      name: "events",
+      columns: {
+        event_id: { name: "event_id", data_type: "BIGINT" },
+      },
+    },
+  }
+
+  test("builds schema context using alias over name", () => {
+    const result = buildSchemaContext(nodes, sources, ["model.project.upstream_a"])
+    expect(result).not.toBeNull()
+    expect(result!.version).toBe("1")
+    // Alias takes precedence over name
+    expect(result!.tables["upstream_alias"]).toBeDefined()
+    expect(result!.tables["upstream_alias"].columns).toHaveLength(2)
+    // Name key must NOT exist when alias is present
+    expect(result!.tables["upstream_a"]).toBeUndefined()
+  })
+
+  test("skips upstream models with empty columns", () => {
+    const result = buildSchemaContext(nodes, sources, ["model.project.upstream_b"])
+    expect(result).toBeNull()
+  })
+
+  test("resolves upstream IDs from sources", () => {
+    const result = buildSchemaContext(nodes, sources, ["source.project.raw.events"])
+    expect(result).not.toBeNull()
+    expect(result!.tables["events"]).toBeDefined()
+    expect(result!.tables["events"].columns).toEqual([
+      { name: "event_id", type: "BIGINT" },
+    ])
+  })
+
+  test("returns null when no upstream IDs provided", () => {
+    expect(buildSchemaContext(nodes, sources, [])).toBeNull()
+  })
+
+  test("returns null when upstream IDs do not resolve", () => {
+    expect(buildSchemaContext(nodes, sources, ["model.project.ghost"])).toBeNull()
+  })
+})
+
+// ---------- extractColumns ----------
+
+describe("extractColumns", () => {
+  test("extracts column with data_type and description", () => {
+    const dict = {
+      id: { name: "id", data_type: "INTEGER", description: "Primary key" },
+    }
+    const cols = extractColumns(dict)
+    expect(cols).toHaveLength(1)
+    expect(cols[0]).toEqual({ name: "id", data_type: "INTEGER", description: "Primary key" })
+  })
+
+  test("falls back to 'type' field when data_type is missing", () => {
+    const dict = {
+      name: { name: "name", type: "VARCHAR" },
+    }
+    const cols = extractColumns(dict)
+    expect(cols).toHaveLength(1)
+    expect(cols[0].name).toBe("name")
+    expect(cols[0].data_type).toBe("VARCHAR")
+    expect(cols[0].description).toBeUndefined()
+  })
+
+  test("uses dict key as column name when col.name is missing", () => {
+    const dict = { amount: { data_type: "DECIMAL" } }
+    const cols = extractColumns(dict)
+    expect(cols[0].name).toBe("amount")
+  })
+
+  test("returns empty array for empty dict", () => {
+    expect(extractColumns({})).toEqual([])
+  })
+})
+
+// ---------- listModelNames ----------
+
+describe("listModelNames", () => {
+  test("returns only model names, excluding sources and tests", () => {
+    const nodes: Record<string, any> = {
+      "model.p.a": { resource_type: "model", name: "alpha" },
+      "source.p.b": { resource_type: "source", name: "beta" },
+      "model.p.c": { resource_type: "model", name: "gamma" },
+      "test.p.d": { resource_type: "test", name: "delta" },
+    }
+    const names = listModelNames(nodes)
+    expect(names).toEqual(["alpha", "gamma"])
+  })
+
+  test("returns empty array for no models", () => {
+    expect(listModelNames({})).toEqual([])
+  })
+})
+
+// ---------- loadRawManifest ----------
+
+describe("loadRawManifest", () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dbt-helpers-test-"))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  test("returns null for non-existent file", () => {
+    expect(loadRawManifest(path.join(tmpDir, "nonexistent.json"))).toBeNull()
+  })
+
+  test("parses valid manifest file", () => {
+    const manifestPath = path.join(tmpDir, "manifest.json")
+    fs.writeFileSync(manifestPath, JSON.stringify({ nodes: {}, metadata: { adapter_type: "snowflake" } }))
+    const result = loadRawManifest(manifestPath)
+    expect(result).not.toBeNull()
+    expect(result.metadata.adapter_type).toBe("snowflake")
+  })
+
+  test("throws on invalid JSON", () => {
+    const manifestPath = path.join(tmpDir, "bad.json")
+    fs.writeFileSync(manifestPath, "not json {{{")
+    expect(() => loadRawManifest(manifestPath)).toThrow()
+  })
+
+  test("throws when manifest is a primitive (not an object)", () => {
+    // typeof 42 === "number", triggers the non-object guard
+    const manifestPath = path.join(tmpDir, "number.json")
+    fs.writeFileSync(manifestPath, "42")
+    expect(() => loadRawManifest(manifestPath)).toThrow("Manifest is not a JSON object")
+  })
+
+  test("caches by path+mtime (same reference returned)", () => {
+    const manifestPath = path.join(tmpDir, "cached.json")
+    fs.writeFileSync(manifestPath, JSON.stringify({ v: 1 }))
+    const first = loadRawManifest(manifestPath)
+    const second = loadRawManifest(manifestPath)
+    // Same object reference from cache
+    expect(first).toBe(second)
+  })
+
+  test("invalidates cache when file content is rewritten", () => {
+    const manifestPath = path.join(tmpDir, "updated.json")
+    fs.writeFileSync(manifestPath, JSON.stringify({ v: 1 }))
+    const first = loadRawManifest(manifestPath)
+
+    // Rewrite — OS updates mtime to current time, which differs from
+    // the first write's mtime (millisecond-resolution on modern Linux).
+    fs.writeFileSync(manifestPath, JSON.stringify({ v: 2 }))
+    const second = loadRawManifest(manifestPath)
+    expect(second.v).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary

### What does this PR do?

**1. `findModel`, `getUniqueId`, `detectDialect`, `buildSchemaContext`, `extractColumns`, `listModelNames`, `loadRawManifest` — `src/altimate/native/dbt/helpers.ts`** (32 new tests)

These 7 exported pure functions are the shared foundation for dbt-lineage, dbt-unit-test-gen, and dbt-manifest handlers. **Zero direct unit tests existed** — they were only tested indirectly through `dbtLineage()` in `dbt-lineage-helpers.test.ts`, which cannot isolate individual function regressions.

A silent bug in any of these helpers cascades across multiple dbt tools:
- `findModel` returning `null` for a valid model → lineage and unit-test generation fail silently
- `detectDialect` returning wrong dialect → altimate-core SQL analysis produces garbage
- `buildSchemaContext` dropping upstream columns → dbt unit-test generation creates empty schemas
- `loadRawManifest` cache corruption → stale manifest data used across requests

**Specific scenarios covered:**

- **`findModel`** (6 tests): lookup by unique_id, lookup by name, source/test node rejection, empty nodes, duplicate model names
- **`getUniqueId`** (4 tests): direct key match, name-based scan, source node rejection, missing model
- **`detectDialect`** (5 tests): all 11 known adapter→dialect mappings, unmapped adapter passthrough, empty/null/missing metadata defaults to snowflake
- **`buildSchemaContext`** (5 tests): alias-over-name precedence (with `toBeUndefined()` guard), empty column skip, source resolution, empty/unresolvable upstream IDs
- **`extractColumns`** (4 tests): data_type extraction, `type` field fallback, dict-key-as-name fallback, empty dict
- **`listModelNames`** (2 tests): model-only filtering, empty nodes
- **`loadRawManifest`** (6 tests): missing file returns null, valid parse, invalid JSON throws, primitive (non-object) throws, path+mtime caching (reference equality), cache invalidation on rewrite

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage for shared dbt utilities with zero direct tests

### How did you verify your code works?

```
bun test test/altimate/dbt-helpers.test.ts   # 32 pass, 54 expect() calls
bun run script/upstream/analyze.ts --markers --base main --strict   # ok
turbo typecheck   # 5/5 packages pass
```

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01G3L4LeyQGJ2ox4ssaqb3Kb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 32 direct unit tests for shared dbt helpers in `src/altimate/native/dbt/helpers.ts` to catch regressions and improve reliability across dbt-lineage, dbt-unit-test-gen, and manifest handlers. Tests cover model lookup, unique_id resolution, dialect detection, schema context building, column extraction, model name listing, and manifest load/caching (including invalidation).

<sup>Written for commit ccac8f474f0788235860032322ed46113eabbf94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for dbt helper functions, covering model lookups, dialect detection, schema context building, column extraction, and manifest loading across various scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->