### PR TITLE
chore: bump @altimateai/altimate-core from 0.2.6 to 0.3.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -85,7 +85,7 @@
         "@ai-sdk/togetherai": "1.0.34",
         "@ai-sdk/vercel": "1.0.33",
         "@ai-sdk/xai": "2.0.51",
-        "@altimateai/altimate-core": "0.2.6",
+        "@altimateai/altimate-core": "0.3.0",
         "@altimateai/drivers": "workspace:*",
         "@aws-sdk/credential-providers": "3.993.0",
         "@clack/prompts": "1.0.0-alpha.1",
@@ -350,17 +350,17 @@
 
     "@altimateai/altimate-code": ["@altimateai/altimate-code@workspace:packages/opencode"],
 
-    "@altimateai/altimate-core": ["@altimateai/altimate-core@0.2.6", "", { "optionalDependencies": { "@altimateai/altimate-core-darwin-arm64": "0.2.6", "@altimateai/altimate-core-darwin-x64": "0.2.6", "@altimateai/altimate-core-linux-arm64-gnu": "0.2.6", "@altimateai/altimate-core-linux-x64-gnu": "0.2.6", "@altimateai/altimate-core-win32-x64-msvc": "0.2.6" } }, "sha512-RJNxDqyCmaEEcumIH7v5aXcZIP+vF7qbANrvIvOMR/Qt9FxhY84Zj6HZtjxdP9Qw8cfukkEbIqnI+gHTkhc5RQ=="],
+    "@altimateai/altimate-core": ["@altimateai/altimate-core@0.3.0", "", { "optionalDependencies": { "@altimateai/altimate-core-darwin-arm64": "0.3.0", "@altimateai/altimate-core-darwin-x64": "0.3.0", "@altimateai/altimate-core-linux-arm64-gnu": "0.3.0", "@altimateai/altimate-core-linux-x64-gnu": "0.3.0", "@altimateai/altimate-core-win32-x64-msvc": "0.3.0" } }, "sha512-TVfNYgmgTQwBdjRvjDsbqNBGRrdVU1QwdIHqrc76zX84cQIoTu82HC0mpamdeJOf+rLILZKYrhFyDbYzO2N6xw=="],
 
-    "@altimateai/altimate-core-darwin-arm64": ["@altimateai/altimate-core-darwin-arm64@0.2.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-my1Li6VFrzEESQkSvGqMbw6othfHJk+Zkx9lY8WFNIiheBDesbunJatGUyvz7/hel56af3FHdgIIeF/H3kzUkA=="],
+    "@altimateai/altimate-core-darwin-arm64": ["@altimateai/altimate-core-darwin-arm64@0.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zL24P/yPz8UIiRFwxCfEkkH+c3ldkSoHPUSkx2ePSM1YVygVsskO2xlbmVArEo0inF2oSTTw1L63jI2cHf2iRg=="],
 
-    "@altimateai/altimate-core-darwin-x64": ["@altimateai/altimate-core-darwin-x64@0.2.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-e+F49pmM1eeRJ/0xBb8HAr9KzCe3WNJ40mViJ0T+uuB3RrPO1+93/4zdsDxZIh+8cG60vDBm/3A8k9ELu1x/Hg=="],
+    "@altimateai/altimate-core-darwin-x64": ["@altimateai/altimate-core-darwin-x64@0.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-4ocNGpM+WDJEHyXhpv76U18XbB32eyiN7+0WZ9v1U+42NzleVjKXYUHP6rYpp+hAEt/S7YfxF0+f0uxDm85+Ig=="],
 
-    "@altimateai/altimate-core-linux-arm64-gnu": ["@altimateai/altimate-core-linux-arm64-gnu@0.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-/7okkP2LJBQFTekBWFvx9SLs8JhzYhfQsMWKnnr1kyZgl4Paw2emT6zyGce9uGBoXc8RXoOxyqlwBTe1Rqeupw=="],
+    "@altimateai/altimate-core-linux-arm64-gnu": ["@altimateai/altimate-core-linux-arm64-gnu@0.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-yMgJFG+HBkXytu6mC0VxV7ODPZbmXkDYtVLVLZ0tpvCAHyH3vJWG+e6n+m6boMRDVVE4OSnGM1wBsDDlwJVWFg=="],
 
