### PR TITLE
test: mcp discover — env-var interpolation in external configs

### DIFF
--- a/packages/opencode/test/mcp/discover.test.ts
+++ b/packages/opencode/test/mcp/discover.test.ts
@@ -363,4 +363,44 @@ describe("discoverExternalMcp", () => {
     expect(result["project-server"]).toBeDefined()
     expect((result["project-server"] as any).enabled).toBe(false)
   })
+
+  // altimate_change start — env-var interpolation in external MCP configs (commit f030bf8)
+  test("resolves ${VAR} env-var references in external config values", async () => {
+    const envKey = "__TEST_MCP_DISCOVER_CMD_" + Date.now()
+    process.env[envKey] = "my-custom-node"
+    try {
+      await mkdir(path.join(tempDir, ".vscode"), { recursive: true })
+      await writeFile(
+        path.join(tempDir, ".vscode/mcp.json"),
+        `{"servers": {"env-test": {"command": "\${${envKey}}", "args": ["serve"]}}}`,
+      )
+
+      const { servers: result } = await discoverExternalMcp(tempDir)
+      expect(result["env-test"]).toBeDefined()
+      expect(result["env-test"]).toMatchObject({
+        type: "local",
+        command: ["my-custom-node", "serve"],
+      })
+    } finally {
+      delete process.env[envKey]
+    }
+  })
+
+  test("resolves ${VAR:-default} with fallback when env var is unset", async () => {
+    const envKey = "__TEST_MCP_DISCOVER_UNSET_" + Date.now()
+    delete process.env[envKey]
+    await mkdir(path.join(tempDir, ".vscode"), { recursive: true })
+    await writeFile(
+      path.join(tempDir, ".vscode/mcp.json"),
+      `{"servers": {"default-test": {"command": "\${${envKey}:-fallback-cmd}", "args": ["run"]}}}`,
+    )
+
+    const { servers: result } = await discoverExternalMcp(tempDir)
+    expect(result["default-test"]).toBeDefined()
+    expect(result["default-test"]).toMatchObject({
+      type: "local",
+      command: ["fallback-cmd", "run"],
+    })
+  })
+  // altimate_change end
 })


### PR DESCRIPTION
### What does this PR do?

**1. `discoverExternalMcp` env-var interpolation — `src/mcp/discover.ts`** (2 new tests)

The `readJsonSafe` function gained env-var interpolation support in commit f030bf8 (#656). When external MCP configs (`.vscode/mcp.json`, `.mcp.json`, `.gemini/settings.json`, etc.) contain `${VAR}` or `${VAR:-default}` patterns, these are now resolved via `ConfigPaths.parseText` before JSON parsing. **Zero tests existed** for this interpolation path — all 18 existing discover tests used hardcoded string values.

This matters because users migrating configs from Claude Code, VS Code, or docker-compose commonly use `${API_KEY}` patterns in their MCP server configs. A regression in the interpolation path would silently produce broken MCP servers with literal `${VAR}` strings instead of resolved values.

New coverage includes:
- **`${VAR}` basic resolution**: Sets a process env var, writes a `.vscode/mcp.json` referencing it, verifies the resolved value appears in the discovered server's command array
- **`${VAR:-default}` fallback**: Uses an unset env var with a `:-fallback` default, verifies the fallback value is used when the variable is not in the environment

### Reconnaissance findings

During reconnaissance, I also examined and ruled out several other candidates:
- `File.search()` (zero test coverage) — rejected by critic due to race condition: the internal file scanner populates cache asynchronously via ripgrep, and `files()` returns cache without waiting for scan completion, making integration tests inherently flaky
- `resolveEnvVars` in `mcp/index.ts` — already well covered in `test/mcp/env-var-interpolation.test.ts`
- `altimate-backend defaultModel` in `provider.ts` — already covered in `test/provider/provider.test.ts`
- `Trace.listTracesPaginated` — already covered in `test/altimate/tracing.test.ts`

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue for this PR
N/A — proactive test coverage for recently added env-var interpolation in MCP discovery

### How did you verify your code works?

```
bun test test/mcp/discover.test.ts       # 20 pass (18 existing + 2 new)
```

Marker guard check: `bun run script/upstream/analyze.ts --markers --base main --strict` → all clear.

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01K8qyA8V76y6zrCYuEVVk3x

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two tests to `discoverExternalMcp` that cover env-var interpolation in external MCP configs. Ensures `${VAR}` and `${VAR:-default}` resolve into the command array via the `readJsonSafe` interpolation path.

<sup>Written for commit 129e635460b3c2a8717b9c6b25919fb9bdacf099. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for environment-variable interpolation in external MCP configuration.
  * Tests validate correct variable placeholder resolution when environment variables are present.
  * Tests verify fallback mechanisms apply appropriate default values when variables are absent.
  * Tests confirm discovered servers maintain proper type classification with interpolated configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->