### PR TITLE
fix: [AI-678] add stub tool definitions for historical tool_use blocks

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -157,7 +157,7 @@ export namespace LLM {
     // Fixes: https://github.com/AltimateAI/altimate-code/issues/678
     const referencedTools = toolNamesFromMessages(input.messages)
     for (const name of referencedTools) {
-      if (!tools[name]) {
+      if (!Object.hasOwn(tools, name)) {
         tools[name] = tool({
           description: `[Historical] Tool no longer available in this session`,
           inputSchema: jsonSchema({ type: "object", properties: {} }),
@@ -267,18 +267,6 @@ export namespace LLM {
     return input.tools
   }
 
-  // Check if messages contain any tool-call content
-  // Used to determine if a dummy tool should be added for LiteLLM proxy compatibility
-  export function hasToolCalls(messages: ModelMessage[]): boolean {
-    for (const msg of messages) {
-      if (!Array.isArray(msg.content)) continue
-      for (const part of msg.content) {
-        if (part.type === "tool-call" || part.type === "tool-result") return true
-      }
-    }
-    return false
-  }
-
   // altimate_change start — collect tool names from message history to prevent API validation errors
   // Anthropic API requires every tool_use block in message history to have a matching tool
   // definition. When agents switch (e.g. Plan→Builder) or MCP tools disconnect, the history
@@ -289,7 +277,7 @@ export namespace LLM {
     for (const msg of messages) {
       if (!Array.isArray(msg.content)) continue
       for (const part of msg.content) {
-        if (part.type === "tool-call") names.add(part.toolName)
+        if (part.type === "tool-call" || part.type === "tool-result") names.add(part.toolName)
       }
     }
     return names

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -149,25 +149,27 @@ export namespace LLM {
 
     const tools = await resolveTools(input)
 
-    // LiteLLM and some Anthropic proxies require the tools parameter to be present
-    // when message history contains tool calls, even if no tools are being used.
-    // Add a dummy tool that is never called to satisfy this validation.
-    // This is enabled for:
-    // 1. Providers with "litellm" in their ID or API ID (auto-detected)
-    // 2. Providers with explicit "litellmProxy: true" option (opt-in for custom gateways)
-    const isLiteLLMProxy =
-      provider.options?.["litellmProxy"] === true ||
-      input.model.providerID.toLowerCase().includes("litellm") ||
-      input.model.api.id.toLowerCase().includes("litellm")
-
-    if (isLiteLLMProxy && Object.keys(tools).length === 0 && hasToolCalls(input.messages)) {
-      tools["_noop"] = tool({
-        description:
-          "Placeholder for LiteLLM/Anthropic proxy compatibility - required when message history contains tool calls but no active tools are needed",
-        inputSchema: jsonSchema({ type: "object", properties: {} }),
-        execute: async () => ({ output: "", title: "", metadata: {} }),
-      })
+    // altimate_change start — ensure tool definitions exist for all tool_use blocks in history
+    // The Anthropic API (and proxies like LiteLLM) require every tool_use block in
+    // message history to have a matching tool definition. When agents switch (Plan→Builder),
+    // MCP tools disconnect, or tools are filtered by permissions, the history may reference
+    // tools absent from the current set. Add stub definitions for any missing tools.
+    // Fixes: https://github.com/AltimateAI/altimate-code/issues/678
+    const referencedTools = toolNamesFromMessages(input.messages)
+    for (const name of referencedTools) {
+      if (!tools[name]) {
+        tools[name] = tool({
+          description: `[Historical] Tool no longer available in this session`,
+          inputSchema: jsonSchema({ type: "object", properties: {} }),
+          execute: async () => ({
+            output: "This tool is no longer available. Please use an alternative approach.",
+            title: "",
+            metadata: {},
+          }),
+        })
+      }
     }
+    // altimate_change end
 
     return streamText({
       onError(error) {
@@ -276,4 +278,21 @@ export namespace LLM {
     }
     return false
   }
+
+  // altimate_change start — collect tool names from message history to prevent API validation errors
+  // Anthropic API requires every tool_use block in message history to have a matching tool
+  // definition. When agents switch (e.g. Plan→Builder) or MCP tools disconnect, the history
+  // may reference tools no longer in the active set. This function extracts those names so
+  // stub definitions can be added. Fixes #678.
+  export function toolNamesFromMessages(messages: ModelMessage[]): Set<string> {
+    const names = new Set<string>()
+    for (const msg of messages) {
+      if (!Array.isArray(msg.content)) continue
+      for (const part of msg.content) {
+        if (part.type === "tool-call") names.add(part.toolName)
+      }
+    }
+    return names
+  }
+  // altimate_change end
 }

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -54,101 +54,32 @@ describe("session.llm.toolNamesFromMessages", () => {
     expect(LLM.toolNamesFromMessages(messages)).toEqual(new Set(["bash"]))
   })
 
-  test("ignores tool-result blocks (only extracts from tool-call)", () => {
+  test("extracts tool names from tool-result blocks", () => {
     const messages = [
       {
         role: "tool",
         content: [{ type: "tool-result", toolCallId: "call-1", toolName: "bash" }],
       },
     ] as ModelMessage[]
-    expect(LLM.toolNamesFromMessages(messages)).toEqual(new Set())
-  })
-})
-
-describe("session.llm.hasToolCalls", () => {
-  test("returns false for empty messages array", () => {
-    expect(LLM.hasToolCalls([])).toBe(false)
+    expect(LLM.toolNamesFromMessages(messages)).toEqual(new Set(["bash"]))
   })
 
-  test("returns false for messages with only text content", () => {
-    const messages: ModelMessage[] = [
-      {
-        role: "user",
-        content: [{ type: "text", text: "Hello" }],
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Hi there" }],
-      },
-    ]
-    expect(LLM.hasToolCalls(messages)).toBe(false)
-  })
-
-  test("returns true when messages contain tool-call", () => {
+  test("extracts from both tool-call and tool-result blocks", () => {
     const messages = [
       {
-        role: "user",
-        content: [{ type: "text", text: "Run a command" }],
-      },
-      {
         role: "assistant",
-        content: [
-          {
-            type: "tool-call",
-            toolCallId: "call-123",
-            toolName: "bash",
-          },
-        ],
+        content: [{ type: "tool-call", toolCallId: "call-1", toolName: "bash" }],
       },
-    ] as ModelMessage[]
-    expect(LLM.hasToolCalls(messages)).toBe(true)
-  })
-
-  test("returns true when messages contain tool-result", () => {
-    const messages = [
       {
         role: "tool",
-        content: [
-          {
-            type: "tool-result",
-            toolCallId: "call-123",
-            toolName: "bash",
-          },
-        ],
+        content: [{ type: "tool-result", toolCallId: "call-1", toolName: "bash" }],
+      },
+      {
+        role: "tool",
+        content: [{ type: "tool-result", toolCallId: "call-2", toolName: "read" }],
       },
     ] as ModelMessage[]
-    expect(LLM.hasToolCalls(messages)).toBe(true)
-  })
-
-  test("returns false for messages with string content", () => {
-    const messages: ModelMessage[] = [
-      {
-        role: "user",
-        content: "Hello world",
-      },
-      {
-        role: "assistant",
-        content: "Hi there",
-      },
-    ]
-    expect(LLM.hasToolCalls(messages)).toBe(false)
-  })
-
-  test("returns true when tool-call is mixed with text content", () => {
-    const messages = [
-      {
-        role: "assistant",
-        content: [
-          { type: "text", text: "Let me run that command" },
-          {
-            type: "tool-call",
-            toolCallId: "call-456",
-            toolName: "read",
-          },
-        ],
-      },
-    ] as ModelMessage[]
-    expect(LLM.hasToolCalls(messages)).toBe(true)
+    expect(LLM.toolNamesFromMessages(messages)).toEqual(new Set(["bash", "read"]))
   })
 })
 

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -14,6 +14,57 @@ import type { Agent } from "../../src/agent/agent"
 import type { MessageV2 } from "../../src/session/message-v2"
 import { SessionID, MessageID } from "../../src/session/schema"
 
+describe("session.llm.toolNamesFromMessages", () => {
+  test("returns empty set for empty messages", () => {
+    expect(LLM.toolNamesFromMessages([])).toEqual(new Set())
+  })
+
+  test("returns empty set for messages with no tool calls", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+      { role: "assistant", content: [{ type: "text", text: "Hi" }] },
+    ]
+    expect(LLM.toolNamesFromMessages(messages)).toEqual(new Set())
+  })
+
+  test("extracts tool names from tool-call blocks", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "call-1", toolName: "bash" },
+          { type: "tool-call", toolCallId: "call-2", toolName: "read" },
+        ],
+      },
+    ] as ModelMessage[]
+    expect(LLM.toolNamesFromMessages(messages)).toEqual(new Set(["bash", "read"]))
+  })
+
+  test("deduplicates tool names across messages", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "tool-call", toolCallId: "call-1", toolName: "bash" }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "tool-call", toolCallId: "call-2", toolName: "bash" }],
+      },
+    ] as ModelMessage[]
+    expect(LLM.toolNamesFromMessages(messages)).toEqual(new Set(["bash"]))
+  })
+
+  test("ignores tool-result blocks (only extracts from tool-call)", () => {
+    const messages = [
+      {
+        role: "tool",
+        content: [{ type: "tool-result", toolCallId: "call-1", toolName: "bash" }],
+      },
+    ] as ModelMessage[]
+    expect(LLM.toolNamesFromMessages(messages)).toEqual(new Set())
+  })
+})
+
 describe("session.llm.hasToolCalls", () => {
   test("returns false for empty messages array", () => {
     expect(LLM.hasToolCalls([])).toBe(false)


### PR DESCRIPTION
### What does this PR do?

Fixes the Anthropic API error "Requests with 'tool_use' and 'tool_result' blocks must include tool definition" that occurs when conversation history references tools no longer in the active set (e.g., after switching agents from Plan→Builder, MCP tools disconnecting, or tools filtered by permissions).

Replaces the previous LiteLLM-only `_noop` workaround with a general fix that:
- Extracts all tool names from `tool-call` blocks in message history
- Adds stub definitions for any tool names missing from the active tools set
- Returns "tool no longer available" if the model attempts to call a historical stub

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #678

### How did you verify your code works?

- Added 5 unit tests for `toolNamesFromMessages()` covering: empty messages, no tool calls, extraction, dedup, tool-call vs tool-result distinction
- All 15 tests in `llm.test.ts` pass (5 new + 10 existing)
- Full local CI passes (`bun run ci` — unit tests + marker guard)
- Multi-model code review (Claude + GPT 5.4 + DeepSeek V3.2) — approved with 1 round of convergence

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Anthropic validation errors by adding stub tool definitions for historical `tool_use` blocks when tools are no longer active. Replaces the LiteLLM-only `_noop` workaround with a provider-agnostic fix for AI-678.

- **Bug Fixes**
  - Scans message history for tool names in `tool-call` and `tool-result`, then adds stubs for any missing in the active set.
  - Stubs return "This tool is no longer available. Please use an alternative approach." to avoid 400s when agents switch or MCP tools disconnect.
  - Uses `Object.hasOwn()` for safe presence checks; removes `_noop` and dead `hasToolCalls()`; adds tests for `toolNamesFromMessages` (extraction, dedup, results).

<sup>Written for commit f7fdcc882d8f00cd70e668b43e87a08f99947490. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced provider-specific logic with a generalized stub-tool mechanism that scans message history for referenced tool names and injects placeholders for any missing tools, ensuring referenced tools are available at runtime.

* **Tests**
  * Added and updated tests to validate extraction and deduplication of tool names from message histories, covering text-only, call-only, result-only, and mixed scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->