### PR TITLE
fix: point /docs command and config links to docs.altimate.sh

### DIFF
--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -431,7 +431,7 @@ export const ProvidersLoginCommand = cmd({
 
         if (["cloudflare", "cloudflare-ai-gateway"].includes(provider)) {
           prompts.log.info(
-            "Cloudflare AI Gateway can be configured with CLOUDFLARE_GATEWAY_ID, CLOUDFLARE_ACCOUNT_ID, and CLOUDFLARE_API_TOKEN environment variables. Read more: https://altimate.ai/docs/providers/#cloudflare-ai-gateway",
+            "Cloudflare AI Gateway can be configured with CLOUDFLARE_GATEWAY_ID, CLOUDFLARE_ACCOUNT_ID, and CLOUDFLARE_API_TOKEN environment variables. Read more: https://docs.altimate.sh/configure/providers/",
           )
         }
 

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -680,7 +680,7 @@ function App() {
       title: "Open docs",
       value: "docs.open",
       onSelect: () => {
-        open("https://altimate.ai/docs").catch(() => {})
+        open("https://docs.altimate.sh").catch(() => {})
         dialog.clear()
       },
       category: "System",

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -78,7 +78,7 @@ export namespace Config {
   export const state = Instance.state(async () => {
     const auth = await Auth.all()
 
-    // Config loading order (low -> high precedence): https://altimate.ai/docs/config#precedence-order
+    // Config loading order (low -> high precedence): https://docs.altimate.sh/configure/config/
     // 1) Remote .well-known/opencode (org defaults)
     // 2) Global config (~/.config/opencode/opencode.json{,c})
     // 3) Custom config (OPENCODE_CONFIG)
@@ -1074,7 +1074,7 @@ export namespace Config {
       command: z
         .record(z.string(), Command)
         .optional()
-        .describe("Command configuration, see https://altimate.ai/docs/commands"),
+        .describe("Command configuration, see https://docs.altimate.sh/configure/commands/"),
       skills: Skills.optional().describe("Additional skill folder paths"),
       watcher: z
         .object({
@@ -1141,7 +1141,7 @@ export namespace Config {
         })
         .catchall(Agent)
         .optional()
-        .describe("Agent configuration, see https://altimate.ai/docs/agents"),
+        .describe("Agent configuration, see https://docs.altimate.sh/configure/agents/"),
       provider: z
         .record(z.string(), Provider)
         .optional()

--- a/packages/opencode/src/session/prompt/anthropic.txt
+++ b/packages/opencode/src/session/prompt/anthropic.txt
@@ -9,7 +9,7 @@ If the user asks for help or wants to give feedback inform them of the following
 - To give feedback, users should report the issue at
   https://github.com/AltimateAI/altimate-code
 
-When the user directly asks about Altimate Code (eg. "can Altimate Code do...", "does Altimate Code have..."), or asks in second person (eg. "are you able...", "can you do..."), or asks how to use a specific Altimate Code feature (eg. implement a hook, write a slash command, or install an MCP server), use the WebFetch tool to gather information to answer the question from Altimate Code docs. The list of available docs is available at https://altimate.ai/docs
+When the user directly asks about Altimate Code (eg. "can Altimate Code do...", "does Altimate Code have..."), or asks in second person (eg. "are you able...", "can you do..."), or asks how to use a specific Altimate Code feature (eg. implement a hook, write a slash command, or install an MCP server), use the WebFetch tool to gather information to answer the question from Altimate Code docs. The list of available docs is available at https://docs.altimate.sh
 
 # Tone and style
 - Only use emojis if the user explicitly requests it. Avoid using emojis in all communication unless asked.

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1209,7 +1209,7 @@ export type Config = {
     diff_style?: "auto" | "stacked"
   }
   /**
-   * Command configuration, see https://altimate.ai/docs/commands
+   * Command configuration, see https://docs.altimate.sh/configure/commands/
    */
   command?: {
     [key: string]: {
@@ -1266,7 +1266,7 @@ export type Config = {
     [key: string]: AgentConfig | undefined
   }
   /**
-   * Agent configuration, see https://altimate.ai/docs/agent
+   * Agent configuration, see https://docs.altimate.sh/configure/agents/
    */
   agent?: {
     plan?: AgentConfig

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1315,7 +1315,7 @@ export type Config = {
   logLevel?: LogLevel
   server?: ServerConfig
   /**
-   * Command configuration, see https://altimate.ai/docs/commands
+   * Command configuration, see https://docs.altimate.sh/configure/commands/
    */
   command?: {
     [key: string]: {
@@ -1389,7 +1389,7 @@ export type Config = {
     [key: string]: AgentConfig | undefined
   }
   /**
-   * Agent configuration, see https://altimate.ai/docs/agents
+   * Agent configuration, see https://docs.altimate.sh/configure/agents/
    */
   agent?: {
     plan?: AgentConfig

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -10340,7 +10340,7 @@
             "$ref": "#/components/schemas/ServerConfig"
           },
           "command": {
-            "description": "Command configuration, see https://altimate.ai/docs/commands",
+            "description": "Command configuration, see https://docs.altimate.sh/configure/commands/",
             "type": "object",
             "propertyNames": {
               "type": "string"
@@ -10474,7 +10474,7 @@
             }
           },
           "agent": {
-            "description": "Agent configuration, see https://altimate.ai/docs/agents",
+            "description": "Agent configuration, see https://docs.altimate.sh/configure/agents/",
             "type": "object",
             "properties": {
               "plan": {


### PR DESCRIPTION
### What does this PR do?

Fixes the TUI `/docs` command (and several config/help-text references) which pointed to `https://altimate.ai/docs` — not the project's docs site. The canonical docs live at `https://docs.altimate.sh` (per `README.md`, `docs/docs/CNAME`, `docs/mkdocs.yml`).

Updated references:

- `packages/opencode/src/cli/cmd/tui/app.tsx` — "Open docs" command URL
- `packages/opencode/src/config/config.ts` — config precedence comment + `command`/`agent` schema descriptions
- `packages/opencode/src/cli/cmd/providers.ts` — Cloudflare AI Gateway help text
- `packages/opencode/src/session/prompt/anthropic.txt` — Anthropic system prompt docs link
- `packages/sdk/openapi.json` + generated `packages/sdk/js/src/**/gen/types.gen.ts` — `command`/`agent` schema descriptions

Also corrected the paths (e.g. `/commands` → `/configure/commands/`) to match the actual mkdocs site structure.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other

### Issue for this PR

Closes #714

### How did you verify your code works?

- Ran `curl -L -o /dev/null -w '%{http_code}' <url>` against every updated URL — all return **HTTP 200**:
  - `https://docs.altimate.sh`
  - `https://docs.altimate.sh/configure/config/`
  - `https://docs.altimate.sh/configure/commands/`
  - `https://docs.altimate.sh/configure/agents/`
  - `https://docs.altimate.sh/configure/providers/`
- Ran `bun run script/upstream/analyze.ts --markers --base main --strict` → `ok    No upstream-shared files modified — no markers needed`.
- Turbo `typecheck` passes for all workspace packages (pre-push hook).
- No functional logic changed — string-only edits across user-facing URLs and generated SDK type comments.

### Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

_No tests added — this is a string-only URL correction with no logic changes. The target URLs were manually verified to return HTTP 200._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Points the TUI /docs command and all in-app docs links to https://docs.altimate.sh. Also fixes paths to /configure/* so users land on the right pages.

- **Bug Fixes**
  - TUI `docs.open` now opens `https://docs.altimate.sh`.
  - Fixed config precedence and schema description URLs to `/configure/config/`, `/configure/commands/`, and `/configure/agents/`.
  - Updated Cloudflare AI Gateway help text to `/configure/providers/`.
  - Updated Anthropic system prompt docs link.
  - Synced links in OpenAPI and generated SDK types.

<sup>Written for commit 344eb97b4de60fec9e8f08ec89ca5beadbc0027c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links throughout the application to reference the new documentation site at docs.altimate.sh

<!-- end of auto-generated comment: release notes by coderabbit.ai -->