### PR TITLE
feat: add --page convenience option for trace list CLI

### DIFF
--- a/packages/opencode/src/cli/cmd/trace.ts
+++ b/packages/opencode/src/cli/cmd/trace.ts
@@ -61,8 +61,9 @@ function listTraces(
   }
 
   if (traces.length === 0 && pagination.total > 0) {
+    const totalPages = Math.ceil(pagination.total / pagination.limit)
     UI.println(`No traces on this page (offset ${pagination.offset} past end of ${pagination.total} traces).`)
-    UI.println(UI.Style.TEXT_DIM + `Try: altimate-code trace list --offset 0 --limit ${pagination.limit}` + UI.Style.TEXT_NORMAL)
+    UI.println(UI.Style.TEXT_DIM + `Try: altimate-code trace list --page 1  (${totalPages} page(s) available)` + UI.Style.TEXT_NORMAL)
     return
   }
 
@@ -110,9 +111,11 @@ function listTraces(
   // altimate_change start — trace: session trace messages with pagination footer
   const rangeStart = pagination.offset + 1
   const rangeEnd = pagination.offset + traces.length
-  UI.println(UI.Style.TEXT_DIM + `Showing ${rangeStart}-${rangeEnd} of ${pagination.total} trace(s) in ${Trace.getTracesDir(tracesDir)}` + UI.Style.TEXT_NORMAL)
+  const currentPage = Math.floor(pagination.offset / pagination.limit) + 1
+  const totalPages = Math.ceil(pagination.total / pagination.limit)
+  UI.println(UI.Style.TEXT_DIM + `Showing ${rangeStart}-${rangeEnd} of ${pagination.total} trace(s) (page ${currentPage}/${totalPages}) in ${Trace.getTracesDir(tracesDir)}` + UI.Style.TEXT_NORMAL)
   if (rangeEnd < pagination.total) {
-    UI.println(UI.Style.TEXT_DIM + `Next page: altimate-code trace list --offset ${rangeEnd} --limit ${pagination.limit}` + UI.Style.TEXT_NORMAL)
+    UI.println(UI.Style.TEXT_DIM + `Next page: altimate-code trace list --page ${currentPage + 1}` + UI.Style.TEXT_NORMAL)
   }
   UI.println(UI.Style.TEXT_DIM + "View a trace: altimate-code trace view <session-id>" + UI.Style.TEXT_NORMAL)
   // altimate_change end
@@ -154,6 +157,11 @@ export const TraceCommand = cmd({
         describe: "number of traces to skip (for pagination)",
         default: 0,
       })
+      .option("page", {
+        alias: ["p"],
+        type: "number",
+        describe: "page number (1-based, converts to offset automatically)",
+      })
       .option("live", {
         type: "boolean",
         describe: "auto-refresh the viewer as the trace updates (for in-progress sessions)",
@@ -173,10 +181,11 @@ export const TraceCommand = cmd({
       // treat `--offset 0` as unset (no semantic change, harmless), but
       // `args.limit || 20` would promote `--limit 0` to 20 instead of
       // letting the API clamp it to 1.
-      const page = await Trace.listTracesPaginated(tracesDir, {
-        offset: args.offset ?? 0,
-        limit: args.limit ?? 20,
-      })
+      const limit = args.limit ?? 20
+      const offset = args.page != null
+        ? (Math.max(1, Math.trunc(args.page)) - 1) * limit
+        : (args.offset ?? 0)
+      const page = await Trace.listTracesPaginated(tracesDir, { offset, limit })
       listTraces(page.traces, page, tracesDir)
       return
     }

--- a/packages/opencode/src/cli/cmd/trace.ts
+++ b/packages/opencode/src/cli/cmd/trace.ts
@@ -115,7 +115,11 @@ function listTraces(
   const totalPages = Math.ceil(pagination.total / pagination.limit)
   UI.println(UI.Style.TEXT_DIM + `Showing ${rangeStart}-${rangeEnd} of ${pagination.total} trace(s) (page ${currentPage}/${totalPages}) in ${Trace.getTracesDir(tracesDir)}` + UI.Style.TEXT_NORMAL)
   if (rangeEnd < pagination.total) {
-    UI.println(UI.Style.TEXT_DIM + `Next page: altimate-code trace list --page ${currentPage + 1}` + UI.Style.TEXT_NORMAL)
+    const isPageAligned = pagination.offset % pagination.limit === 0
+    const nextHint = isPageAligned
+      ? `altimate-code trace list --page ${currentPage + 1} --limit ${pagination.limit}`
+      : `altimate-code trace list --offset ${rangeEnd} --limit ${pagination.limit}`
+    UI.println(UI.Style.TEXT_DIM + `Next page: ${nextHint}` + UI.Style.TEXT_NORMAL)
   }
   UI.println(UI.Style.TEXT_DIM + "View a trace: altimate-code trace view <session-id>" + UI.Style.TEXT_NORMAL)
   // altimate_change end
@@ -182,8 +186,9 @@ export const TraceCommand = cmd({
       // `args.limit || 20` would promote `--limit 0` to 20 instead of
       // letting the API clamp it to 1.
       const limit = args.limit ?? 20
-      const offset = args.page != null
-        ? (Math.max(1, Math.trunc(args.page)) - 1) * limit
+      const rawPage = args.page != null ? args.page : undefined
+      const offset = rawPage != null && Number.isFinite(rawPage)
+        ? (Math.max(1, Math.trunc(rawPage)) - 1) * limit
         : (args.offset ?? 0)
       const page = await Trace.listTracesPaginated(tracesDir, { offset, limit })
       listTraces(page.traces, page, tracesDir)

--- a/packages/opencode/test/cli/trace-page-option.test.ts
+++ b/packages/opencode/test/cli/trace-page-option.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test"
+
+/**
+ * Tests for the --page convenience option added to `trace list`.
+ *
+ * The page-to-offset conversion lives inline in the CLI handler, so we test
+ * the formula directly here rather than spawning a subprocess.
+ */
+
+// --- page-to-offset conversion (mirrors the handler logic) ---
+
+function pageToOffset(page: number | undefined, offset: number, limit: number): number {
+  if (page != null) {
+    return (Math.max(1, Math.trunc(page)) - 1) * limit
+  }
+  return offset
+}
+
+describe("trace list --page to offset conversion", () => {
+  test("page 1 maps to offset 0", () => {
+    expect(pageToOffset(1, 0, 20)).toBe(0)
+  })
+
+  test("page 2 with default limit maps to offset 20", () => {
+    expect(pageToOffset(2, 0, 20)).toBe(20)
+  })
+
+  test("page 3 with limit 10 maps to offset 20", () => {
+    expect(pageToOffset(3, 0, 10)).toBe(20)
+  })
+
+  test("page 5 with limit 5 maps to offset 20", () => {
+    expect(pageToOffset(5, 0, 5)).toBe(20)
+  })
+
+  test("page takes precedence over explicit offset", () => {
+    // --page 2 --offset 99 → page wins
+    expect(pageToOffset(2, 99, 20)).toBe(20)
+  })
+
+  test("undefined page falls back to provided offset", () => {
+    expect(pageToOffset(undefined, 40, 20)).toBe(40)
+  })
+
+  test("page 0 is clamped to page 1 (offset 0)", () => {
+    expect(pageToOffset(0, 0, 20)).toBe(0)
+  })
+
+  test("negative page is clamped to page 1 (offset 0)", () => {
+    expect(pageToOffset(-5, 0, 20)).toBe(0)
+  })
+
+  test("fractional page is truncated", () => {
+    // page 2.7 → trunc to 2 → offset 20
+    expect(pageToOffset(2.7, 0, 20)).toBe(20)
+  })
+})
+
+// --- pagination footer formatting (mirrors listTraces footer) ---
+
+function formatFooter(offset: number, limit: number, total: number, shown: number) {
+  const rangeStart = offset + 1
+  const rangeEnd = offset + shown
+  const currentPage = Math.floor(offset / limit) + 1
+  const totalPages = Math.ceil(total / limit)
+  const summary = `Showing ${rangeStart}-${rangeEnd} of ${total} trace(s) (page ${currentPage}/${totalPages})`
+  const nextHint = rangeEnd < total
+    ? `Next page: altimate-code trace list --page ${currentPage + 1}`
+    : null
+  return { summary, nextHint }
+}
+
+describe("trace list pagination footer", () => {
+  test("first page of multiple shows page 1/N and next hint", () => {
+    const { summary, nextHint } = formatFooter(0, 20, 50, 20)
+    expect(summary).toBe("Showing 1-20 of 50 trace(s) (page 1/3)")
+    expect(nextHint).toBe("Next page: altimate-code trace list --page 2")
+  })
+
+  test("middle page shows correct range and next hint", () => {
+    const { summary, nextHint } = formatFooter(20, 20, 50, 20)
+    expect(summary).toBe("Showing 21-40 of 50 trace(s) (page 2/3)")
+    expect(nextHint).toBe("Next page: altimate-code trace list --page 3")
+  })
+
+  test("last page has no next hint", () => {
+    const { summary, nextHint } = formatFooter(40, 20, 50, 10)
+    expect(summary).toBe("Showing 41-50 of 50 trace(s) (page 3/3)")
+    expect(nextHint).toBeNull()
+  })
+
+  test("single page has no next hint", () => {
+    const { summary, nextHint } = formatFooter(0, 20, 5, 5)
+    expect(summary).toBe("Showing 1-5 of 5 trace(s) (page 1/1)")
+    expect(nextHint).toBeNull()
+  })
+
+  test("custom limit changes page calculation", () => {
+    const { summary, nextHint } = formatFooter(10, 10, 35, 10)
+    expect(summary).toBe("Showing 11-20 of 35 trace(s) (page 2/4)")
+    expect(nextHint).toBe("Next page: altimate-code trace list --page 3")
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Fixes #669 — adds `--page N` (`-p N`) convenience option to `altimate-code trace list` so users don't have to manually calculate `--offset` values for pagination.

Before: `altimate-code trace list --offset 20 --limit 20`  
After: `altimate-code trace list --page 2`

### Changes

| File | Change |
|------|--------|
| `packages/opencode/src/cli/cmd/trace.ts` | Added `--page` / `-p` option with page-to-offset conversion (`offset = (page - 1) * limit`). Updated pagination footer to show `page X/Y` and `--page N` hints |
| `packages/opencode/test/cli/trace-page-option.test.ts` | 14 unit tests covering page-to-offset conversion (edge cases: 0, negative, fractional, precedence over --offset) and footer formatting |

### Behavior

- `--page 1` → offset 0 (first page)
- `--page 2 --limit 10` → offset 10
- `--page` takes precedence over `--offset` when both provided
- Invalid values (0, negative, fractional) are clamped/truncated to valid pages
- Footer now shows: `Showing 1-20 of 50 trace(s) (page 1/3)` and `Next page: altimate-code trace list --page 2`
- Backward compatible — existing `--offset`/`--limit` usage unchanged

### Screenshots

<img width="1383" height="434" alt="Screenshot 2026-04-13 at 9 10 06 PM" src="https://github.com/user-attachments/assets/567d1d9a-f3be-4c1b-915c-7627fe688f2a" />
<img width="1383" height="374" alt="Screenshot 2026-04-13 at 9 09 06 PM" src="https://github.com/user-attachments/assets/de299b0e-9f97-47a4-808c-23efe26d4cb9" />


### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Issue for this PR

Closes #669

Related: #596 (original pagination infrastructure)

### How did you verify your code works?

- 14 unit tests pass (`bun test test/cli/trace-page-option.test.ts`)
- Tested locally with real traces: `--page 1`, `--page 2`, `--page 6` (last), `--page 99` (past end)
- TypeScript: zero new errors
- `--help` correctly shows the new `-p, --page` option

### Checklist

- [x] I have performed a self-review of my code
- [x] My changes follow the existing code style
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--page` (`-p`) option to `altimate-code trace list` so users can paginate by page number instead of calculating `--offset`. The footer now shows `page X/Y`, and hints preserve `--limit` and choose the right format.

- **New Features**
  - `--page` converts to offset (`(page - 1) * limit`) and overrides `--offset`.
  - Invalid `--page` values (0, negative, fractional) are clamped/truncated; non-numeric is ignored.
  - Footer shows `page X/Y`; next-page hint uses `--page` when aligned, otherwise `--offset`, and keeps `--limit`.
  - Empty-page message suggests `--page 1` and shows total pages.
  - Backward compatible with existing `--offset`/`--limit`.
  - Added 14 unit tests for conversion and footer formatting.

<sup>Written for commit 779496a2dd2071400eca1c6608dd2aeadb13798f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a 1-based page option (-p/--page) for easier pagination when listing traces.

* **Improvements**
  * Pagination footer now shows current page and total pages.
  * "No traces on this page" message and "Next page" hints updated to suggest page-based navigation.

* **Tests**
  * Added tests covering page-to-offset behavior and pagination footer formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->