-    "@altimateai/altimate-core-linux-x64-gnu": ["@altimateai/altimate-core-linux-x64-gnu@0.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-AhOsBwyxMsW+fDA6vXRX0iamXP5KBr01ZkcdD3OjvjohmdTN7679gcAwmIbHn177dnQNtwq1ZG6F6mVP/XL2YA=="],
+    "@altimateai/altimate-core-linux-x64-gnu": ["@altimateai/altimate-core-linux-x64-gnu@0.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ucN7OMvyzvpSaJtMJCRbMHMwmfVWgVN7jEHVdHwaygpbmlWYLRH8EQLoNOe9sy4CWAblm6gitk5n8e8QgWQYSQ=="],
 
-    "@altimateai/altimate-core-win32-x64-msvc": ["@altimateai/altimate-core-win32-x64-msvc@0.2.6", "", { "os": "win32", "cpu": "x64" }, "sha512-zxxB/FqvZMOuxjaz2tS397j6dtDoGYx3l2MDKbf4gGfjL1/Osc9I+cWndECONPJy5wq7jCY2B/dxjDJrob5zig=="],
+    "@altimateai/altimate-core-win32-x64-msvc": ["@altimateai/altimate-core-win32-x64-msvc@0.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-sjokHZWLzwpGOWQfkrT5wKpkmt5tB6iau5zZoIme3jYezyUVHnWkPdjJtTmHGdAiRUbbyBV/LriZhzztqi1vxw=="],
 
     "@altimateai/dbt-integration": ["@altimateai/dbt-integration@0.2.9", "", { "dependencies": { "@altimateai/altimate-core": "0.1.6", "node-abort-controller": "^3.1.1", "node-fetch": "^3.3.2", "python-bridge": "^1.1.0", "semver": "^7.6.3", "yaml": "^2.5.0" }, "peerDependencies": { "patch-package": "^8.0.0" } }, "sha512-L+sazdclVNVPuRrSRq/0dGfyNEOHHGKqOCGEkZiXFbaW9hRGRqk+9LgmOUwyDq2VA79qvduOehe7+Uk0Oo3sow=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -78,7 +78,7 @@
     "@ai-sdk/togetherai": "1.0.34",
     "@ai-sdk/vercel": "1.0.33",
     "@ai-sdk/xai": "2.0.51",
-    "@altimateai/altimate-core": "0.2.6",
+    "@altimateai/altimate-core": "0.3.0",
     "@altimateai/drivers": "workspace:*",
     "@aws-sdk/credential-providers": "3.993.0",
     "@clack/prompts": "1.0.0-alpha.1",


### PR DESCRIPTION
### What does this PR do?

Bumps the `@altimateai/altimate-core` native bridge from `0.2.6` to `0.3.0` in `packages/opencode/package.json` and regenerates `bun.lock`. No source code changes.

The transitive `@altimateai/altimate-core@0.1.6` pinned under `@altimateai/dbt-integration@0.2.9` is untouched — that's a separate package's dependency graph and out of scope for this bump.

### Type of change

- [x] Chore (maintenance: dependency bump, tooling, or non-functional change)

### Issue for this PR

Closes #716

### How did you verify your code works?

- `bun turbo typecheck` — green across all 7 packages
- `bun test test/altimate/altimate-core-native.test.ts test/altimate/altimate-core-e2e.test.ts` — **126 pass, 0 fail** (340 expect() calls)
- `bun install` ran cleanly; `bun.lock` regenerated with matching `0.3.0` optional platform binaries (darwin-arm64, darwin-x64, linux-arm64-gnu, linux-x64-gnu, win32-x64-msvc)
- Ran fast local CI — only unrelated SSE flake (passes in isolation, pre-existing resource-contention flake unrelated to this bump). Marker guard green (no upstream-shared files modified).

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `@altimateai/altimate-core` from 0.2.6 to 0.3.0 in `packages/opencode`, regenerating `bun.lock` with matching optional platform binaries. No source code changes.

<sup>Written for commit 5f57f378ca53d2548a06fd1533ef64bda4b8e56e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependency to version 0.3.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->