### PR TITLE
feat: add trace-manager package — PII review, insights, issues, analytics dashboard

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -87,6 +87,7 @@
         "@ai-sdk/xai": "2.0.51",
         "@altimateai/altimate-core": "0.3.0",
         "@altimateai/drivers": "workspace:*",
+        "@altimateai/trace-manager": "workspace:*",
         "@aws-sdk/credential-providers": "3.993.0",
         "@clack/prompts": "1.0.0-alpha.1",
         "@gitlab/gitlab-ai-provider": "3.6.0",
@@ -216,6 +217,21 @@
         "@types/node": "catalog:",
         "@typescript/native-preview": "catalog:",
         "typescript": "catalog:",
+      },
+    },
+    "packages/trace-manager": {
+      "name": "@altimateai/trace-manager",
+      "version": "0.1.0",
+      "dependencies": {
+        "@opencode-ai/plugin": "workspace:*",
+        "duckdb": "^1.3.0",
+        "hono": "^4.7.10",
+        "zod": "^3.24.4",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.2.14",
+        "@types/yargs": "^17.0.33",
+        "typescript": "^5.8.3",
       },
     },
     "packages/util": {
@@ -367,6 +383,8 @@
     "@altimateai/dbt-tools": ["@altimateai/dbt-tools@workspace:packages/dbt-tools"],
 
     "@altimateai/drivers": ["@altimateai/drivers@workspace:packages/drivers"],
+
+    "@altimateai/trace-manager": ["@altimateai/trace-manager@workspace:packages/trace-manager"],
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
 
@@ -2549,6 +2567,12 @@
     "@altimateai/dbt-integration/@altimateai/altimate-core": ["@altimateai/altimate-core@0.1.6", "", { "optionalDependencies": { "@altimateai/altimate-core-darwin-arm64": "0.1.6", "@altimateai/altimate-core-darwin-x64": "0.1.6", "@altimateai/altimate-core-linux-arm64-gnu": "0.1.6", "@altimateai/altimate-core-linux-x64-gnu": "0.1.6", "@altimateai/altimate-core-win32-x64-msvc": "0.1.6" } }, "sha512-Kl0hjT88Q56AdGxKJyCcPElxcpZYDYmLhDHK7ZeZIn2oVaXyynExLcIHn+HktUe9USuWtba3tZA/52jJsMyrGg=="],
 
     "@altimateai/dbt-integration/yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+
+    "@altimateai/trace-manager/hono": ["hono@4.12.8", "", {}, "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A=="],
+
+    "@altimateai/trace-manager/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@altimateai/trace-manager/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@aws-crypto/crc32/@aws-sdk/types": ["@aws-sdk/types@3.930.0", "", { "dependencies": { "@smithy/types": "^4.9.0", "tslib": "^2.6.2" } }, "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A=="],
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
       "packages/util",
       "packages/sdk/js",
       "packages/dbt-tools",
-      "packages/drivers"
+      "packages/drivers",
+      "packages/trace-manager"
     ],
     "catalog": {
       "@types/bun": "1.3.9",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -92,6 +92,7 @@
     "@openauthjs/openauth": "catalog:",
     "@opencode-ai/plugin": "workspace:*",
     "@opencode-ai/script": "workspace:*",
+    "@altimateai/trace-manager": "workspace:*",
     "@opencode-ai/sdk": "workspace:*",
     "@opencode-ai/util": "workspace:*",
     "@openrouter/ai-sdk-provider": "1.5.4",

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -42,6 +42,9 @@ import { SkillCommand } from "./cli/cmd/skill"
 // altimate_change start — check: deterministic SQL check command
 import { CheckCommand } from "./cli/cmd/check"
 // altimate_change end
+// altimate_change start — trace-manager: PII review, publish, analytics dashboard
+import { TraceManageCommand } from "@altimateai/trace-manager/src/cli"
+// altimate_change end
 import path from "path"
 import { Global } from "./global"
 import { JsonMigration } from "./storage/json-migration"
@@ -216,6 +219,9 @@ let cli = yargs(hideBin(process.argv))
   // altimate_change end
   // altimate_change start — check: register deterministic SQL check command
   .command(CheckCommand)
+// altimate_change end
+// altimate_change start — trace-manager
+  .command(TraceManageCommand)
 // altimate_change end
 
 if (Installation.isLocal()) {

--- a/packages/opencode/src/server/routes/trace-manager.ts
+++ b/packages/opencode/src/server/routes/trace-manager.ts
@@ -1,0 +1,37 @@
+import { Hono } from "hono"
+
+export function TraceManagerRoutes() {
+  const app = new Hono()
+
+  let cachedApp: Awaited<ReturnType<typeof import("@altimateai/trace-manager/src/web/server").createApp>> | null = null
+
+  async function getApp() {
+    if (cachedApp) return cachedApp
+
+    const { createApp } = await import("@altimateai/trace-manager/src/web/server")
+
+    let lake: import("@altimateai/trace-manager/src/lake/lake-manager").LakeManager | undefined
+    try {
+      const { LakeManager } = await import("@altimateai/trace-manager/src/lake/lake-manager")
+      const { loadOrCreateConfig } = await import("@altimateai/trace-manager/src/consent/consent-store")
+      const { loadAllTraces } = await import("@altimateai/trace-manager/src/traces")
+      const config = await loadOrCreateConfig()
+      lake = await LakeManager.create(config.lake.path)
+      const traces = await loadAllTraces()
+      for (const t of traces) await lake.ingest(t)
+    } catch {}
+
+    cachedApp = await createApp({ lake })
+    return cachedApp
+  }
+
+  app.all("/*", async (c) => {
+    const traceApp = await getApp()
+    const url = new URL(c.req.url)
+    url.pathname = url.pathname.replace(/^\/trace-manager/, "") || "/"
+    const rewritten = new Request(url.toString(), c.req.raw)
+    return traceApp.fetch(rewritten)
+  })
+
+  return app
+}

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -43,6 +43,7 @@ import { Filesystem } from "@/util/filesystem"
 import { QuestionRoutes } from "./routes/question"
 import { PermissionRoutes } from "./routes/permission"
 import { GlobalRoutes } from "./routes/global"
+import { TraceManagerRoutes } from "./routes/trace-manager"
 import { MDNS } from "./mdns"
 import { lazy } from "@/util/lazy"
 
@@ -560,6 +561,7 @@ export namespace Server {
           })
         },
       )
+      .route("/trace-manager", TraceManagerRoutes())
       .all("/*", async (c) => {
         const path = c.req.path
 

--- a/packages/trace-manager/bun.lock
+++ b/packages/trace-manager/bun.lock
@@ -1,0 +1,15 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@altimateai/trace-manager",
+      "dependencies": {
+        "hono": "^4.7.10",
+      },
+    },
+  },
+  "packages": {
+    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
+  }
+}

--- a/packages/trace-manager/docs/architecture.mmd
+++ b/packages/trace-manager/docs/architecture.mmd
@@ -1,0 +1,11 @@
+flowchart LR
+    A["TraceFile JSON"] --> B["PII Engine"]
+    B --> C["Publisher\n(HTTP)"]
+    B --> D["DuckDB\nData Lake"]
+    D --> E["Analytics"]
+    E --> F["Web UI\n(React + Hono)"]
+    B --> F
+    F -.->|"--share"| G["ngrok"]
+
+    style A fill:#f9f,stroke:#333
+    style F fill:#bbf,stroke:#333

--- a/packages/trace-manager/package.json
+++ b/packages/trace-manager/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@altimateai/trace-manager",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "dashboard": "bun run src/dashboard.ts",
+    "dev": "bun run --watch src/dashboard.ts",
+    "build:ui": "cd ui && bun run build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@opencode-ai/plugin": "workspace:*",
+    "hono": "^4.7.10",
+    "zod": "^3.24.4",
+    "duckdb": "^1.3.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3",
+    "@types/bun": "^1.2.14",
+    "@types/yargs": "^17.0.33"
+  }
+}

--- a/packages/trace-manager/src/analytics/conversations.ts
+++ b/packages/trace-manager/src/analytics/conversations.ts
@@ -1,0 +1,109 @@
+import type { LakeManager } from "../lake/lake-manager"
+
+export interface ConversationAnalytics {
+  totalSessions: number
+  completedSessions: number
+  erroredSessions: number
+  successRate: number
+  avgDuration: number
+  avgToolCalls: number
+  avgGenerations: number
+  avgTokens: number
+  p50Duration: number
+  p90Duration: number
+  p50Latency: number
+  p90Latency: number
+  p99Latency: number
+  topTools: Array<{ name: string; count: number; totalDuration: number }>
+  topChains: Array<{ pattern: string; count: number }>
+  turnDistribution: Record<string, number>
+  doomLoops: number
+  toolErrors: number
+}
+
+export async function getConversationAnalytics(lake: LakeManager): Promise<ConversationAnalytics> {
+  const [totals] = await lake.query<{
+    total: number; completed: number; errored: number
+    avg_dur: number; avg_tools: number; avg_gens: number; avg_tokens: number
+    p50_dur: number; p90_dur: number
+  }>(`
+    SELECT
+      COUNT(*) as total,
+      COUNT(*) FILTER (WHERE status = 'completed') as completed,
+      COUNT(*) FILTER (WHERE status IN ('error', 'crashed')) as errored,
+      AVG(duration_ms) as avg_dur,
+      AVG(total_tool_calls) as avg_tools,
+      AVG(total_generations) as avg_gens,
+      AVG(total_tokens) as avg_tokens,
+      PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY duration_ms) as p50_dur,
+      PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY duration_ms) as p90_dur
+    FROM sessions
+  `)
+
+  const latency = await lake.query<{ p50: number; p90: number; p99: number }>(`
+    SELECT
+      COALESCE(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY duration_ms), 0) as p50,
+      COALESCE(PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY duration_ms), 0) as p90,
+      COALESCE(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY duration_ms), 0) as p99
+    FROM spans WHERE kind = 'generation' AND duration_ms IS NOT NULL AND duration_ms > 0
+  `)
+
+  const toolRows = await lake.query<{ name: string; cnt: number; dur: number }>(`
+    SELECT name, COUNT(*) as cnt, COALESCE(SUM(duration_ms), 0) as dur
+    FROM spans WHERE kind = 'tool'
+    GROUP BY name ORDER BY cnt DESC LIMIT 10
+  `)
+
+  const chainRows = await lake.query<{ chain: string; cnt: number }>(`
+    WITH ordered AS (
+      SELECT session_id, name, ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY started_at) as rn
+      FROM spans WHERE kind = 'tool' AND started_at IS NOT NULL
+    )
+    SELECT a.name || '→' || b.name as chain, COUNT(*) as cnt
+    FROM ordered a JOIN ordered b ON a.session_id = b.session_id AND b.rn = a.rn + 1
+    GROUP BY chain ORDER BY cnt DESC LIMIT 8
+  `)
+
+  const turnBuckets = await lake.query<{ bucket: string; cnt: number }>(`
+    SELECT
+      CASE
+        WHEN total_generations <= 3 THEN '1-3'
+        WHEN total_generations <= 8 THEN '4-8'
+        WHEN total_generations <= 15 THEN '9-15'
+        ELSE '16+'
+      END as bucket,
+      COUNT(*) as cnt
+    FROM sessions GROUP BY bucket
+  `)
+
+  const [loopCount] = await lake.query<{ n: number }>(
+    "SELECT COUNT(*) as n FROM sessions WHERE loops != '[]' AND loops IS NOT NULL"
+  )
+  const [errCount] = await lake.query<{ n: number }>(
+    "SELECT COUNT(*) as n FROM spans WHERE kind = 'tool' AND status = 'error'"
+  )
+
+  const dist: Record<string, number> = { "1-3": 0, "4-8": 0, "9-15": 0, "16+": 0 }
+  for (const row of turnBuckets) dist[row.bucket] = row.cnt
+
+  return {
+    totalSessions: totals?.total ?? 0,
+    completedSessions: totals?.completed ?? 0,
+    erroredSessions: totals?.errored ?? 0,
+    successRate: totals?.total ? (totals.completed ?? 0) / totals.total : 0,
+    avgDuration: totals?.avg_dur ?? 0,
+    avgToolCalls: totals?.avg_tools ?? 0,
+    avgGenerations: totals?.avg_gens ?? 0,
+    avgTokens: totals?.avg_tokens ?? 0,
+    p50Duration: totals?.p50_dur ?? 0,
+    p90Duration: totals?.p90_dur ?? 0,
+    p50Latency: latency[0]?.p50 ?? 0,
+    p90Latency: latency[0]?.p90 ?? 0,
+    p99Latency: latency[0]?.p99 ?? 0,
+    topTools: toolRows.map((r) => ({ name: r.name, count: r.cnt, totalDuration: r.dur })),
+    topChains: chainRows.map((r) => ({ pattern: r.chain, count: r.cnt })),
+    turnDistribution: dist,
+    doomLoops: loopCount?.n ?? 0,
+    toolErrors: errCount?.n ?? 0,
+  }
+}

--- a/packages/trace-manager/src/analytics/insights.ts
+++ b/packages/trace-manager/src/analytics/insights.ts
@@ -1,0 +1,193 @@
+import type { TraceFile } from "../types"
+
+export type InsightSeverity = "critical" | "warning" | "info" | "positive"
+
+export interface Insight {
+  id: string
+  severity: InsightSeverity
+  category: string
+  title: string
+  description: string
+  evidence: string[]
+  recommendation: string
+  affectedSessions: string[]
+  metric?: { label: string; value: string; trend?: "up" | "down" | "flat" }
+}
+
+export function generateInsights(traces: TraceFile[]): Insight[] {
+  if (!traces.length) return []
+  const insights: Insight[] = []
+  let idSeq = 0
+  const mkId = () => `insight-${++idSeq}`
+
+  // ── Cost insights ──
+  const totalCost = traces.reduce((s, t) => s + t.summary.totalCost, 0)
+  const costByModel: Record<string, { cost: number; sessions: string[] }> = {}
+  for (const t of traces) {
+    const m = t.metadata.model ?? "unknown"
+    if (!costByModel[m]) costByModel[m] = { cost: 0, sessions: [] }
+    costByModel[m].cost += t.summary.totalCost
+    costByModel[m].sessions.push(t.sessionId)
+  }
+  const modelEntries = Object.entries(costByModel).sort((a, b) => b[1].cost - a[1].cost)
+  if (modelEntries.length > 1 && modelEntries[0][1].cost > totalCost * 0.8) {
+    insights.push({
+      id: mkId(), severity: "warning", category: "Cost",
+      title: `${modelEntries[0][0].split("/").pop()} accounts for ${((modelEntries[0][1].cost / (totalCost || 1)) * 100).toFixed(0)}% of all cost`,
+      description: "A single model is dominating spend. Cheaper models may handle simpler tasks.",
+      evidence: [`$${modelEntries[0][1].cost.toFixed(4)} out of $${totalCost.toFixed(4)} total`],
+      recommendation: "Route simple tasks (file reads, small edits) to cheaper models. Reserve expensive models for complex reasoning.",
+      affectedSessions: modelEntries[0][1].sessions,
+      metric: { label: "Model share", value: `${((modelEntries[0][1].cost / (totalCost || 1)) * 100).toFixed(0)}%`, trend: "up" },
+    })
+  }
+
+  // ── Token waste: high input with low output ──
+  const highInputLowOutput = traces.filter(
+    (t) => t.summary.tokens.input > 50000 && t.summary.tokens.output < 500,
+  )
+  if (highInputLowOutput.length >= 2) {
+    insights.push({
+      id: mkId(), severity: "warning", category: "Efficiency",
+      title: `${highInputLowOutput.length} sessions consumed 50K+ input tokens but produced <500 output tokens`,
+      description: "These sessions sent large context to the model but got minimal output — likely context is being wasted.",
+      evidence: highInputLowOutput.map((t) => `"${t.metadata.title ?? t.sessionId}": ${t.summary.tokens.input.toLocaleString()} in → ${t.summary.tokens.output.toLocaleString()} out`),
+      recommendation: "Check if full file contents are being sent when only specific sections are needed. Consider using grep/search before read.",
+      affectedSessions: highInputLowOutput.map((t) => t.sessionId),
+      metric: { label: "Wasted context", value: `${highInputLowOutput.length} sessions` },
+    })
+  }
+
+  // ── Doom loops ──
+  const withLoops = traces.filter((t) => t.summary.loops && t.summary.loops.length > 0)
+  if (withLoops.length > 0) {
+    const allLoops = withLoops.flatMap((t) => t.summary.loops ?? [])
+    const loopTools: Record<string, number> = {}
+    for (const l of allLoops) loopTools[l.tool] = (loopTools[l.tool] ?? 0) + l.count
+    const topLoopTool = Object.entries(loopTools).sort((a, b) => b[1] - a[1])[0]
+
+    insights.push({
+      id: mkId(), severity: "critical", category: "Reliability",
+      title: `${withLoops.length} session(s) entered doom loops — ${topLoopTool?.[0] ?? "unknown"} repeated ${topLoopTool?.[1] ?? 0} times`,
+      description: "The agent got stuck calling the same tool with the same input repeatedly. This wastes tokens and time.",
+      evidence: withLoops.map((t) => `"${t.metadata.title ?? t.sessionId}": ${(t.summary.loops ?? []).map((l) => `${l.tool}(${l.count}x)`).join(", ")}`),
+      recommendation: "Add loop detection guardrails. If a tool fails 3+ times with the same input, break the loop and try a different approach.",
+      affectedSessions: withLoops.map((t) => t.sessionId),
+      metric: { label: "Loop rate", value: `${((withLoops.length / traces.length) * 100).toFixed(0)}%`, trend: "up" },
+    })
+  }
+
+  // ── Tool errors ──
+  const toolErrors: Record<string, { count: number; sessions: Set<string> }> = {}
+  for (const t of traces) {
+    for (const s of t.spans) {
+      if (s.kind === "tool" && s.status === "error") {
+        if (!toolErrors[s.name]) toolErrors[s.name] = { count: 0, sessions: new Set() }
+        toolErrors[s.name].count++
+        toolErrors[s.name].sessions.add(t.sessionId)
+      }
+    }
+  }
+  const errorEntries = Object.entries(toolErrors).sort((a, b) => b[1].count - a[1].count)
+  if (errorEntries.length > 0) {
+    const [toolName, data] = errorEntries[0]
+    insights.push({
+      id: mkId(), severity: data.count >= 5 ? "critical" : "warning", category: "Reliability",
+      title: `"${toolName}" failed ${data.count} times across ${data.sessions.size} session(s)`,
+      description: `The most failing tool is "${toolName}". Frequent tool failures degrade user experience and waste tokens on retries.`,
+      evidence: errorEntries.slice(0, 5).map(([n, d]) => `${n}: ${d.count} failures in ${d.sessions.size} sessions`),
+      recommendation: `Investigate why "${toolName}" fails. Common causes: permission denied, file not found, syntax errors in generated code.`,
+      affectedSessions: [...data.sessions],
+      metric: { label: "Top failing tool", value: `${toolName} (${data.count}x)` },
+    })
+  }
+
+  // ── Long sessions ──
+  const longSessions = traces.filter((t) => t.summary.duration > 600_000) // >10 min
+  if (longSessions.length > 0) {
+    const avgDur = traces.reduce((s, t) => s + t.summary.duration, 0) / traces.length
+    const longAvgDur = longSessions.reduce((s, t) => s + t.summary.duration, 0) / longSessions.length
+    insights.push({
+      id: mkId(), severity: longSessions.length > traces.length * 0.3 ? "warning" : "info", category: "Performance",
+      title: `${longSessions.length} session(s) exceeded 10 minutes (avg ${fmtDur(longAvgDur)})`,
+      description: `These sessions are significantly longer than the overall average of ${fmtDur(avgDur)}. Long sessions may indicate complex tasks or inefficient tool usage.`,
+      evidence: longSessions.slice(0, 5).map((t) => `"${t.metadata.title ?? t.sessionId}": ${fmtDur(t.summary.duration)}, ${t.summary.totalToolCalls} tool calls`),
+      recommendation: "Break complex tasks into smaller, focused sessions. Check if the agent is exploring unnecessary paths.",
+      affectedSessions: longSessions.map((t) => t.sessionId),
+      metric: { label: "Long sessions", value: `${longSessions.length}/${traces.length}` },
+    })
+  }
+
+  // ── Tool usage imbalance ──
+  const toolCounts: Record<string, number> = {}
+  for (const t of traces) for (const tt of t.summary.topTools ?? []) toolCounts[tt.name] = (toolCounts[tt.name] ?? 0) + tt.count
+  const totalToolCalls = Object.values(toolCounts).reduce((a, b) => a + b, 0)
+  const sortedTools = Object.entries(toolCounts).sort((a, b) => b[1] - a[1])
+  if (sortedTools.length > 3 && sortedTools[0][1] > totalToolCalls * 0.5) {
+    insights.push({
+      id: mkId(), severity: "info", category: "Patterns",
+      title: `"${sortedTools[0][0]}" dominates tool usage at ${((sortedTools[0][1] / totalToolCalls) * 100).toFixed(0)}% of all calls`,
+      description: "A single tool accounts for most activity. This might be normal (read-heavy workflows) or might indicate the agent isn't using specialized tools.",
+      evidence: sortedTools.slice(0, 5).map(([n, c]) => `${n}: ${c} calls (${((c / totalToolCalls) * 100).toFixed(0)}%)`),
+      recommendation: `If "${sortedTools[0][0]}" is "read" or "bash", check if grep/glob could replace some usage. If "edit", verify edits are landing on first try.`,
+      affectedSessions: [],
+      metric: { label: "Dominant tool", value: `${sortedTools[0][0]} (${((sortedTools[0][1] / totalToolCalls) * 100).toFixed(0)}%)` },
+    })
+  }
+
+  // ── Successful patterns ──
+  const completedSessions = traces.filter((t) => t.summary.status === "completed")
+  const successRate = traces.length ? completedSessions.length / traces.length : 0
+  if (successRate >= 0.9 && traces.length >= 5) {
+    insights.push({
+      id: mkId(), severity: "positive", category: "Health",
+      title: `${(successRate * 100).toFixed(0)}% success rate across ${traces.length} sessions`,
+      description: "The agent is completing tasks reliably. This is a healthy signal.",
+      evidence: [`${completedSessions.length} completed, ${traces.length - completedSessions.length} failed/errored`],
+      recommendation: "Keep monitoring. Consider increasing task complexity or automating more workflows.",
+      affectedSessions: [],
+      metric: { label: "Success rate", value: `${(successRate * 100).toFixed(0)}%`, trend: successRate > 0.95 ? "up" : "flat" },
+    })
+  }
+
+  // ── Cache utilization ──
+  const cacheUsers = traces.filter((t) => t.summary.tokens.cacheRead > 0)
+  const noCacheUsers = traces.filter((t) => t.summary.tokens.cacheRead === 0 && t.summary.totalTokens > 10000)
+  if (noCacheUsers.length > traces.length * 0.5 && traces.length >= 3) {
+    insights.push({
+      id: mkId(), severity: "info", category: "Efficiency",
+      title: `${noCacheUsers.length} of ${traces.length} sessions used zero prompt cache`,
+      description: "Prompt caching can significantly reduce costs for repeated context. Many sessions are not benefiting from caching.",
+      evidence: [`Sessions with cache: ${cacheUsers.length}`, `Sessions without: ${noCacheUsers.length}`, `Potential savings: ${((noCacheUsers.reduce((s, t) => s + t.summary.tokens.input, 0)) * 0.5 / 1_000_000 * 3).toFixed(2)} USD (estimate)`],
+      recommendation: "Enable prompt caching on your provider. Structure system prompts to maximize cache hits.",
+      affectedSessions: noCacheUsers.map((t) => t.sessionId),
+    })
+  }
+
+  // ── Agent distribution ──
+  const agentCounts: Record<string, number> = {}
+  for (const t of traces) agentCounts[t.metadata.agent ?? "default"] = (agentCounts[t.metadata.agent ?? "default"] ?? 0) + 1
+  if (Object.keys(agentCounts).length > 1) {
+    const sorted = Object.entries(agentCounts).sort((a, b) => b[1] - a[1])
+    insights.push({
+      id: mkId(), severity: "info", category: "Usage",
+      title: `${Object.keys(agentCounts).length} different agent types in use`,
+      description: "Multiple agent types are being used, which is healthy for task specialization.",
+      evidence: sorted.map(([a, c]) => `${a}: ${c} sessions (${((c / traces.length) * 100).toFixed(0)}%)`),
+      recommendation: "Ensure the right agent type is being used for each task. Builder for implementation, explorer for research, general for mixed tasks.",
+      affectedSessions: [],
+    })
+  }
+
+  return insights.sort((a, b) => {
+    const order: Record<InsightSeverity, number> = { critical: 0, warning: 1, info: 2, positive: 3 }
+    return order[a.severity] - order[b.severity]
+  })
+}
+
+function fmtDur(ms: number): string {
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
+  const m = Math.floor(ms / 60000)
+  const s = Math.floor((ms % 60000) / 1000)
+  return `${m}m${s ? s + "s" : ""}`
+}

--- a/packages/trace-manager/src/analytics/issues.ts
+++ b/packages/trace-manager/src/analytics/issues.ts
@@ -1,0 +1,275 @@
+import type { TraceFile } from "../types"
+
+export type IssueSeverity = "critical" | "high" | "medium" | "low"
+export type IssueTopic =
+  | "tool_failure" | "doom_loop" | "timeout" | "token_waste"
+  | "permission_denied" | "model_error" | "long_session"
+  | "empty_response" | "repeated_edit" | "crash"
+
+export interface DetectedIssue {
+  id: string
+  topic: IssueTopic
+  severity: IssueSeverity
+  title: string
+  description: string
+  pattern: string
+  occurrences: Array<{
+    sessionId: string
+    sessionTitle: string
+    userId: string
+    timestamp: string
+    spanId?: string
+    detail: string
+  }>
+  frequency: number
+  firstSeen: string
+  lastSeen: string
+  affectedUsers: string[]
+  suggestedFix: string
+}
+
+const TOPIC_LABELS: Record<IssueTopic, string> = {
+  tool_failure: "Tool Failure",
+  doom_loop: "Doom Loop",
+  timeout: "Timeout",
+  token_waste: "Token Waste",
+  permission_denied: "Permission Denied",
+  model_error: "Model Error",
+  long_session: "Long Session",
+  empty_response: "Empty Response",
+  repeated_edit: "Repeated Edit",
+  crash: "Crash",
+}
+
+const TOPIC_SEVERITY_BASE: Record<IssueTopic, IssueSeverity> = {
+  crash: "critical",
+  doom_loop: "critical",
+  model_error: "high",
+  tool_failure: "high",
+  permission_denied: "medium",
+  timeout: "medium",
+  token_waste: "medium",
+  empty_response: "low",
+  long_session: "low",
+  repeated_edit: "low",
+}
+
+export function detectIssues(traces: TraceFile[]): DetectedIssue[] {
+  const issueMap = new Map<string, DetectedIssue>()
+  let idSeq = 0
+
+  function addOccurrence(
+    patternKey: string,
+    topic: IssueTopic,
+    title: string,
+    description: string,
+    suggestedFix: string,
+    trace: TraceFile,
+    detail: string,
+    spanId?: string,
+  ) {
+    const userId = trace.metadata.userId ?? trace.metadata.agent ?? trace.metadata.providerId ?? "unknown"
+    const occurrence = {
+      sessionId: trace.sessionId,
+      sessionTitle: trace.metadata.title ?? trace.sessionId,
+      userId,
+      timestamp: trace.startedAt,
+      spanId,
+      detail,
+    }
+
+    const existing = issueMap.get(patternKey)
+    if (existing) {
+      existing.occurrences.push(occurrence)
+      existing.frequency++
+      if (trace.startedAt < existing.firstSeen) existing.firstSeen = trace.startedAt
+      if (trace.startedAt > existing.lastSeen) existing.lastSeen = trace.startedAt
+      if (!existing.affectedUsers.includes(userId)) existing.affectedUsers.push(userId)
+      existing.severity = escalateSeverity(existing.severity, existing.frequency)
+    } else {
+      issueMap.set(patternKey, {
+        id: `issue-${++idSeq}`,
+        topic,
+        severity: TOPIC_SEVERITY_BASE[topic],
+        title,
+        description,
+        pattern: patternKey,
+        occurrences: [occurrence],
+        frequency: 1,
+        firstSeen: trace.startedAt,
+        lastSeen: trace.startedAt,
+        affectedUsers: [userId],
+        suggestedFix,
+      })
+    }
+  }
+
+  for (const trace of traces) {
+    // Crashes
+    if (trace.summary.status === "crashed") {
+      addOccurrence(
+        "crash:session",
+        "crash",
+        "Session crashed",
+        "The agent session terminated abnormally without completing.",
+        "Check logs for unhandled exceptions. Ensure MCP servers are stable and responsive.",
+        trace,
+        trace.summary.error ?? "Abnormal termination",
+      )
+    }
+
+    // Doom loops
+    for (const loop of trace.summary.loops ?? []) {
+      addOccurrence(
+        `doom_loop:${loop.tool}`,
+        "doom_loop",
+        `Doom loop on "${loop.tool}"`,
+        `The agent called "${loop.tool}" ${loop.count}+ times with the same input, unable to make progress.`,
+        `Add tool-specific error handling. If "${loop.tool}" fails repeatedly, the agent should try an alternative approach or ask the user.`,
+        trace,
+        `${loop.tool} repeated ${loop.count} times: ${loop.description ?? ""}`,
+      )
+    }
+
+    // Tool failures
+    const failedTools: Record<string, number> = {}
+    for (const span of trace.spans) {
+      if (span.kind === "tool" && span.status === "error") {
+        failedTools[span.name] = (failedTools[span.name] ?? 0) + 1
+
+        const rawOut = typeof span.output === "string" ? span.output : span.output ? JSON.stringify(span.output) : ""
+        const errorPreview = rawOut.slice(0, 200)
+        addOccurrence(
+          `tool_failure:${span.name}`,
+          "tool_failure",
+          `"${span.name}" tool failures`,
+          `The "${span.name}" tool is failing during execution. Each failure wastes a generation round-trip.`,
+          `Review common error patterns for "${span.name}". For bash: check exit codes. For edit: verify file paths exist. For read: check permissions.`,
+          trace,
+          errorPreview || `${span.name} returned error status`,
+          span.spanId,
+        )
+      }
+    }
+
+    // Empty/minimal generation responses
+    for (const span of trace.spans) {
+      if (span.kind === "generation" && span.tokens) {
+        const outputTokens = span.tokens.output ?? 0
+        const inputTokens = span.tokens.input ?? 0
+        if (inputTokens > 10000 && outputTokens < 10) {
+          addOccurrence(
+            "empty_response:generation",
+            "empty_response",
+            "Model returned near-empty response to large context",
+            "The model received substantial context but produced almost no output, suggesting confusion or context overflow.",
+            "Reduce context size. Use targeted file reads instead of full file dumps. Check if the prompt is clear.",
+            trace,
+            `${inputTokens.toLocaleString()} input tokens → ${outputTokens} output tokens`,
+            span.spanId,
+          )
+        }
+      }
+    }
+
+    // Token waste (>100K tokens, <5 tool calls)
+    if (trace.summary.totalTokens > 100_000 && trace.summary.totalToolCalls < 5) {
+      addOccurrence(
+        "token_waste:high_tokens_low_action",
+        "token_waste",
+        "High token usage with minimal tool activity",
+        "Sessions consuming >100K tokens with fewer than 5 tool calls suggest the model is reasoning extensively without acting.",
+        "Encourage the agent to act earlier. Use prompts that emphasize 'do, then verify' over 'plan extensively, then do'.",
+        trace,
+        `${trace.summary.totalTokens.toLocaleString()} tokens, ${trace.summary.totalToolCalls} tool calls`,
+      )
+    }
+
+    // Long sessions (>15 min)
+    if (trace.summary.duration > 900_000) {
+      addOccurrence(
+        "long_session:over_15min",
+        "long_session",
+        "Sessions exceeding 15 minutes",
+        "Very long sessions may indicate the agent is stuck or the task is too broad for a single session.",
+        "Break large tasks into smaller subtasks. Use session forking for parallel work streams.",
+        trace,
+        `Duration: ${Math.floor(trace.summary.duration / 60000)}m, ${trace.summary.totalToolCalls} tool calls`,
+      )
+    }
+
+    // Repeated edits to same file
+    const editTargets: Record<string, number> = {}
+    for (const span of trace.spans) {
+      if (span.kind === "tool" && (span.name === "edit" || span.name === "write")) {
+        const file = extractFilePath(span.input ?? "")
+        if (file) editTargets[file] = (editTargets[file] ?? 0) + 1
+      }
+    }
+    for (const [file, count] of Object.entries(editTargets)) {
+      if (count >= 4) {
+        addOccurrence(
+          `repeated_edit:${file}`,
+          "repeated_edit",
+          `Repeated edits to "${file.split("/").pop()}"`,
+          `The same file was edited ${count} times in one session, suggesting the agent is struggling to get it right.`,
+          "Check if the agent is getting clear error feedback. Lint/type-check feedback after edits can reduce churn.",
+          trace,
+          `${file} edited ${count} times`,
+        )
+      }
+    }
+  }
+
+  const issues = [...issueMap.values()]
+  issues.sort((a, b) => {
+    const sev: Record<IssueSeverity, number> = { critical: 0, high: 1, medium: 2, low: 3 }
+    if (sev[a.severity] !== sev[b.severity]) return sev[a.severity] - sev[b.severity]
+    return b.frequency - a.frequency
+  })
+
+  return issues
+}
+
+function escalateSeverity(current: IssueSeverity, frequency: number): IssueSeverity {
+  if (frequency >= 10 && current !== "critical") return "critical"
+  if (frequency >= 5 && (current === "medium" || current === "low")) return "high"
+  if (frequency >= 3 && current === "low") return "medium"
+  return current
+}
+
+function extractFilePath(input: unknown): string | null {
+  const str = typeof input === "string" ? input : typeof input === "object" && input ? JSON.stringify(input) : ""
+  const match = str.match(/(?:\/[\w./-]+\.[\w]+)/)
+  return match?.[0] ?? null
+}
+
+export function classifySessionTopic(trace: TraceFile): string[] {
+  const topics: string[] = []
+  const text = [
+    trace.metadata.title,
+    trace.summary.narrative,
+    ...(trace.spans.slice(0, 3).map((s) => typeof s.input === "string" ? s.input : "").filter(Boolean)),
+  ].join(" ").toLowerCase()
+
+  const topicKeywords: Record<string, string[]> = {
+    "Bug Fix": ["fix", "bug", "error", "issue", "broken", "crash", "fail", "patch"],
+    "Feature": ["add", "implement", "create", "build", "new feature", "introduce"],
+    "Refactor": ["refactor", "restructure", "clean up", "reorganize", "simplify", "deduplicate"],
+    "Testing": ["test", "spec", "coverage", "assert", "expect", "mock", "fixture"],
+    "Documentation": ["doc", "readme", "comment", "explain", "guide", "tutorial"],
+    "Configuration": ["config", "setup", "install", "deploy", "env", "yaml", "toml"],
+    "Database": ["sql", "query", "migration", "schema", "table", "dbt", "warehouse"],
+    "DevOps": ["docker", "ci", "pipeline", "deploy", "kubernetes", "helm"],
+    "Review": ["review", "analyze", "audit", "check", "inspect", "explore"],
+  }
+
+  for (const [topic, keywords] of Object.entries(topicKeywords)) {
+    if (keywords.some((kw) => text.includes(kw))) topics.push(topic)
+  }
+
+  if (!topics.length) topics.push("General")
+  return topics
+}
+
+export { TOPIC_LABELS as IssueTopicLabels }

--- a/packages/trace-manager/src/analytics/users.ts
+++ b/packages/trace-manager/src/analytics/users.ts
@@ -1,0 +1,84 @@
+import type { LakeManager } from "../lake/lake-manager"
+
+export interface UserStats {
+  userId: string
+  sessions: number
+  tokens: number
+  cost: number
+  duration: number
+  completed: number
+  successRate: number
+  topTool: string
+  models: Record<string, number>
+}
+
+export interface UserAnalytics {
+  users: UserStats[]
+  heatmap: number[][]
+}
+
+export async function getUserAnalytics(lake: LakeManager): Promise<UserAnalytics> {
+  const userRows = await lake.query<{
+    user_id: string; sessions: number; tokens: number; cost: number
+    duration: number; completed: number
+  }>(`
+    SELECT
+      COALESCE(user_id, COALESCE(agent, COALESCE(provider_id, 'unknown'))) as user_id,
+      COUNT(*) as sessions,
+      COALESCE(SUM(total_tokens), 0) as tokens,
+      COALESCE(SUM(total_cost), 0) as cost,
+      COALESCE(SUM(duration_ms), 0) as duration,
+      COUNT(*) FILTER (WHERE status = 'completed') as completed
+    FROM sessions
+    GROUP BY user_id
+    ORDER BY sessions DESC
+  `)
+
+  const users: UserStats[] = []
+  for (const row of userRows) {
+    const topToolRows = await lake.query<{ name: string; cnt: number }>(`
+      SELECT s.name, COUNT(*) as cnt
+      FROM spans s
+      JOIN sessions sess ON s.session_id = sess.session_id
+      WHERE s.kind = 'tool'
+        AND COALESCE(sess.user_id, COALESCE(sess.agent, COALESCE(sess.provider_id, 'unknown'))) = '${row.user_id.replace(/'/g, "''")}'
+      GROUP BY s.name ORDER BY cnt DESC LIMIT 1
+    `)
+
+    const modelRows = await lake.query<{ model: string; cnt: number }>(`
+      SELECT COALESCE(model, 'unknown') as model, COUNT(*) as cnt
+      FROM sessions
+      WHERE COALESCE(user_id, COALESCE(agent, COALESCE(provider_id, 'unknown'))) = '${row.user_id.replace(/'/g, "''")}'
+      GROUP BY model
+    `)
+
+    const models: Record<string, number> = {}
+    for (const m of modelRows) models[m.model] = m.cnt
+
+    users.push({
+      userId: row.user_id,
+      sessions: row.sessions,
+      tokens: row.tokens,
+      cost: row.cost,
+      duration: row.duration,
+      completed: row.completed,
+      successRate: row.sessions ? row.completed / row.sessions : 0,
+      topTool: topToolRows[0]?.name ?? "-",
+      models,
+    })
+  }
+
+  const heatmapRows = await lake.query<{ dow: number; hour: number; cnt: number }>(`
+    SELECT DAYOFWEEK(started_at) as dow, HOUR(started_at) as hour, COUNT(*) as cnt
+    FROM sessions WHERE started_at IS NOT NULL
+    GROUP BY dow, hour
+  `)
+
+  const heatmap: number[][] = Array.from({ length: 7 }, () => new Array(24).fill(0))
+  for (const row of heatmapRows) {
+    const dayIdx = (row.dow) % 7
+    heatmap[dayIdx][row.hour] = row.cnt
+  }
+
+  return { users, heatmap }
+}

--- a/packages/trace-manager/src/cli.ts
+++ b/packages/trace-manager/src/cli.ts
@@ -1,0 +1,194 @@
+import type { Argv, CommandModule } from "yargs"
+
+export const TraceManageCommand: CommandModule = {
+  command: "trace-manage [action]",
+  describe: "Trace Manager — PII review, publish, summarize, analytics dashboard",
+  builder: (yargs: Argv) => {
+    return yargs
+      .positional("action", {
+        describe: "action to perform",
+        type: "string",
+        choices: ["dashboard", "consent", "summarize", "publish", "analyze", "ingest"] as const,
+        default: "dashboard",
+      })
+      .option("port", {
+        type: "number",
+        describe: "port for dashboard server",
+        default: 3847,
+      })
+      .option("share", {
+        type: "boolean",
+        describe: "create ngrok tunnel for sharing the dashboard",
+        default: false,
+      })
+      .option("id", {
+        type: "string",
+        describe: "session ID (for summarize/publish)",
+      })
+      .option("endpoint", {
+        type: "string",
+        describe: "HTTP endpoint URL (for publish)",
+      })
+      .option("yes", {
+        alias: "y",
+        type: "boolean",
+        describe: "skip confirmation prompts",
+        default: false,
+      })
+  },
+  handler: async (args: any) => {
+    const action = args.action || "dashboard"
+
+    if (action === "consent") {
+      const { runSecurityGuide } = await import("./consent/security-guide")
+      await runSecurityGuide({ interactive: true })
+      return
+    }
+
+    if (action === "summarize") {
+      const { loadAllTraces } = await import("./traces")
+      const { summarizeTrace, printTraceSummary } = await import("./summarize/trace-summarizer")
+      const traces = await loadAllTraces()
+      const trace = args.id
+        ? traces.find((t: any) => t.sessionId === args.id || t.sessionId.startsWith(args.id))
+        : traces[0]
+      if (!trace) {
+        console.error("  No trace found" + (args.id ? ` for ${args.id}` : ""))
+        process.exit(1)
+      }
+      printTraceSummary(summarizeTrace(trace))
+
+      const { detectPIIInTrace } = await import("./pii/detector")
+      const findings = detectPIIInTrace(trace)
+      if (findings.length) {
+        const { loadOrCreateConfig } = await import("./consent/consent-store")
+        const cfg = await loadOrCreateConfig()
+        console.log(`  PII detected: ${findings.length} item(s)`)
+        for (const f of findings) {
+          const act = cfg.consent.piiCategories[f.category] ?? "redact"
+          console.log(`    • ${f.category} in ${f.field} → will be ${act}ed`)
+        }
+        console.log("")
+      }
+      return
+    }
+
+    if (action === "publish") {
+      const { loadAllTraces } = await import("./traces")
+      const { publishTrace, printPublishResult } = await import("./publish/publisher")
+      const { loadOrCreateConfig } = await import("./consent/consent-store")
+      const { detectPIIInTrace } = await import("./pii/detector")
+
+      const traces = await loadAllTraces()
+      const trace = args.id
+        ? traces.find((t: any) => t.sessionId === args.id || t.sessionId.startsWith(args.id))
+        : traces[0]
+      if (!trace) {
+        console.error("  No trace found")
+        process.exit(1)
+      }
+
+      const cfg = await loadOrCreateConfig()
+      const findings = detectPIIInTrace(trace)
+      console.log(`\n  Publishing: "${trace.metadata.title ?? trace.sessionId}"`)
+      if (findings.length) {
+        console.log(`  PII: ${findings.length} item(s) will be handled per your consent config`)
+      }
+
+      const ep = args.endpoint
+        ? { name: "custom", url: args.endpoint }
+        : undefined
+      const result = await publishTrace(trace, cfg, ep)
+      printPublishResult(result)
+      console.log("")
+      return
+    }
+
+    if (action === "analyze") {
+      const { loadAllTraces } = await import("./traces")
+      const { summarizeTraces } = await import("./summarize/trace-summarizer")
+      const traces = await loadAllTraces()
+      const bulk = summarizeTraces(traces)
+      console.log(`\n  Trace Analytics (${bulk.count} sessions)`)
+      console.log("  " + "─".repeat(40))
+      console.log(`  Success rate:   ${(bulk.successRate * 100).toFixed(0)}%`)
+      console.log(`  Total tokens:   ${bulk.totalTokens.toLocaleString()}`)
+      console.log(`  Total cost:     $${bulk.totalCost.toFixed(4)}`)
+      console.log(`  Avg duration:   ${bulk.avgDuration < 60000 ? (bulk.avgDuration / 1000).toFixed(1) + "s" : Math.floor(bulk.avgDuration / 60000) + "m"}`)
+      console.log(`  Avg tokens:     ${bulk.avgTokens.toLocaleString()}`)
+      console.log("")
+      return
+    }
+
+    if (action === "ingest") {
+      const { loadOrCreateConfig } = await import("./consent/consent-store")
+      const { LakeManager } = await import("./lake/lake-manager")
+      const { loadAllTraces } = await import("./traces")
+      const cfg = await loadOrCreateConfig()
+      const lake = await LakeManager.create(cfg.lake.path)
+      const traces = await loadAllTraces()
+      console.log(`\n  Ingesting ${traces.length} traces into DuckDB...`)
+      for (const t of traces) {
+        await lake.ingest(t)
+        process.stdout.write(".")
+      }
+      const count = await lake.getSessionCount()
+      console.log(`\n  ✓ ${count} sessions in lake at ${cfg.lake.path}\n`)
+      await lake.close()
+      return
+    }
+
+    // Default: dashboard
+    const { loadConfig } = await import("./consent/consent-store")
+    const { runSecurityGuide } = await import("./consent/security-guide")
+    const existing = await loadConfig()
+    const config = existing ?? await runSecurityGuide({ interactive: process.stdin.isTTY !== false })
+
+    let lake: import("./lake/lake-manager").LakeManager | undefined
+    try {
+      const { LakeManager } = await import("./lake/lake-manager")
+      const { loadAllTraces } = await import("./traces")
+      lake = await LakeManager.create(config.lake.path)
+      const traces = await loadAllTraces()
+      for (const t of traces) await lake.ingest(t)
+    } catch {}
+
+    const { createApp } = await import("./web/server")
+    const app = await createApp({ lake })
+    const server = Bun.serve({
+      port: args.port || 3847,
+      hostname: "127.0.0.1",
+      fetch: app.fetch,
+    })
+
+    const url = `http://localhost:${server.port}`
+    console.log(`\n  Trace Manager Dashboard: ${url}`)
+
+    if (args.share) {
+      try {
+        const { startNgrokTunnel } = await import("./web/ngrok")
+        console.log("  Starting ngrok tunnel...")
+        const publicUrl = await startNgrokTunnel(server.port ?? 3847)
+        console.log(`  Public URL: ${publicUrl}`)
+      } catch (e: any) {
+        console.log(`  ngrok unavailable: ${e.message ?? e}`)
+      }
+    }
+
+    console.log("  Press Ctrl+C to stop\n")
+
+    try {
+      const cmd = process.platform === "darwin" ? "open" : "xdg-open"
+      Bun.spawn([cmd, url], { stdout: "ignore", stderr: "ignore" })
+    } catch {}
+
+    const shutdown = async () => {
+      if (lake) await lake.close().catch(() => {})
+      try { server.stop() } catch {}
+      process.exit(0)
+    }
+    process.on("SIGINT", shutdown)
+    process.on("SIGTERM", shutdown)
+    await new Promise(() => {})
+  },
+}

--- a/packages/trace-manager/src/consent/consent-store.ts
+++ b/packages/trace-manager/src/consent/consent-store.ts
@@ -1,0 +1,78 @@
+import fs from "fs/promises"
+import path from "path"
+import os from "os"
+import type { TraceManagerConfig, PIIAction, PIICategory } from "../types"
+
+const CONFIG_DIR = path.join(os.homedir(), ".altimate")
+const CONFIG_FILE = "trace-manager.json"
+
+export function configPath(): string {
+  return process.env.TRACE_MANAGER_CONFIG ?? path.join(CONFIG_DIR, CONFIG_FILE)
+}
+
+export function createDefaultConfig(): TraceManagerConfig {
+  return {
+    version: 1,
+    consent: {
+      acceptedAt: new Date().toISOString(),
+      piiCategories: {
+        email: "redact",
+        api_key: "redact",
+        ip_address: "hash",
+        file_path: "allow",
+        name: "hash",
+        phone: "redact",
+        ssn: "redact",
+        credit_card: "redact",
+      },
+      customPatterns: [],
+      autoPublish: false,
+      autoIngest: false,
+      retentionDays: 90,
+    },
+    publish: { endpoints: [] },
+    lake: {
+      path: process.env.TRACE_MANAGER_LAKE ?? path.join(os.homedir(), ".altimate/trace-lake.duckdb"),
+    },
+  }
+}
+
+export async function loadConfig(): Promise<TraceManagerConfig | null> {
+  const p = configPath()
+  const raw = await fs.readFile(p, "utf-8").catch(() => null)
+  if (!raw) return null
+  const parsed = JSON.parse(raw)
+  if (parsed.version !== 1) throw new Error(`Unsupported trace-manager config version: ${parsed.version}`)
+  return parsed as TraceManagerConfig
+}
+
+export async function saveConfig(config: TraceManagerConfig): Promise<void> {
+  const p = configPath()
+  await fs.mkdir(path.dirname(p), { recursive: true })
+  await fs.writeFile(p, JSON.stringify(config, null, 2) + "\n")
+}
+
+export async function loadOrCreateConfig(): Promise<TraceManagerConfig> {
+  const existing = await loadConfig()
+  if (existing) return existing
+  const config = createDefaultConfig()
+  await saveConfig(config)
+  return config
+}
+
+export const PII_CATEGORY_LABELS: Record<PIICategory, string> = {
+  email: "Email addresses",
+  api_key: "API keys & tokens",
+  ip_address: "IP addresses",
+  file_path: "File paths",
+  name: "Personal names",
+  phone: "Phone numbers",
+  ssn: "SSN / national IDs",
+  credit_card: "Credit card numbers",
+}
+
+export const PII_ACTION_LABELS: Record<PIIAction, string> = {
+  redact: "Replace with [REDACTED]",
+  hash: "SHA-256 hash (first 8 chars)",
+  allow: "Keep as-is",
+}

--- a/packages/trace-manager/src/consent/security-guide.ts
+++ b/packages/trace-manager/src/consent/security-guide.ts
@@ -1,0 +1,137 @@
+import {
+  createDefaultConfig,
+  saveConfig,
+  loadConfig,
+  PII_CATEGORY_LABELS,
+  PII_ACTION_LABELS,
+} from "./consent-store"
+import type { PIIAction, PIICategory, TraceManagerConfig } from "../types"
+
+const ACTIONS: PIIAction[] = ["redact", "hash", "allow"]
+const CATEGORIES: PIICategory[] = ["email", "api_key", "ip_address", "file_path", "name", "phone", "ssn", "credit_card"]
+
+function printHeader(isReconfigure: boolean) {
+  console.log("")
+  console.log("╭─────────────────────────────────────────────────────────╮")
+  console.log("│              Altimate Code — Trace Manager               │")
+  console.log("│                    Security Guide                        │")
+  console.log("╰─────────────────────────────────────────────────────────╯")
+  console.log("")
+  if (!isReconfigure) {
+    console.log("  Altimate Code records session traces locally to help you")
+    console.log("  review, debug, and improve your coding sessions.")
+    console.log("")
+    console.log("  Before we start, let's configure what data stays private.")
+    console.log("  Nothing leaves your machine unless you explicitly publish.")
+  } else {
+    console.log("  Reconfiguring your trace privacy settings.")
+  }
+  console.log("")
+  console.log("─────────────────────────────────────────────────────────")
+  console.log("")
+}
+
+function printCurrentSettings(config: TraceManagerConfig) {
+  console.log("  PII Category            Action")
+  console.log("  ────────────────────    ──────────────────")
+  for (const cat of CATEGORIES) {
+    const action = config.consent.piiCategories[cat] ?? "redact"
+    const label = PII_CATEGORY_LABELS[cat].padEnd(22)
+    const actionLabel = PII_ACTION_LABELS[action]
+    console.log(`  ${label}  ${action.padEnd(8)} (${actionLabel})`)
+  }
+  console.log("")
+  console.log(`  Auto-publish:       ${config.consent.autoPublish ? "yes" : "no"}`)
+  console.log(`  Auto-ingest to lake: ${config.consent.autoIngest ? "yes" : "no"}`)
+  console.log(`  Retention:          ${config.consent.retentionDays} days`)
+  console.log("")
+}
+
+export async function runSecurityGuide(options?: { interactive?: boolean }): Promise<TraceManagerConfig> {
+  const existing = await loadConfig()
+  const isReconfigure = !!existing
+  const config = existing ?? createDefaultConfig()
+
+  printHeader(isReconfigure)
+
+  if (isReconfigure) {
+    console.log("  Current settings:")
+    console.log("")
+    printCurrentSettings(config)
+  }
+
+  if (options?.interactive === false) {
+    if (!isReconfigure) {
+      console.log("  Using default privacy settings (conservative):")
+      console.log("")
+      printCurrentSettings(config)
+      config.consent.acceptedAt = new Date().toISOString()
+      await saveConfig(config)
+      console.log("  ✓ Preferences saved to " + (await import("./consent-store")).configPath())
+      console.log("  ✓ Change anytime: altimate-code trace-manage consent")
+      console.log("")
+    }
+    return config
+  }
+
+  console.log("  Configure PII handling (press Enter to accept defaults):")
+  console.log("")
+
+  for (const cat of CATEGORIES) {
+    const current = config.consent.piiCategories[cat] ?? "redact"
+    const label = PII_CATEGORY_LABELS[cat]
+    const prompt = `  ${label} [${current}]: `
+    process.stdout.write(prompt)
+
+    const line = await readLine()
+    const trimmed = line.trim().toLowerCase()
+    if (trimmed && ACTIONS.includes(trimmed as PIIAction)) {
+      config.consent.piiCategories[cat] = trimmed as PIIAction
+    }
+  }
+
+  console.log("")
+  process.stdout.write("  Review PII before every publish? [Y/n]: ")
+  const reviewAnswer = (await readLine()).trim().toLowerCase()
+  config.consent.autoPublish = reviewAnswer === "n" || reviewAnswer === "no"
+
+  process.stdout.write("  Auto-ingest traces into analytics lake? [y/N]: ")
+  const ingestAnswer = (await readLine()).trim().toLowerCase()
+  config.consent.autoIngest = ingestAnswer === "y" || ingestAnswer === "yes"
+
+  config.consent.acceptedAt = new Date().toISOString()
+  await saveConfig(config)
+
+  console.log("")
+  console.log("─────────────────────────────────────────────────────────")
+  console.log("")
+  console.log("  ✓ Preferences saved to " + (await import("./consent-store")).configPath())
+  console.log("  ✓ Change anytime: altimate-code trace-manage consent")
+  console.log("")
+
+  return config
+}
+
+function readLine(): Promise<string> {
+  return new Promise((resolve) => {
+    let data = ""
+    const onData = (chunk: Buffer) => {
+      const str = chunk.toString()
+      if (str.includes("\n")) {
+        data += str.split("\n")[0]
+        process.stdin.off("data", onData)
+        if (wasRaw) process.stdin.setRawMode?.(false)
+        process.stdin.pause()
+        resolve(data)
+        return
+      }
+      data += str
+    }
+    let wasRaw = false
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode?.(false)
+    }
+    process.stdin.resume()
+    process.stdin.on("data", onData)
+  })
+}

--- a/packages/trace-manager/src/dashboard.ts
+++ b/packages/trace-manager/src/dashboard.ts
@@ -1,0 +1,95 @@
+import { createApp } from "./web/server"
+import { loadConfig } from "./consent/consent-store"
+import { runSecurityGuide } from "./consent/security-guide"
+import { getTracesDir } from "./traces"
+import { startNgrokTunnel } from "./web/ngrok"
+import { LakeManager } from "./lake/lake-manager"
+import { loadAllTraces } from "./traces"
+
+const args = process.argv.slice(2)
+const command = args[0]
+
+if (command === "consent") {
+  await runSecurityGuide({ interactive: true })
+  process.exit(0)
+}
+
+if (command === "ingest") {
+  const config = await ensureConsent()
+  const lake = await LakeManager.create(config.lake.path)
+  const traces = await loadAllTraces()
+  console.log(`\n  Ingesting ${traces.length} traces into DuckDB...`)
+  for (const t of traces) {
+    await lake.ingest(t)
+    process.stdout.write(".")
+  }
+  const count = await lake.getSessionCount()
+  console.log(`\n  ✓ ${count} sessions in lake at ${config.lake.path}\n`)
+  await lake.close()
+  process.exit(0)
+}
+
+if (command === "summarize") {
+  const { summarizeTrace, printTraceSummary } = await import("./summarize/trace-summarizer")
+  const traces = await loadAllTraces()
+  const id = args[1]
+  if (id) {
+    const trace = traces.find((t) => t.sessionId === id || t.sessionId.startsWith(id))
+    if (!trace) { console.error(`  Trace not found: ${id}`); process.exit(1) }
+    printTraceSummary(summarizeTrace(trace))
+  } else {
+    if (!traces.length) { console.log("  No traces found."); process.exit(0) }
+    printTraceSummary(summarizeTrace(traces[0]))
+  }
+  process.exit(0)
+}
+
+// Default: start dashboard
+const config = await ensureConsent()
+const share = args.includes("--share")
+const portArg = args.find((a) => a.startsWith("--port="))
+const port = portArg ? parseInt(portArg.split("=")[1]) : parseInt(process.env.PORT ?? "3847")
+
+let lake: LakeManager | undefined
+try {
+  lake = await LakeManager.create(config.lake.path)
+  const traces = await loadAllTraces()
+  console.log(`\n  Auto-ingesting ${traces.length} traces...`)
+  for (const t of traces) await lake.ingest(t)
+  console.log(`  ✓ ${await lake.getSessionCount()} sessions in DuckDB`)
+} catch (e) {
+  console.log(`  Note: DuckDB lake unavailable (${e instanceof Error ? e.message : e})`)
+  console.log("  Dashboard will use in-memory analytics.\n")
+}
+
+const app = await createApp({ lake })
+const server = Bun.serve({ port, hostname: "127.0.0.1", fetch: app.fetch })
+
+console.log(`\n  Trace Manager Dashboard: http://localhost:${server.port}`)
+console.log(`  Reading traces from: ${getTracesDir()}`)
+
+if (share) {
+  try {
+    console.log("  Starting ngrok tunnel...")
+    const url = await startNgrokTunnel(server.port ?? port)
+    console.log(`  Public URL: ${url}`)
+  } catch (e) {
+    console.log(`  ngrok unavailable: ${e instanceof Error ? e.message : e}`)
+    console.log("  Install ngrok or @ngrok/ngrok for sharing.")
+  }
+}
+
+console.log("  Press Ctrl+C to stop\n")
+
+try { const openCmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open"; Bun.spawn([openCmd, `http://localhost:${server.port}`], { stdout: "ignore", stderr: "ignore" }) } catch {}
+
+const shutdown = async () => { if (lake) await lake.close().catch(() => {}); try { server.stop() } catch {} process.exit(0) }
+process.on("SIGINT", shutdown)
+process.on("SIGTERM", shutdown)
+await new Promise(() => {})
+
+async function ensureConsent() {
+  const existing = await loadConfig()
+  if (existing) return existing
+  return runSecurityGuide({ interactive: process.stdin.isTTY !== false })
+}

--- a/packages/trace-manager/src/index.ts
+++ b/packages/trace-manager/src/index.ts
@@ -1,0 +1,219 @@
+import type { Plugin } from "@opencode-ai/plugin"
+import { tool } from "@opencode-ai/plugin"
+import { loadOrCreateConfig, loadConfig } from "./consent/consent-store"
+import { loadAllTraces, loadTrace } from "./traces"
+import { summarizeTrace, printTraceSummary } from "./summarize/trace-summarizer"
+import { detectPIIInTrace } from "./pii/detector"
+import { redactTrace } from "./pii/redactor"
+import { publishTrace, printPublishResult } from "./publish/publisher"
+
+export const TraceManagerPlugin: Plugin = async (ctx) => {
+  const config = await loadOrCreateConfig()
+
+  return {
+    tool: {
+      "trace-manage-summarize": tool({
+        description:
+          "Summarize a session trace — shows duration, tokens, cost, tool usage, narrative, and detected issues. " +
+          "Call without arguments to summarize the most recent trace, or pass a session ID.",
+        args: {
+          sessionId: tool.schema
+            .string()
+            .optional()
+            .describe("Session ID to summarize (defaults to most recent)"),
+        },
+        async execute(args) {
+          const traces = await loadAllTraces()
+          const trace = args.sessionId
+            ? traces.find(
+                (t) =>
+                  t.sessionId === args.sessionId ||
+                  t.sessionId.startsWith(args.sessionId!),
+              )
+            : traces[0]
+
+          if (!trace) return "No trace found" + (args.sessionId ? ` for ID ${args.sessionId}` : "")
+
+          const report = summarizeTrace(trace)
+          return [
+            `Session: "${report.title}"`,
+            `Duration: ${report.duration} | Status: ${report.status}`,
+            `Model: ${report.model} | Agent: ${report.agent}`,
+            `Tokens: ${report.totalTokens.toLocaleString()} (in=${report.tokensBreakdown.input.toLocaleString()} out=${report.tokensBreakdown.output.toLocaleString()})`,
+            `Cost: $${report.totalCost.toFixed(4)}`,
+            `Tools: ${report.topTools.map((t) => `${t.name}(${t.count})`).join(" ") || "none"}`,
+            `Generations: ${report.generations}`,
+            report.loops.length
+              ? `Loops: ${report.loops.map((l) => `${l.tool}(${l.count}x)`).join(", ")}`
+              : null,
+            "",
+            report.narrative,
+          ]
+            .filter(Boolean)
+            .join("\n")
+        },
+      }),
+
+      "trace-manage-pii-review": tool({
+        description:
+          "Detect PII in a session trace — shows what sensitive data (emails, API keys, IPs, etc.) exists " +
+          "and what redaction action will be applied before publishing.",
+        args: {
+          sessionId: tool.schema
+            .string()
+            .optional()
+            .describe("Session ID to review (defaults to most recent)"),
+        },
+        async execute(args) {
+          const traces = await loadAllTraces()
+          const trace = args.sessionId
+            ? traces.find(
+                (t) =>
+                  t.sessionId === args.sessionId ||
+                  t.sessionId.startsWith(args.sessionId!),
+              )
+            : traces[0]
+
+          if (!trace) return "No trace found"
+
+          const findings = detectPIIInTrace(trace)
+          if (!findings.length) return `No PII detected in "${trace.metadata.title ?? trace.sessionId}"`
+
+          const cfg = await loadOrCreateConfig()
+          const lines = [
+            `PII Review: "${trace.metadata.title ?? trace.sessionId}"`,
+            `Found ${findings.length} PII item(s):`,
+            "",
+          ]
+          for (const f of findings) {
+            const action = cfg.consent.piiCategories[f.category] ?? "redact"
+            const preview = f.match.slice(0, 4) + "***" + f.match.slice(-2)
+            lines.push(`  [${action.toUpperCase()}] ${f.category}: ${preview} (${f.field}${f.spanId ? ` span ${f.spanId.slice(0, 8)}` : ""})`)
+          }
+          return lines.join("\n")
+        },
+      }),
+
+      "trace-manage-publish": tool({
+        description:
+          "Publish a session trace to a configured HTTP endpoint after PII redaction. " +
+          "Uses the PII settings from your trace-manager consent configuration.",
+        args: {
+          sessionId: tool.schema
+            .string()
+            .optional()
+            .describe("Session ID to publish (defaults to most recent)"),
+          endpoint: tool.schema
+            .string()
+            .optional()
+            .describe("Override publish endpoint URL"),
+        },
+        async execute(args) {
+          const traces = await loadAllTraces()
+          const trace = args.sessionId
+            ? traces.find(
+                (t) =>
+                  t.sessionId === args.sessionId ||
+                  t.sessionId.startsWith(args.sessionId!),
+              )
+            : traces[0]
+
+          if (!trace) return "No trace found"
+
+          const cfg = await loadOrCreateConfig()
+          const ep = args.endpoint
+            ? { name: "custom", url: args.endpoint }
+            : undefined
+          const result = await publishTrace(trace, cfg, ep)
+
+          if (result.success) {
+            return `✓ Published "${trace.metadata.title ?? trace.sessionId}" to ${result.endpoint}` +
+              (result.url ? `\nURL: ${result.url}` : "") +
+              `\nPII: ${result.piiRedacted} redacted, ${result.piiAllowed} allowed`
+          }
+          return `✗ Publish failed: ${result.error}`
+        },
+      }),
+
+      "trace-manage-analyze": tool({
+        description:
+          "Analyze all session traces and show conversation analytics — success rates, " +
+          "tool usage patterns, latency percentiles, and failure analysis.",
+        args: {},
+        async execute() {
+          const traces = await loadAllTraces()
+          if (!traces.length) return "No traces found"
+
+          const completed = traces.filter((t) => t.summary.status === "completed").length
+          const totalTokens = traces.reduce((s, t) => s + t.summary.totalTokens, 0)
+          const totalCost = traces.reduce((s, t) => s + t.summary.totalCost, 0)
+          const avgDur = traces.reduce((s, t) => s + t.summary.duration, 0) / traces.length
+
+          const toolFreq: Record<string, number> = {}
+          for (const t of traces)
+            for (const tt of t.summary.topTools ?? [])
+              toolFreq[tt.name] = (toolFreq[tt.name] ?? 0) + tt.count
+          const topTools = Object.entries(toolFreq)
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, 5)
+
+          const fmtD = (ms: number) => ms < 60000 ? `${(ms / 1000).toFixed(1)}s` : `${Math.floor(ms / 60000)}m${Math.floor((ms % 60000) / 1000)}s`
+
+          return [
+            `Trace Analytics (${traces.length} sessions)`,
+            `─────────────────────────────`,
+            `Success rate: ${((completed / traces.length) * 100).toFixed(0)}% (${completed}/${traces.length})`,
+            `Total tokens: ${totalTokens.toLocaleString()}`,
+            `Total cost:   $${totalCost.toFixed(4)}`,
+            `Avg duration: ${fmtD(avgDur)}`,
+            "",
+            "Top tools:",
+            ...topTools.map(([name, count]) => `  ${name}: ${count} calls`),
+          ].join("\n")
+        },
+      }),
+
+      "trace-manage-dashboard": tool({
+        description:
+          "Launch the Trace Manager web dashboard on localhost for browsing traces, " +
+          "reviewing PII, viewing knowledge graphs, and analyzing conversation/user analytics.",
+        args: {
+          port: tool.schema.number().optional().describe("Port (default 3847)"),
+          share: tool.schema.boolean().optional().describe("Create ngrok tunnel for sharing"),
+        },
+        async execute(args) {
+          const port = args.port ?? 3847
+          const { createApp } = await import("./web/server")
+          const app = await createApp()
+          const server = Bun.serve({
+            port,
+            hostname: "127.0.0.1",
+            fetch: app.fetch,
+          })
+          const url = `http://localhost:${server.port}`
+          try {
+            const openCmd = process.platform === "darwin" ? "open" : "xdg-open"
+            Bun.spawn([openCmd, url], { stdout: "ignore", stderr: "ignore" })
+          } catch {}
+          return `Dashboard running at ${url}\nOpen in your browser to view traces, analytics, PII review, and knowledge graphs.`
+        },
+      }),
+    },
+
+    async event({ event }) {
+      if (
+        config.consent.autoIngest &&
+        (event as any).type === "session.status" &&
+        (event as any).properties?.status === "idle"
+      ) {
+        try {
+          const { LakeManager } = await import("./lake/lake-manager")
+          const lake = await LakeManager.create(config.lake.path)
+          const traces = await loadAllTraces()
+          if (traces[0]) await lake.ingest(traces[0])
+          await lake.close()
+        } catch {}
+      }
+    },
+  }
+}

--- a/packages/trace-manager/src/lake/lake-manager.ts
+++ b/packages/trace-manager/src/lake/lake-manager.ts
@@ -1,0 +1,175 @@
+import type { TraceFile, PIIFinding } from "../types"
+
+const SCHEMA_DDL = `
+CREATE TABLE IF NOT EXISTS sessions (
+  session_id VARCHAR PRIMARY KEY,
+  trace_id VARCHAR,
+  title VARCHAR,
+  started_at TIMESTAMP,
+  ended_at TIMESTAMP,
+  duration_ms INTEGER,
+  status VARCHAR,
+  model VARCHAR,
+  provider_id VARCHAR,
+  agent VARCHAR,
+  user_id VARCHAR,
+  total_tokens INTEGER,
+  input_tokens INTEGER,
+  output_tokens INTEGER,
+  cache_read_tokens INTEGER,
+  total_cost DOUBLE,
+  total_tool_calls INTEGER,
+  total_generations INTEGER,
+  narrative TEXT,
+  top_tools JSON,
+  loops JSON,
+  ingested_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS spans (
+  span_id VARCHAR,
+  session_id VARCHAR,
+  parent_span_id VARCHAR,
+  name VARCHAR,
+  kind VARCHAR,
+  started_at TIMESTAMP,
+  ended_at TIMESTAMP,
+  duration_ms INTEGER,
+  status VARCHAR,
+  model VARCHAR,
+  tokens_input INTEGER,
+  tokens_output INTEGER,
+  cost DOUBLE,
+  tool_call_id VARCHAR,
+  input_preview VARCHAR,
+  output_preview VARCHAR,
+  PRIMARY KEY (span_id, session_id)
+);
+
+CREATE TABLE IF NOT EXISTS pii_findings (
+  id INTEGER PRIMARY KEY,
+  session_id VARCHAR,
+  span_id VARCHAR,
+  field_path VARCHAR,
+  category VARCHAR,
+  action_taken VARCHAR,
+  detected_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+`
+
+type DuckDB = any
+
+export class LakeManager {
+  private db: DuckDB
+  private conn: any
+
+  private constructor(db: DuckDB, conn: any) {
+    this.db = db
+    this.conn = conn
+  }
+
+  static async create(dbPath: string): Promise<LakeManager> {
+    const duckdb = await import("duckdb")
+    return new Promise((resolve, reject) => {
+      const db = new (duckdb.default ?? duckdb).Database(dbPath, {}, (err: Error | null) => {
+        if (err) return reject(err)
+        const conn = db.connect()
+        const lake = new LakeManager(db, conn)
+        lake.initSchema().then(() => resolve(lake)).catch(reject)
+      })
+    })
+  }
+
+  private async initSchema(): Promise<void> {
+    const stmts = SCHEMA_DDL.split(";").filter((s) => s.trim())
+    for (const stmt of stmts) {
+      await this.exec(stmt)
+    }
+  }
+
+  private exec(sql: string, params?: any[]): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (params?.length) {
+        this.conn.run(sql, ...params, (err: Error | null) => (err ? reject(err) : resolve()))
+      } else {
+        this.conn.exec(sql, (err: Error | null) => (err ? reject(err) : resolve()))
+      }
+    })
+  }
+
+  async query<T = Record<string, unknown>>(sql: string, params?: any[]): Promise<T[]> {
+    return new Promise((resolve, reject) => {
+      const cb = (err: Error | null, rows: T[]) => (err ? reject(err) : resolve(rows ?? []))
+      if (params?.length) {
+        this.conn.all(sql, ...params, cb)
+      } else {
+        this.conn.all(sql, cb)
+      }
+    })
+  }
+
+  async ingest(trace: TraceFile): Promise<void> {
+    const toTs = (iso?: string) => (iso ? `'${iso}'` : "NULL")
+    const esc = (s?: string | null) => (s ? `'${s.replace(/'/g, "''")}'` : "NULL")
+    const preview = (s?: string | null, maxLen = 500) => {
+      if (!s) return "NULL"
+      const trimmed = s.length > maxLen ? s.slice(0, maxLen) : s
+      return esc(trimmed)
+    }
+
+    await this.exec(`DELETE FROM spans WHERE session_id = ${esc(trace.sessionId)}`)
+    await this.exec(`DELETE FROM sessions WHERE session_id = ${esc(trace.sessionId)}`)
+
+    await this.exec(`INSERT INTO sessions VALUES (
+      ${esc(trace.sessionId)}, ${esc(trace.traceId)}, ${esc(trace.metadata.title)},
+      ${toTs(trace.startedAt)}, ${toTs(trace.endedAt)}, ${trace.summary.duration},
+      ${esc(trace.summary.status)}, ${esc(trace.metadata.model)}, ${esc(trace.metadata.providerId)},
+      ${esc(trace.metadata.agent)}, ${esc(trace.metadata.userId)},
+      ${trace.summary.totalTokens}, ${trace.summary.tokens.input}, ${trace.summary.tokens.output},
+      ${trace.summary.tokens.cacheRead}, ${trace.summary.totalCost},
+      ${trace.summary.totalToolCalls}, ${trace.summary.totalGenerations},
+      ${esc(trace.summary.narrative)},
+      ${esc(JSON.stringify(trace.summary.topTools ?? []))},
+      ${esc(JSON.stringify(trace.summary.loops ?? []))},
+      CURRENT_TIMESTAMP
+    )`)
+
+    for (const span of trace.spans) {
+      const startTs = span.startTime ? `EPOCH_MS(${span.startTime})` : "NULL"
+      const endTs = span.endTime ? `EPOCH_MS(${span.endTime})` : "NULL"
+      const dur = span.startTime && span.endTime ? span.endTime - span.startTime : "NULL"
+      const model =
+        typeof span.model === "string"
+          ? span.model
+          : span.model?.modelId ?? null
+
+      await this.exec(`INSERT OR REPLACE INTO spans VALUES (
+        ${esc(span.spanId)}, ${esc(trace.sessionId)}, ${esc(span.parentSpanId)},
+        ${esc(span.name)}, ${esc(span.kind)},
+        ${startTs}, ${endTs}, ${dur},
+        ${esc(span.status)}, ${esc(model)},
+        ${span.tokens?.input ?? "NULL"}, ${span.tokens?.output ?? "NULL"},
+        ${span.cost ?? "NULL"}, ${esc(span.tool?.callId)},
+        ${preview(span.input)}, ${preview(span.output)}
+      )`)
+    }
+  }
+
+  async recordPIIFindings(sessionId: string, findings: PIIFinding[], action: string): Promise<void> {
+    for (const f of findings) {
+      await this.exec(`INSERT INTO pii_findings (session_id, span_id, field_path, category, action_taken)
+        VALUES ('${sessionId}', ${f.spanId ? `'${f.spanId}'` : "NULL"}, '${f.field}', '${f.category}', '${action}')`)
+    }
+  }
+
+  async getSessionCount(): Promise<number> {
+    const rows = await this.query<{ n: number }>("SELECT COUNT(*) as n FROM sessions")
+    return rows[0]?.n ?? 0
+  }
+
+  async close(): Promise<void> {
+    return new Promise((resolve) => {
+      this.db.close(() => resolve())
+    })
+  }
+}

--- a/packages/trace-manager/src/pii/detector.ts
+++ b/packages/trace-manager/src/pii/detector.ts
@@ -1,0 +1,126 @@
+import type { PIICategory, PIIFinding } from "../types"
+
+interface PatternDef {
+  category: PIICategory
+  regex: RegExp
+  validate?: (match: string) => boolean
+}
+
+const PATTERNS: PatternDef[] = [
+  {
+    category: "email",
+    regex: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
+  },
+  {
+    category: "api_key",
+    regex: /(?:sk-[a-zA-Z0-9_-]{20,}|ghp_[a-zA-Z0-9]{36,}|gho_[a-zA-Z0-9]{36,}|glpat-[a-zA-Z0-9_-]{20,}|xox[bsrp]-[a-zA-Z0-9-]{10,}|AKIA[0-9A-Z]{16}|Bearer\s+[a-zA-Z0-9._~+\/=-]{20,})/g,
+  },
+  {
+    category: "ip_address",
+    regex: /\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b/g,
+    validate: (match) => {
+      // exclude semver-like patterns (e.g., 1.2.3.4 is valid IP but rare as version)
+      if (/^\d+\.\d+\.\d+\.\d+$/.test(match)) {
+        const parts = match.split(".").map(Number)
+        return parts[0] !== 0 && parts[0] !== 127 || parts.some((p) => p > 0)
+      }
+      return true
+    },
+  },
+  {
+    category: "file_path",
+    regex: /(?:\/Users\/[^\s"']+|\/home\/[^\s"']+|C:\\Users\\[^\s"']+|~\/[^\s"']+)/g,
+  },
+  {
+    category: "phone",
+    regex: /(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/g,
+    validate: (match) => {
+      const digits = match.replace(/\D/g, "")
+      return digits.length >= 10 && digits.length <= 15
+    },
+  },
+  {
+    category: "ssn",
+    regex: /\b\d{3}[-\s]?\d{2}[-\s]?\d{4}\b/g,
+    validate: (match) => {
+      const digits = match.replace(/\D/g, "")
+      return digits.length === 9 && !digits.startsWith("000") && !digits.startsWith("9")
+    },
+  },
+  {
+    category: "credit_card",
+    regex: /\b(?:4\d{3}|5[1-5]\d{2}|3[47]\d{2}|6(?:011|5\d{2}))[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b/g,
+    validate: (match) => {
+      const digits = match.replace(/\D/g, "")
+      return digits.length >= 13 && digits.length <= 19 && luhnCheck(digits)
+    },
+  },
+]
+
+function luhnCheck(num: string): boolean {
+  let sum = 0
+  let alt = false
+  for (let i = num.length - 1; i >= 0; i--) {
+    let n = parseInt(num[i], 10)
+    if (alt) {
+      n *= 2
+      if (n > 9) n -= 9
+    }
+    sum += n
+    alt = !alt
+  }
+  return sum % 10 === 0
+}
+
+export function detectPII(text: string | null | undefined, field?: string, spanId?: string): PIIFinding[] {
+  if (!text) return []
+  const findings: PIIFinding[] = []
+  for (const pattern of PATTERNS) {
+    const regex = new RegExp(pattern.regex.source, pattern.regex.flags)
+    let m: RegExpExecArray | null
+    while ((m = regex.exec(text)) !== null) {
+      const match = m[0]
+      if (pattern.validate && !pattern.validate(match)) continue
+      findings.push({
+        category: pattern.category,
+        match,
+        start: m.index,
+        end: m.index + match.length,
+        field: field ?? "text",
+        spanId,
+      })
+    }
+  }
+  return findings
+}
+
+export function detectPIIInTrace(trace: import("../types").TraceFile): PIIFinding[] {
+  const findings: PIIFinding[] = []
+
+  if (trace.metadata.userId) {
+    findings.push(...detectPII(trace.metadata.userId, "metadata.userId"))
+  }
+  if (trace.metadata.prompt) {
+    findings.push(...detectPII(trace.metadata.prompt, "metadata.prompt"))
+  }
+
+  for (const span of trace.spans) {
+    if (span.input) {
+      findings.push(...detectPII(span.input, "span.input", span.spanId))
+    }
+    if (span.output) {
+      findings.push(...detectPII(span.output, "span.output", span.spanId))
+    }
+  }
+
+  return findings
+}
+
+export function addCustomPatterns(patterns: Array<{ name: string; regex: string }>) {
+  for (const p of patterns) {
+    PATTERNS.push({
+      category: "api_key",
+      regex: new RegExp(p.regex, "g"),
+    })
+  }
+}

--- a/packages/trace-manager/src/pii/redactor.ts
+++ b/packages/trace-manager/src/pii/redactor.ts
@@ -1,0 +1,79 @@
+import { createHash } from "crypto"
+import type { PIIAction, PIICategory, PIIFinding, TraceFile, TraceManagerConfig } from "../types"
+import { detectPIIInTrace } from "./detector"
+
+function hashValue(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 8)
+}
+
+export function redactString(
+  text: string,
+  findings: PIIFinding[],
+  actions: Partial<Record<PIICategory, PIIAction>>,
+): string {
+  if (!findings.length) return text
+
+  const sorted = [...findings].sort((a, b) => b.start - a.start)
+  let result = text
+  for (const f of sorted) {
+    const action = actions[f.category] ?? "redact"
+    if (action === "allow") continue
+    const replacement = action === "hash" ? hashValue(f.match) : "[REDACTED]"
+    result = result.slice(0, f.start) + replacement + result.slice(f.end)
+  }
+  return result
+}
+
+export interface RedactionResult {
+  trace: TraceFile
+  findings: PIIFinding[]
+  redactedCount: number
+  allowedCount: number
+}
+
+export function redactTrace(
+  trace: TraceFile,
+  config: TraceManagerConfig,
+  overrides?: Partial<Record<string, PIIAction>>,
+): RedactionResult {
+  const findings = detectPIIInTrace(trace)
+  const actions = { ...config.consent.piiCategories, ...overrides } as Partial<Record<PIICategory, PIIAction>>
+
+  let redactedCount = 0
+  let allowedCount = 0
+
+  const redacted: TraceFile = JSON.parse(JSON.stringify(trace))
+
+  if (redacted.metadata.userId) {
+    const metaFindings = findings.filter((f) => f.field === "metadata.userId")
+    if (metaFindings.length) {
+      redacted.metadata.userId = redactString(redacted.metadata.userId, metaFindings, actions)
+    }
+  }
+  if (redacted.metadata.prompt) {
+    const metaFindings = findings.filter((f) => f.field === "metadata.prompt")
+    if (metaFindings.length) {
+      redacted.metadata.prompt = redactString(redacted.metadata.prompt, metaFindings, actions)
+    }
+  }
+
+  for (const span of redacted.spans) {
+    const inputFindings = findings.filter((f) => f.spanId === span.spanId && f.field === "span.input")
+    const outputFindings = findings.filter((f) => f.spanId === span.spanId && f.field === "span.output")
+
+    if (span.input && inputFindings.length) {
+      span.input = redactString(span.input, inputFindings, actions)
+    }
+    if (span.output && outputFindings.length) {
+      span.output = redactString(span.output, outputFindings, actions)
+    }
+  }
+
+  for (const f of findings) {
+    const action = actions[f.category] ?? "redact"
+    if (action === "allow") allowedCount++
+    else redactedCount++
+  }
+
+  return { trace: redacted, findings, redactedCount, allowedCount }
+}

--- a/packages/trace-manager/src/publish/publisher.ts
+++ b/packages/trace-manager/src/publish/publisher.ts
@@ -1,0 +1,87 @@
+import type { TraceFile, TraceManagerConfig } from "../types"
+import { redactTrace } from "../pii/redactor"
+
+export interface PublishResult {
+  success: boolean
+  endpoint: string
+  url?: string
+  error?: string
+  piiRedacted: number
+  piiAllowed: number
+}
+
+export async function publishTrace(
+  trace: TraceFile,
+  config: TraceManagerConfig,
+  endpoint?: { name: string; url: string; headers?: Record<string, string> },
+): Promise<PublishResult> {
+  const target = endpoint ?? config.publish.endpoints[0]
+  if (!target) {
+    return {
+      success: false,
+      endpoint: "none",
+      error: "No publish endpoint configured. Add one via: altimate-code trace-manage consent",
+      piiRedacted: 0,
+      piiAllowed: 0,
+    }
+  }
+
+  const { trace: redacted, redactedCount, allowedCount } = redactTrace(trace, config)
+
+  try {
+    const response = await fetch(target.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(target.headers ?? {}),
+      },
+      body: JSON.stringify(redacted),
+      signal: AbortSignal.timeout(10_000),
+    })
+
+    if (!response.ok) {
+      return {
+        success: false,
+        endpoint: target.name,
+        error: `HTTP ${response.status}: ${response.statusText}`,
+        piiRedacted: redactedCount,
+        piiAllowed: allowedCount,
+      }
+    }
+
+    let url: string | undefined
+    try {
+      const body = await response.json()
+      url = (body as any)?.url
+    } catch {}
+
+    return {
+      success: true,
+      endpoint: target.name,
+      url,
+      piiRedacted: redactedCount,
+      piiAllowed: allowedCount,
+    }
+  } catch (e) {
+    return {
+      success: false,
+      endpoint: target.name,
+      error: e instanceof Error ? e.message : String(e),
+      piiRedacted: redactedCount,
+      piiAllowed: allowedCount,
+    }
+  }
+}
+
+export function printPublishResult(result: PublishResult): void {
+  if (result.success) {
+    console.log(`  ✓ Published to ${result.endpoint}`)
+    if (result.url) console.log(`    URL: ${result.url}`)
+  } else {
+    console.log(`  ✗ Failed to publish to ${result.endpoint}`)
+    console.log(`    Error: ${result.error}`)
+  }
+  if (result.piiRedacted > 0) {
+    console.log(`    PII: ${result.piiRedacted} field(s) redacted, ${result.piiAllowed} allowed`)
+  }
+}

--- a/packages/trace-manager/src/summarize/trace-summarizer.ts
+++ b/packages/trace-manager/src/summarize/trace-summarizer.ts
@@ -1,0 +1,126 @@
+import type { TraceFile } from "../types"
+
+export interface TraceSummaryReport {
+  sessionId: string
+  title: string
+  model: string
+  agent: string
+  status: string
+  duration: string
+  durationMs: number
+  totalTokens: number
+  tokensBreakdown: { input: number; output: number; cacheRead: number }
+  totalCost: number
+  toolCalls: number
+  generations: number
+  narrative: string
+  topTools: Array<{ name: string; count: number; avgDuration: number }>
+  loops: Array<{ tool: string; count: number }>
+  spanKindDistribution: Record<string, number>
+  avgGenerationLatency: number
+}
+
+function fmtDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
+  const m = Math.floor(ms / 60000)
+  const s = Math.floor((ms % 60000) / 1000)
+  return `${m}m${s ? s + "s" : ""}`
+}
+
+export function summarizeTrace(trace: TraceFile): TraceSummaryReport {
+  const genSpans = trace.spans.filter(
+    (s) => s.kind === "generation" && s.startTime && s.endTime,
+  )
+  const genLatencies = genSpans.map((s) => s.endTime! - s.startTime!)
+  const avgGenLatency = genLatencies.length
+    ? genLatencies.reduce((a, b) => a + b, 0) / genLatencies.length
+    : 0
+
+  const kindDist: Record<string, number> = {}
+  for (const s of trace.spans) {
+    kindDist[s.kind] = (kindDist[s.kind] ?? 0) + 1
+  }
+
+  const topTools = (trace.summary.topTools ?? []).map((t) => ({
+    name: t.name,
+    count: t.count,
+    avgDuration: t.count ? t.totalDuration / t.count : 0,
+  }))
+
+  return {
+    sessionId: trace.sessionId,
+    title: trace.metadata.title ?? trace.sessionId,
+    model: trace.metadata.model ?? "unknown",
+    agent: trace.metadata.agent ?? "default",
+    status: trace.summary.status,
+    duration: fmtDuration(trace.summary.duration),
+    durationMs: trace.summary.duration,
+    totalTokens: trace.summary.totalTokens,
+    tokensBreakdown: {
+      input: trace.summary.tokens.input,
+      output: trace.summary.tokens.output,
+      cacheRead: trace.summary.tokens.cacheRead,
+    },
+    totalCost: trace.summary.totalCost,
+    toolCalls: trace.summary.totalToolCalls,
+    generations: trace.summary.totalGenerations,
+    narrative: trace.summary.narrative ?? "No narrative available.",
+    topTools,
+    loops: (trace.summary.loops ?? []).map((l) => ({ tool: l.tool, count: l.count })),
+    spanKindDistribution: kindDist,
+    avgGenerationLatency: avgGenLatency,
+  }
+}
+
+export function summarizeTraces(traces: TraceFile[]): {
+  count: number
+  totalTokens: number
+  totalCost: number
+  totalDuration: number
+  avgDuration: number
+  avgTokens: number
+  avgCost: number
+  successRate: number
+  summaries: TraceSummaryReport[]
+} {
+  const summaries = traces.map(summarizeTrace)
+  const totalTokens = traces.reduce((s, t) => s + t.summary.totalTokens, 0)
+  const totalCost = traces.reduce((s, t) => s + t.summary.totalCost, 0)
+  const totalDuration = traces.reduce((s, t) => s + t.summary.duration, 0)
+  const completed = traces.filter((t) => t.summary.status === "completed").length
+
+  return {
+    count: traces.length,
+    totalTokens,
+    totalCost,
+    totalDuration,
+    avgDuration: traces.length ? totalDuration / traces.length : 0,
+    avgTokens: traces.length ? totalTokens / traces.length : 0,
+    avgCost: traces.length ? totalCost / traces.length : 0,
+    successRate: traces.length ? completed / traces.length : 0,
+    summaries,
+  }
+}
+
+export function printTraceSummary(report: TraceSummaryReport): void {
+  console.log("")
+  console.log(`  Session: "${report.title}"`)
+  console.log("  " + "─".repeat(50))
+  console.log(`  Duration:     ${report.duration}`)
+  console.log(`  Model:        ${report.model}`)
+  console.log(`  Agent:        ${report.agent}`)
+  console.log(`  Status:       ${report.status}`)
+  console.log(`  Tokens:       ${report.totalTokens.toLocaleString()} (in: ${report.tokensBreakdown.input.toLocaleString()} / out: ${report.tokensBreakdown.output.toLocaleString()}${report.tokensBreakdown.cacheRead ? ` / cache: ${report.tokensBreakdown.cacheRead.toLocaleString()}` : ""})`)
+  console.log(`  Cost:         $${report.totalCost.toFixed(4)}`)
+  console.log(`  Tools:        ${report.topTools.map((t) => `${t.name}(${t.count})`).join(" ") || "none"}`)
+  console.log(`  Generations:  ${report.generations}`)
+  if (report.loops.length) {
+    console.log(`  Loops:        ${report.loops.map((l) => `${l.tool} (${l.count}x)`).join(", ")}`)
+  }
+  console.log("")
+  if (report.narrative) {
+    console.log(`  ${report.narrative}`)
+    console.log("")
+  }
+}

--- a/packages/trace-manager/src/traces.ts
+++ b/packages/trace-manager/src/traces.ts
@@ -1,0 +1,50 @@
+import fs from "fs/promises"
+import path from "path"
+import os from "os"
+import type { TraceFile } from "./types"
+
+export const DEFAULT_TRACES_DIR = path.join(
+  os.homedir(),
+  ".local/share/altimate-code/traces",
+)
+
+export function getTracesDir(): string {
+  return process.env.TRACES_DIR ?? DEFAULT_TRACES_DIR
+}
+
+export async function loadAllTraces(dir?: string): Promise<TraceFile[]> {
+  const tracesDir = dir ?? getTracesDir()
+  const files = await fs.readdir(tracesDir).catch(() => [])
+  const jsonFiles = (files as string[]).filter(
+    (f) => f.endsWith(".json") && !f.startsWith("."),
+  )
+  const traces: TraceFile[] = []
+  for (const file of jsonFiles) {
+    const content = await fs
+      .readFile(path.join(tracesDir, file), "utf-8")
+      .catch(() => null)
+    if (!content) continue
+    try {
+      const trace = JSON.parse(content) as TraceFile
+      if (trace.version === 2 && trace.sessionId) traces.push(trace)
+    } catch {}
+  }
+  traces.sort(
+    (a, b) =>
+      new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+  )
+  return traces
+}
+
+export async function loadTrace(
+  sessionId: string,
+  dir?: string,
+): Promise<TraceFile | null> {
+  const traces = await loadAllTraces(dir)
+  return (
+    traces.find(
+      (t) =>
+        t.sessionId === sessionId || t.sessionId.startsWith(sessionId),
+    ) ?? null
+  )
+}

--- a/packages/trace-manager/src/types.ts
+++ b/packages/trace-manager/src/types.ts
@@ -1,0 +1,82 @@
+export interface TraceFile {
+  version: number
+  traceId: string
+  sessionId: string
+  startedAt: string
+  endedAt?: string
+  metadata: {
+    title?: string
+    model?: string
+    providerId?: string
+    agent?: string
+    userId?: string
+    prompt?: string
+    environment?: string
+    version?: string
+    tags?: string[]
+  }
+  spans: TraceSpan[]
+  summary: TraceSummary
+}
+
+export interface TraceSpan {
+  spanId: string
+  parentSpanId?: string | null
+  name: string
+  kind: string
+  startTime?: number
+  endTime?: number
+  status?: string
+  model?: { modelId?: string; providerId?: string } | string
+  finishReason?: string
+  tokens?: { input?: number; output?: number; reasoning?: number; total?: number; cacheRead?: number; cacheWrite?: number }
+  cost?: number
+  input?: string
+  output?: string
+  attributes?: Record<string, unknown>
+  tool?: { callId?: string; durationMs?: number }
+}
+
+export interface TraceSummary {
+  totalTokens: number
+  totalCost: number
+  totalToolCalls: number
+  totalGenerations: number
+  duration: number
+  status: string
+  error?: string
+  tokens: { input: number; output: number; reasoning: number; cacheRead: number; cacheWrite: number }
+  loops?: Array<{ tool: string; inputHash?: string; count: number; description: string }>
+  narrative?: string
+  topTools?: Array<{ name: string; count: number; totalDuration: number }>
+}
+
+export type PIICategory = "email" | "api_key" | "ip_address" | "file_path" | "name" | "phone" | "ssn" | "credit_card"
+export type PIIAction = "redact" | "hash" | "allow"
+
+export interface PIIFinding {
+  category: PIICategory
+  match: string
+  start: number
+  end: number
+  field: string
+  spanId?: string
+}
+
+export interface TraceManagerConfig {
+  version: 1
+  consent: {
+    acceptedAt: string
+    piiCategories: Partial<Record<PIICategory, PIIAction>>
+    customPatterns: Array<{ name: string; regex: string; action: PIIAction }>
+    autoPublish: boolean
+    autoIngest: boolean
+    retentionDays: number
+  }
+  publish: {
+    endpoints: Array<{ name: string; url: string; headers?: Record<string, string> }>
+  }
+  lake: {
+    path: string
+  }
+}

--- a/packages/trace-manager/src/web/dashboard-ui.ts
+++ b/packages/trace-manager/src/web/dashboard-ui.ts
@@ -1,0 +1,418 @@
+export function renderDashboardHTML(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Trace Manager — Altimate Code</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<script src="https://d3js.org/d3.v7.min.js"></script>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+body{font-family:'Inter',system-ui,sans-serif}
+.card{transition:transform .15s,box-shadow .15s}.card:hover{transform:translateY(-1px);box-shadow:0 4px 12px rgba(0,0,0,.08)}
+.bar{transition:width .6s ease}
+tr.clickable{cursor:pointer}tr.clickable:hover{background:#f9fafb}
+.heatmap-cell{border-radius:2px}
+.graph-node{cursor:pointer}.graph-link{stroke:#94a3b8;stroke-opacity:.6}
+.tooltip{position:absolute;background:#1f2937;color:#fff;padding:6px 10px;border-radius:6px;font-size:12px;pointer-events:none;z-index:50}
+.sev-critical{background:#fef2f2;border-color:#fca5a5;color:#991b1b}
+.sev-high{background:#fff7ed;border-color:#fdba74;color:#9a3412}
+.sev-warning{background:#fffbeb;border-color:#fcd34d;color:#92400e}
+.sev-medium{background:#fffbeb;border-color:#fcd34d;color:#92400e}
+.sev-info{background:#eff6ff;border-color:#93c5fd;color:#1e40af}
+.sev-low{background:#f0fdf4;border-color:#86efac;color:#166534}
+.sev-positive{background:#f0fdf4;border-color:#86efac;color:#166534}
+.sev-badge{padding:2px 8px;border-radius:9999px;font-size:11px;font-weight:600;text-transform:uppercase}
+.sev-badge-critical{background:#fee2e2;color:#991b1b}.sev-badge-high{background:#ffedd5;color:#9a3412}
+.sev-badge-warning{background:#fef3c7;color:#92400e}.sev-badge-medium{background:#fef3c7;color:#92400e}
+.sev-badge-info{background:#dbeafe;color:#1e40af}.sev-badge-low{background:#dcfce7;color:#166534}
+.sev-badge-positive{background:#dcfce7;color:#166534}
+.topic-tag{display:inline-block;padding:2px 8px;border-radius:4px;font-size:11px;font-weight:500;background:#e0e7ff;color:#3730a3;margin-right:4px}
+.timeline-bar{height:20px;border-radius:4px;position:absolute;min-width:2px;opacity:0.85}
+.timeline-bar:hover{opacity:1;box-shadow:0 0 0 2px rgba(99,102,241,.5)}
+.back-btn{cursor:pointer;display:inline-flex;align-items:center;gap:4px;color:#6366f1;font-size:13px;font-weight:500}
+.back-btn:hover{color:#4f46e5}
+</style>
+</head>
+<body class="bg-gray-50 min-h-screen">
+<div class="flex min-h-screen">
+
+<nav class="w-56 bg-gray-900 text-gray-300 flex flex-col flex-shrink-0 fixed h-full z-10">
+  <div class="px-5 py-5 border-b border-gray-700">
+    <h1 class="text-white text-lg font-bold tracking-tight">Trace Manager</h1>
+    <p class="text-xs text-gray-500 mt-0.5">altimate-code</p>
+  </div>
+  <div class="flex-1 py-4 space-y-0.5" id="sidebar-nav"></div>
+  <div class="px-5 py-4 border-t border-gray-700">
+    <div id="lake-status" class="text-xs text-gray-500"></div>
+    <p class="text-xs text-gray-600 mt-1">v0.1.0</p>
+  </div>
+</nav>
+
+<main class="flex-1 ml-56 overflow-auto">
+  <div class="max-w-6xl mx-auto px-6 py-6" id="main-content"></div>
+</main>
+</div>
+
+<script>
+const API=location.pathname.indexOf('/trace-manager')===0?'/trace-manager':'';
+const PAGES=[
+  {id:'dashboard',label:'Dashboard',icon:'M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z'},
+  {id:'traces',label:'Traces',icon:'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2'},
+  {id:'insights',label:'Insights',icon:'M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z'},
+  {id:'issues',label:'Issues',icon:'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z'},
+  {id:'conversations',label:'Conversations',icon:'M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z'},
+  {id:'users',label:'Users',icon:'M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z'},
+  {id:'graph',label:'Knowledge Graph',icon:'M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1'},
+];
+
+let currentPage='dashboard';
+document.getElementById('sidebar-nav').innerHTML=PAGES.map(p=>
+  '<a href="#" onclick="switchPage(\\''+p.id+'\\');return false" id="nav-'+p.id+'" class="flex items-center gap-3 px-5 py-2.5 text-sm hover:bg-gray-800 hover:text-white transition nav-link'+(p.id==='dashboard'?' bg-gray-800 text-white':'')+'"><svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="'+p.icon+'"/></svg>'+p.label+'</a>'
+).join('');
+
+function switchPage(id){
+  document.querySelectorAll('.nav-link').forEach(el=>{el.classList.remove('bg-gray-800','text-white');el.classList.add('text-gray-400')});
+  const nav=document.getElementById('nav-'+id);if(nav){nav.classList.add('bg-gray-800','text-white');nav.classList.remove('text-gray-400')}
+  currentPage=id;
+  const loaders={dashboard:loadDashboard,traces:loadTraces,insights:loadInsights,issues:loadIssues,conversations:loadConversations,users:loadUsers,graph:()=>loadGraphPicker()};
+  (loaders[id]||loaders.dashboard)();
+}
+
+// ── Helpers ──
+const $=id=>document.getElementById(id);
+const fmtD=ms=>{if(!ms||ms<=0)return'0s';if(ms<1000)return ms+'ms';if(ms<60000)return(ms/1000).toFixed(1)+'s';const m=Math.floor(ms/60000),s=Math.floor((ms%60000)/1000);return m+'m'+(s?s+'s':'')};
+const fmtC=c=>(!c||c===0)?'$0.00':c<.01?'$'+c.toFixed(4):'$'+c.toFixed(2);
+const fmtT=n=>{if(!n)return'0';if(n>=1e6)return(n/1e6).toFixed(1)+'M';if(n>=1e3)return(n/1e3).toFixed(1)+'K';return String(n)};
+const fmtTime=iso=>{const d=Date.now()-new Date(iso).getTime();if(d<6e4)return'just now';if(d<36e5)return Math.floor(d/6e4)+'m ago';if(d<864e5)return Math.floor(d/36e5)+'h ago';return Math.floor(d/864e5)+'d ago'};
+const fmtDate=iso=>{const d=new Date(iso);return(d.getMonth()+1).toString().padStart(2,'0')+'/'+d.getDate().toString().padStart(2,'0')+' '+d.getHours().toString().padStart(2,'0')+':'+d.getMinutes().toString().padStart(2,'0')};
+const badge=s=>{const c={completed:'bg-green-100 text-green-700',ok:'bg-green-100 text-green-700',error:'bg-red-100 text-red-700',crashed:'bg-red-100 text-red-700',running:'bg-yellow-100 text-yellow-700'};return'<span class="px-2 py-0.5 rounded-full text-xs font-medium '+(c[s]||'bg-gray-100 text-gray-600')+'">'+s+'</span>'};
+const mCard=(l,v,sub)=>'<div class="bg-white rounded-lg border p-4 card"><p class="text-xs font-medium text-gray-500 uppercase tracking-wide">'+l+'</p><p class="text-2xl font-bold text-gray-900 mt-1">'+v+'</p>'+(sub?'<p class="text-xs text-gray-400 mt-1">'+sub+'</p>':'')+'</div>';
+const hBar=(items,max)=>{if(!items.length)return'<p class="text-sm text-gray-400">No data</p>';const mx=max||Math.max(...items.map(i=>i.value));return items.map(i=>{const pct=mx?Math.round(i.value/mx*100):0;return'<div class="flex items-center gap-3 mb-2"><span class="text-xs text-gray-600 w-28 text-right shrink-0">'+i.label+'</span><div class="flex-1 bg-gray-100 rounded-full h-5 overflow-hidden"><div class="h-full rounded-full bar '+(i.color||'bg-indigo-500')+'" style="width:'+pct+'%"></div></div><span class="text-xs text-gray-500 w-20 shrink-0">'+i.display+'</span></div>'}).join('')};
+const sevBadge=s=>'<span class="sev-badge sev-badge-'+s+'">'+s+'</span>';
+const render=h=>{document.getElementById('main-content').innerHTML=h};
+
+// ══════════════════════════════════════════════════════
+// DASHBOARD — insights-driven, not just stats
+// ══════════════════════════════════════════════════════
+async function loadDashboard(){
+  const[ov,insights]=await Promise.all([fetch(API+'/api/analytics/overview').then(r=>r.json()),fetch(API+'/api/insights').then(r=>r.json())]);
+  let h='<h2 class="text-xl font-semibold text-gray-800 mb-5">Dashboard</h2>';
+  h+='<div class="grid grid-cols-4 gap-4 mb-6">'+mCard('Sessions',ov.totalSessions)+mCard('Total Tokens',fmtT(ov.totalTokens))+mCard('Total Cost',fmtC(ov.totalCost))+mCard('Tool Calls',ov.totalTools.toLocaleString())+'</div>';
+
+  // Insights section — the star of the show
+  if(insights.length){
+    h+='<div class="mb-6"><h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide mb-3">Key Insights</h3>';
+    for(const ins of insights.slice(0,6)){
+      h+='<div class="border rounded-lg p-4 mb-3 sev-'+ins.severity+' card"><div class="flex items-start justify-between">'
+        +'<div class="flex-1"><div class="flex items-center gap-2 mb-1">'+sevBadge(ins.severity)+'<span class="text-xs font-medium text-gray-500">'+ins.category+'</span></div>'
+        +'<p class="font-semibold text-sm">'+ins.title+'</p>'
+        +'<p class="text-xs mt-1 opacity-80">'+ins.description+'</p>'
+        +'<p class="text-xs mt-2 font-medium">Recommendation: <span class="font-normal">'+ins.recommendation+'</span></p>'
+        +'</div>';
+      if(ins.metric)h+='<div class="text-right ml-4 shrink-0"><p class="text-xs text-gray-500">'+ins.metric.label+'</p><p class="text-lg font-bold">'+ins.metric.value+'</p></div>';
+      h+='</div></div>';
+    }
+    h+='</div>';
+  }
+
+  h+='<div class="grid grid-cols-2 gap-6">';
+  h+='<div class="bg-white rounded-lg border p-5 card"><h3 class="text-sm font-medium text-gray-500 mb-3">Recent Sessions</h3>'+
+    ov.recentSessions.map(s=>'<div class="flex items-center justify-between py-2 border-b border-gray-50 last:border-0 clickable" onclick="openTraceDetail(\\''+s.sessionId+'\\')"><div class="flex-1 min-w-0"><p class="text-sm font-medium text-gray-800 truncate">'+s.title+'</p><p class="text-xs text-gray-400">'+fmtD(s.duration)+'</p></div><div class="flex items-center gap-2">'+badge(s.status)+'<span class="text-xs text-gray-400">'+fmtTime(s.startedAt)+'</span></div></div>').join('')+'</div>';
+  h+='<div class="bg-white rounded-lg border p-5 card"><h3 class="text-sm font-medium text-gray-500 mb-3">Cost by Model</h3>'+hBar(Object.entries(ov.costByModel).map(([m,c])=>({label:m.split('/').pop(),value:c,display:fmtC(c),color:'bg-indigo-500'})))+'</div>';
+  h+='</div>';
+  render(h);
+}
+
+// ══════════════════════════════════════════════════════
+// TRACES — double-click opens detail
+// ══════════════════════════════════════════════════════
+async function loadTraces(){
+  const[data,topics]=await Promise.all([fetch(API+'/api/traces').then(r=>r.json()),fetch(API+'/api/topics').then(r=>r.json())]);
+  let h='<h2 class="text-xl font-semibold text-gray-800 mb-2">Traces</h2><p class="text-sm text-gray-500 mb-5">Double-click any row to open detailed review</p>';
+  h+='<div class="flex gap-2 mb-4 flex-wrap">';
+  h+='<button class="px-3 py-1 text-xs rounded-full bg-indigo-100 text-indigo-700 font-medium" onclick="loadTraces()">All ('+data.total+')</button>';
+  for(const t of topics.slice(0,6))h+='<span class="topic-tag">'+t.topic+' ('+t.count+')</span>';
+  h+='</div>';
+  h+='<div class="bg-white rounded-lg border overflow-hidden"><table class="w-full text-sm"><thead><tr class="text-left text-xs text-gray-500 uppercase tracking-wide border-b bg-gray-50">'
+    +'<th class="py-2.5 px-4">Date</th><th class="py-2.5 px-2">Status</th><th class="py-2.5 px-2">Duration</th>'
+    +'<th class="py-2.5 px-2">Tokens</th><th class="py-2.5 px-2">Cost</th><th class="py-2.5 px-2">Tools</th><th class="py-2.5 px-2">Title</th></tr></thead><tbody>';
+  for(const t of data.traces){
+    const tools=(t.topTools||[]).map(tt=>tt.name+'('+tt.count+')').join(' ');
+    h+='<tr class="clickable border-b border-gray-50" ondblclick="openTraceDetail(\\''+t.sessionId+'\\')"><td class="py-3 px-4 text-gray-500">'+fmtDate(t.startedAt)+'</td><td class="py-3 px-2">'+badge(t.status)+'</td><td class="py-3 px-2 text-gray-700 font-medium">'+fmtD(t.duration)+'</td><td class="py-3 px-2 text-gray-600">'+fmtT(t.totalTokens)+'</td><td class="py-3 px-2 text-gray-600">'+fmtC(t.totalCost)+'</td><td class="py-3 px-2 text-gray-500 text-xs">'+(tools||'-')+'</td><td class="py-3 px-2 text-gray-800 font-medium truncate max-w-xs">'+(t.title||t.sessionId)+'</td></tr>';
+  }
+  h+='</tbody></table></div>';
+  render(h);
+}
+
+// ══════════════════════════════════════════════════════
+// TRACE DETAIL — full review page
+// ══════════════════════════════════════════════════════
+async function openTraceDetail(sid){
+  render('<p class="text-gray-400">Loading trace detail...</p>');
+  const d=await fetch(API+'/api/traces/'+sid+'/detail').then(r=>r.json());
+  let h='<div class="back-btn mb-4" onclick="switchPage(\\'traces\\')"><svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg> Back to Traces</div>';
+  h+='<div class="flex items-start justify-between mb-5"><div><h2 class="text-xl font-semibold text-gray-800">'+(d.metadata.title||d.sessionId)+'</h2>';
+  h+='<div class="flex items-center gap-2 mt-1">'+badge(d.summary.status);
+  for(const t of d.topics)h+='<span class="topic-tag">'+t+'</span>';
+  h+='<span class="text-xs text-gray-400">'+fmtDate(d.metadata.startedAt||d.summary.startedAt||'')+'</span></div>';
+  h+='</div><div class="text-right">';
+  h+='<button onclick="viewGraph(\\''+sid+'\\');return false" class="px-3 py-1.5 text-xs rounded bg-indigo-600 text-white hover:bg-indigo-700 mr-2">Knowledge Graph</button>';
+  h+='<button onclick="viewPII(\\''+sid+'\\');return false" class="px-3 py-1.5 text-xs rounded bg-amber-600 text-white hover:bg-amber-700">PII Review</button>';
+  h+='</div></div>';
+
+  // Summary cards
+  h+='<div class="grid grid-cols-5 gap-3 mb-6">';
+  h+=mCard('Duration',fmtD(d.summary.duration));
+  h+=mCard('Tokens',fmtT(d.summary.totalTokens),'in='+fmtT(d.summary.tokens?.input)+' out='+fmtT(d.summary.tokens?.output));
+  h+=mCard('Cost',fmtC(d.summary.totalCost));
+  h+=mCard('Tools',d.summary.totalToolCalls);
+  h+=mCard('Generations',d.summary.totalGenerations);
+  h+='</div>';
+
+  // Narrative
+  if(d.summary.narrative){
+    h+='<div class="bg-white rounded-lg border p-4 mb-6"><h3 class="text-sm font-medium text-gray-500 mb-2">Narrative</h3><p class="text-sm text-gray-700 leading-relaxed">'+d.summary.narrative+'</p></div>';
+  }
+
+  // Alerts (loops, PII, errors)
+  const alerts=[];
+  if(d.summary.loops&&d.summary.loops.length)alerts.push({sev:'critical',msg:'Doom loop detected: '+d.summary.loops.map(l=>l.tool+' ('+l.count+'x)').join(', ')});
+  if(d.piiCount>0)alerts.push({sev:'warning',msg:d.piiCount+' PII item(s) detected in this trace'});
+  const errorSpans=d.spans.filter(s=>s.status==='error');
+  if(errorSpans.length)alerts.push({sev:'high',msg:errorSpans.length+' tool error(s): '+errorSpans.map(s=>s.name).join(', ')});
+  if(alerts.length){
+    h+='<div class="mb-6 space-y-2">';
+    for(const a of alerts)h+='<div class="border rounded-lg px-4 py-2.5 sev-'+a.sev+' text-sm flex items-center gap-2">'+sevBadge(a.sev)+a.msg+'</div>';
+    h+='</div>';
+  }
+
+  // Timeline waterfall
+  h+='<div class="bg-white rounded-lg border p-4 mb-6"><h3 class="text-sm font-medium text-gray-500 mb-3">Span Timeline</h3>';
+  const validSpans=d.spans.filter(s=>s.startTime&&s.endTime);
+  if(validSpans.length){
+    const minTime=Math.min(...validSpans.map(s=>s.startTime));
+    const maxTime=Math.max(...validSpans.map(s=>s.endTime));
+    const totalRange=maxTime-minTime||1;
+    const kindColors={session:'#6366f1',generation:'#3b82f6',tool:'#10b981',text:'#6b7280',span:'#a855f7'};
+    h+='<div class="relative" style="height:'+(validSpans.length*28+10)+'px">';
+    validSpans.forEach((s,i)=>{
+      const left=((s.startTime-minTime)/totalRange*100).toFixed(2);
+      const width=Math.max(0.5,((s.endTime-s.startTime)/totalRange*100)).toFixed(2);
+      const color=kindColors[s.kind]||'#94a3b8';
+      const errorBorder=s.status==='error'?'border:2px solid #ef4444;':'';
+      h+='<div class="timeline-bar" style="top:'+(i*28)+'px;left:'+left+'%;width:'+width+'%;background:'+color+';'+errorBorder+'" title="'+s.name+' ('+s.kind+') '+fmtD(s.duration||0)+'"></div>';
+      h+='<span class="absolute text-[10px] text-gray-500 truncate" style="top:'+(i*28+3)+'px;left:calc('+left+'% + '+width+'% + 6px);max-width:200px">'+s.name.slice(0,30)+(s.duration?' '+fmtD(s.duration):'')+'</span>';
+    });
+    h+='</div>';
+    h+='<div class="flex gap-4 mt-3 text-xs text-gray-500">';
+    Object.entries(kindColors).forEach(([k,c])=>h+='<div class="flex items-center gap-1"><div class="w-3 h-3 rounded" style="background:'+c+'"></div>'+k+'</div>');
+    h+='</div>';
+  } else h+='<p class="text-sm text-gray-400">No timing data available</p>';
+  h+='</div>';
+
+  // Spans table
+  h+='<div class="bg-white rounded-lg border overflow-hidden"><h3 class="text-sm font-medium text-gray-500 p-4 pb-0">Spans ('+d.spans.length+')</h3>';
+  h+='<table class="w-full text-xs mt-2"><thead><tr class="text-left text-xs text-gray-500 uppercase tracking-wide border-b bg-gray-50">'
+    +'<th class="py-2 px-3">Kind</th><th class="py-2 px-3">Name</th><th class="py-2 px-3">Status</th><th class="py-2 px-3">Duration</th><th class="py-2 px-3">Tokens</th><th class="py-2 px-3">Preview</th></tr></thead><tbody>';
+  for(const s of d.spans){
+    const kindBg={generation:'bg-blue-50 text-blue-700',tool:'bg-green-50 text-green-700',session:'bg-indigo-50 text-indigo-700',text:'bg-gray-50 text-gray-600',span:'bg-purple-50 text-purple-700'};
+    h+='<tr class="border-b border-gray-50 hover:bg-gray-50"><td class="py-2 px-3"><span class="px-1.5 py-0.5 rounded text-[10px] font-medium '+(kindBg[s.kind]||'bg-gray-100')+'">'+s.kind+'</span></td>'
+      +'<td class="py-2 px-3 font-medium text-gray-700 truncate max-w-[200px]">'+s.name+'</td>'
+      +'<td class="py-2 px-3">'+(s.status==='error'?'<span class="text-red-600 font-medium">error</span>':'<span class="text-green-600">ok</span>')+'</td>'
+      +'<td class="py-2 px-3 text-gray-600">'+(s.duration?fmtD(s.duration):'-')+'</td>'
+      +'<td class="py-2 px-3 text-gray-600">'+(s.tokens?fmtT((s.tokens.input||0)+(s.tokens.output||0)):'-')+'</td>'
+      +'<td class="py-2 px-3 text-gray-400 truncate max-w-[300px]">'+(s.inputPreview||s.outputPreview||'-')+'</td></tr>';
+  }
+  h+='</tbody></table></div>';
+  render(h);
+}
+
+// ══════════════════════════════════════════════════════
+// INSIGHTS — actionable intelligence
+// ══════════════════════════════════════════════════════
+async function loadInsights(){
+  const insights=await fetch(API+'/api/insights').then(r=>r.json());
+  let h='<h2 class="text-xl font-semibold text-gray-800 mb-2">Insights</h2><p class="text-sm text-gray-500 mb-5">Actionable intelligence from your trace data — not just numbers</p>';
+  if(!insights.length){h+='<div class="bg-green-50 border border-green-200 rounded-lg p-6 text-center"><p class="text-green-700 font-medium">No insights yet</p><p class="text-sm text-green-600 mt-1">Run more sessions to generate insights.</p></div>';render(h);return}
+
+  const bySev={critical:[],warning:[],info:[],positive:[]};
+  for(const i of insights)(bySev[i.severity]||bySev.info).push(i);
+
+  for(const[sev,items] of Object.entries(bySev)){
+    if(!items.length)continue;
+    const label={critical:'Critical',warning:'Warnings',info:'Informational',positive:'Positive Signals'}[sev]||sev;
+    h+='<h3 class="text-sm font-semibold text-gray-600 uppercase tracking-wide mt-6 mb-3">'+label+' ('+items.length+')</h3>';
+    for(const ins of items){
+      h+='<div class="border rounded-lg p-5 mb-3 sev-'+sev+' card"><div class="flex items-start justify-between">';
+      h+='<div class="flex-1"><div class="flex items-center gap-2 mb-2">'+sevBadge(sev)+'<span class="text-xs font-medium text-gray-500 bg-white/60 px-2 py-0.5 rounded">'+ins.category+'</span></div>';
+      h+='<p class="font-semibold text-sm mb-1">'+ins.title+'</p>';
+      h+='<p class="text-xs opacity-80 mb-3">'+ins.description+'</p>';
+      if(ins.evidence.length){
+        h+='<details class="mb-2"><summary class="text-xs font-medium cursor-pointer hover:underline">Evidence ('+ins.evidence.length+')</summary><ul class="mt-1 text-xs opacity-70 space-y-0.5 ml-4 list-disc">';
+        for(const e of ins.evidence.slice(0,5))h+='<li>'+e+'</li>';
+        h+='</ul></details>';
+      }
+      h+='<div class="bg-white/50 rounded p-2 mt-2"><p class="text-xs"><span class="font-semibold">Recommendation:</span> '+ins.recommendation+'</p></div>';
+      if(ins.affectedSessions.length)h+='<p class="text-[10px] text-gray-400 mt-2">Affects '+ins.affectedSessions.length+' session(s)</p>';
+      h+='</div>';
+      if(ins.metric)h+='<div class="text-right ml-6 shrink-0 bg-white/40 rounded-lg p-3"><p class="text-[10px] text-gray-500 uppercase tracking-wide">'+ins.metric.label+'</p><p class="text-xl font-bold mt-0.5">'+ins.metric.value+'</p>'+(ins.metric.trend?'<p class="text-xs">'+(ins.metric.trend==='up'?'↑':'↓')+'</p>':'')+'</div>';
+      h+='</div></div>';
+    }
+  }
+  render(h);
+}
+
+// ══════════════════════════════════════════════════════
+// ISSUES — admin view of recurring problems
+// ══════════════════════════════════════════════════════
+async function loadIssues(){
+  const data=await fetch(API+'/api/issues').then(r=>r.json());
+  let h='<h2 class="text-xl font-semibold text-gray-800 mb-2">Issues</h2><p class="text-sm text-gray-500 mb-5">Frequently occurring problems across all users — auto-classified by severity</p>';
+
+  if(!data.issues.length){h+='<div class="bg-green-50 border border-green-200 rounded-lg p-6 text-center"><p class="text-green-700 font-medium">No issues detected</p></div>';render(h);return}
+
+  // Summary strip
+  const counts={critical:0,high:0,medium:0,low:0};
+  for(const iss of data.issues)counts[iss.severity]=(counts[iss.severity]||0)+1;
+  h+='<div class="grid grid-cols-4 gap-3 mb-6">';
+  h+='<div class="bg-red-50 border border-red-200 rounded-lg p-3 text-center"><p class="text-2xl font-bold text-red-700">'+counts.critical+'</p><p class="text-xs text-red-600">Critical</p></div>';
+  h+='<div class="bg-orange-50 border border-orange-200 rounded-lg p-3 text-center"><p class="text-2xl font-bold text-orange-700">'+counts.high+'</p><p class="text-xs text-orange-600">High</p></div>';
+  h+='<div class="bg-yellow-50 border border-yellow-200 rounded-lg p-3 text-center"><p class="text-2xl font-bold text-yellow-700">'+counts.medium+'</p><p class="text-xs text-yellow-600">Medium</p></div>';
+  h+='<div class="bg-green-50 border border-green-200 rounded-lg p-3 text-center"><p class="text-2xl font-bold text-green-700">'+counts.low+'</p><p class="text-xs text-green-600">Low</p></div>';
+  h+='</div>';
+
+  for(const iss of data.issues){
+    h+='<div class="border rounded-lg mb-4 overflow-hidden sev-'+iss.severity+'">';
+    h+='<div class="p-4"><div class="flex items-start justify-between">';
+    h+='<div class="flex-1"><div class="flex items-center gap-2 mb-1">'+sevBadge(iss.severity)+'<span class="topic-tag">'+iss.topic.replace('_',' ')+'</span><span class="text-xs text-gray-400">'+iss.frequency+' occurrence(s)</span></div>';
+    h+='<p class="font-semibold text-sm">'+iss.title+'</p>';
+    h+='<p class="text-xs opacity-80 mt-1">'+iss.description+'</p>';
+    h+='</div>';
+    h+='<div class="text-right ml-4 shrink-0"><p class="text-xs text-gray-500">Affected users</p><p class="text-lg font-bold">'+iss.affectedUsers.length+'</p><p class="text-[10px] text-gray-400">'+iss.affectedUsers.join(', ')+'</p></div>';
+    h+='</div>';
+
+    h+='<div class="bg-white/50 rounded p-3 mt-3"><p class="text-xs"><span class="font-semibold">Suggested fix:</span> '+iss.suggestedFix+'</p></div>';
+
+    // Occurrences table
+    if(iss.occurrences.length>0){
+      h+='<details class="mt-3"><summary class="text-xs font-medium cursor-pointer hover:underline">Occurrences ('+iss.occurrences.length+')</summary>';
+      h+='<table class="w-full text-xs mt-2"><thead><tr class="border-b"><th class="text-left py-1 pr-2">Session</th><th class="text-left py-1 pr-2">User</th><th class="text-left py-1 pr-2">When</th><th class="text-left py-1">Detail</th></tr></thead><tbody>';
+      for(const occ of iss.occurrences.slice(0,10)){
+        h+='<tr class="border-b border-gray-100 clickable" ondblclick="openTraceDetail(\\''+occ.sessionId+'\\')"><td class="py-1.5 pr-2 text-indigo-600 truncate max-w-[200px]">'+occ.sessionTitle+'</td><td class="py-1.5 pr-2 text-gray-600">'+occ.userId+'</td><td class="py-1.5 pr-2 text-gray-400">'+fmtTime(occ.timestamp)+'</td><td class="py-1.5 text-gray-500 truncate max-w-[250px]">'+occ.detail+'</td></tr>';
+      }
+      h+='</tbody></table></details>';
+    }
+    h+='<p class="text-[10px] text-gray-400 mt-2">First seen: '+fmtDate(iss.firstSeen)+' · Last seen: '+fmtDate(iss.lastSeen)+'</p>';
+    h+='</div></div>';
+  }
+  render(h);
+}
+
+// ══════════════════════════════════════════════════════
+// CONVERSATIONS
+// ══════════════════════════════════════════════════════
+async function loadConversations(){
+  const d=await fetch(API+'/api/analytics/conversations').then(r=>r.json());
+  let h='<h2 class="text-xl font-semibold text-gray-800 mb-5">Conversation Analytics</h2>';
+  h+='<div class="grid grid-cols-4 gap-4 mb-6">'+mCard('Avg Turns',d.avgGenerations.toFixed(1),'generations/session')+mCard('Avg Duration',fmtD(d.avgDuration))+mCard('Avg Tokens',fmtT(d.avgTokens),'per session')+mCard('Success Rate',(d.successRate*100).toFixed(0)+'%',d.completedSessions+' of '+d.totalSessions)+'</div>';
+  h+='<div class="grid grid-cols-2 gap-6 mb-6">';
+  const td=d.turnDistribution,total=Object.values(td).reduce((a,b)=>a+b,0)||1;
+  h+='<div class="bg-white rounded-lg border p-5 card"><h3 class="text-sm font-medium text-gray-500 mb-3">Turn Distribution</h3>'+hBar(Object.entries(td).map(([b,c])=>({label:b+' turns',value:c,display:c+' ('+Math.round(c/total*100)+'%)',color:b==='16+'?'bg-amber-500':'bg-indigo-500'})))+'</div>';
+  h+='<div class="bg-white rounded-lg border p-5 card"><h3 class="text-sm font-medium text-gray-500 mb-3">Tool Chain Patterns</h3>'+(d.topChains.length?hBar(d.topChains.map(c=>({label:c.pattern,value:c.count,display:c.count+'x',color:'bg-violet-500'}))):'<p class="text-sm text-gray-400">Not enough data</p>')+'</div>';
+  h+='</div>';
+  h+='<div class="bg-white rounded-lg border p-5 card"><h3 class="text-sm font-medium text-gray-500 mb-3">Top Tools</h3>'+hBar(d.topTools.map(t=>({label:t.name,value:t.count,display:t.count+' ('+fmtD(t.totalDuration)+')',color:'bg-emerald-500'})))+'</div>';
+  render(h);
+}
+
+// ══════════════════════════════════════════════════════
+// USERS
+// ══════════════════════════════════════════════════════
+async function loadUsers(){
+  const d=await fetch(API+'/api/analytics/users').then(r=>r.json());
+  let h='<h2 class="text-xl font-semibold text-gray-800 mb-5">User Analytics</h2>';
+  h+='<div class="grid grid-cols-4 gap-4 mb-6">'+mCard('Users',d.users.length)+mCard('Avg Sessions/User',d.users.length?(d.users.reduce((s,u)=>s+u.sessions,0)/d.users.length).toFixed(1):'0')+mCard('Avg Cost/User',d.users.length?fmtC(d.users.reduce((s,u)=>s+u.cost,0)/d.users.length):'$0')+mCard('Avg Success',d.users.length?(d.users.reduce((s,u)=>s+u.successRate,0)/d.users.length*100).toFixed(0)+'%':'0%')+'</div>';
+  const days=['Sun','Mon','Tue','Wed','Thu','Fri','Sat'],maxH=Math.max(1,...d.heatmap.flat());
+  let hm='<div class="overflow-x-auto"><table class="text-xs"><tr><td></td>'+Array.from({length:24},(_,i)=>'<td class="text-center text-gray-400 px-0.5 pb-1">'+(i%3===0?i:'')+'</td>').join('')+'</tr>';
+  for(let i=0;i<7;i++){hm+='<tr><td class="text-right text-gray-500 pr-2 py-0.5">'+days[i]+'</td>';for(let j=0;j<24;j++){const v=d.heatmap[i][j],int=v/maxH,bg=v===0?'#f3f4f6':int<.33?'#c7d2fe':int<.66?'#818cf8':'#4f46e5';hm+='<td class="px-0.5 py-0.5"><div class="heatmap-cell w-4 h-4" style="background:'+bg+'" title="'+days[i]+' '+j+':00 — '+v+'"></div></td>'}hm+='</tr>'}
+  hm+='</table></div>';
+  h+='<div class="bg-white rounded-lg border p-5 card mb-6"><h3 class="text-sm font-medium text-gray-500 mb-3">Activity Heatmap</h3>'+hm+'</div>';
+  h+='<div class="bg-white rounded-lg border p-5 card"><h3 class="text-sm font-medium text-gray-500 mb-3">User Breakdown</h3><table class="w-full text-sm"><thead><tr class="text-left text-xs text-gray-500 uppercase tracking-wide border-b"><th class="pb-2 pr-3">User</th><th class="pb-2 pr-3">Sessions</th><th class="pb-2 pr-3">Tokens</th><th class="pb-2 pr-3">Cost</th><th class="pb-2 pr-3">Success</th><th class="pb-2">Fav Tool</th></tr></thead><tbody>';
+  for(const u of d.users)h+='<tr class="border-b border-gray-50"><td class="py-2.5 pr-3 font-medium text-gray-800">'+u.userId+'</td><td class="py-2.5 pr-3 text-gray-600">'+u.sessions+'</td><td class="py-2.5 pr-3 text-gray-600">'+fmtT(u.tokens)+'</td><td class="py-2.5 pr-3 text-gray-600">'+fmtC(u.cost)+'</td><td class="py-2.5 pr-3">'+(u.successRate*100).toFixed(0)+'%</td><td class="py-2.5 text-gray-500">'+u.topTool+'</td></tr>';
+  h+='</tbody></table></div>';
+  render(h);
+}
+
+// ══════════════════════════════════════════════════════
+// PII REVIEW
+// ══════════════════════════════════════════════════════
+async function viewPII(sid){
+  const[pii,trace]=await Promise.all([fetch(API+'/api/pii/preview/'+sid).then(r=>r.json()),fetch(API+'/api/traces/'+sid).then(r=>r.json())]);
+  let h='<div class="back-btn mb-4" onclick="switchPage(\\'traces\\')"><svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg> Back</div>';
+  h+='<h2 class="text-xl font-semibold text-gray-800 mb-5">PII Review — '+(trace.metadata?.title||sid)+'</h2>';
+  if(!pii.findings.length){h+='<div class="bg-green-50 border border-green-200 rounded-lg p-4"><p class="text-green-700 font-medium">No PII detected</p></div>';render(h);return}
+  h+='<div class="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-4"><p class="text-amber-800 font-medium">'+pii.total+' PII item(s) detected</p></div>';
+  h+='<div class="bg-white rounded-lg border divide-y">';
+  for(const f of pii.findings){const ac={redact:'bg-red-100 text-red-700',hash:'bg-yellow-100 text-yellow-700',allow:'bg-green-100 text-green-700'};h+='<div class="p-4 flex items-center justify-between"><div><span class="text-xs font-medium uppercase tracking-wide text-gray-500">'+f.category+'</span><p class="text-sm text-gray-800 mt-1 font-mono">'+f.preview+'</p><p class="text-xs text-gray-400 mt-0.5">'+f.field+'</p></div><span class="px-2 py-1 rounded text-xs font-medium '+(ac[f.action]||'bg-gray-100')+'">'+f.action+'</span></div>'}
+  h+='</div>';render(h);
+}
+
+// ══════════════════════════════════════════════════════
+// KNOWLEDGE GRAPH
+// ══════════════════════════════════════════════════════
+let graphSim=null;
+async function loadGraphPicker(){
+  const data=await fetch(API+'/api/traces').then(r=>r.json());
+  let h='<h2 class="text-xl font-semibold text-gray-800 mb-2">Knowledge Graph</h2><p class="text-sm text-gray-500 mb-5">Select a trace to visualize</p>';
+  h+='<div class="grid grid-cols-2 gap-3">';
+  for(const t of data.traces.slice(0,12)){
+    h+='<div class="bg-white rounded-lg border p-4 card clickable" ondblclick="viewGraph(\\''+t.sessionId+'\\')"><div class="flex items-center justify-between"><div><p class="text-sm font-medium text-gray-800">'+(t.title||t.sessionId)+'</p><p class="text-xs text-gray-400">'+fmtD(t.duration)+' · '+t.totalToolCalls+' tools</p></div>'+badge(t.status)+'</div></div>';
+  }
+  h+='</div>';render(h);
+}
+
+async function viewGraph(sid){
+  let h='<div class="back-btn mb-4" onclick="switchPage(\\'graph\\')"><svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg> Back</div>';
+  h+='<h2 class="text-xl font-semibold text-gray-800 mb-2">Knowledge Graph</h2><p class="text-sm text-gray-500 mb-4">Session: '+sid.slice(0,24)+'...</p>';
+  h+='<div class="flex gap-2 mb-4"><button onclick="renderGraphType(\\'spans\\',\\''+sid+'\\',this)" class="px-3 py-1.5 text-sm rounded bg-indigo-600 text-white graph-tab">Span Tree</button><button onclick="renderGraphType(\\'dataflow\\',\\''+sid+'\\',this)" class="px-3 py-1.5 text-sm rounded bg-gray-200 text-gray-700 graph-tab">Data Flow</button><button onclick="renderGraphType(\\'entities\\',\\''+sid+'\\',this)" class="px-3 py-1.5 text-sm rounded bg-gray-200 text-gray-700 graph-tab">Entities</button></div>';
+  h+='<div id="graph-container" class="bg-white rounded-lg border" style="height:500px"></div>';
+  render(h);renderGraphType('spans',sid);
+}
+
+async function renderGraphType(type,sid,btn){
+  if(btn){document.querySelectorAll('.graph-tab').forEach(b=>{b.className='px-3 py-1.5 text-sm rounded bg-gray-200 text-gray-700 graph-tab'});btn.className='px-3 py-1.5 text-sm rounded bg-indigo-600 text-white graph-tab'}
+  const data=await fetch(API+'/api/graph/'+type+'/'+sid).then(r=>r.json());
+  drawGraph(data);
+}
+
+function drawGraph(data){
+  if(graphSim)graphSim.stop();
+  const container=document.getElementById('graph-container');container.innerHTML='';
+  if(!data.nodes.length){container.innerHTML='<p class="text-gray-400 text-sm p-8">No graph data</p>';return}
+  const w=container.clientWidth,h=container.clientHeight||500;
+  const svg=d3.select(container).append('svg').attr('width',w).attr('height',h);
+  const g=svg.append('g');
+  svg.call(d3.zoom().scaleExtent([.2,5]).on('zoom',e=>g.attr('transform',e.transform)));
+  const colors={session:'#6366f1',generation:'#3b82f6',tool:'#10b981',text:'#6b7280',span:'#a855f7',pii:'#ef4444',file:'#f59e0b',function:'#8b5cf6',command:'#06b6d4'};
+  const nodeMap=new Map(data.nodes.map(n=>[n.id,n]));
+  const validEdges=data.edges.filter(e=>nodeMap.has(e.source?.id||e.source)&&nodeMap.has(e.target?.id||e.target));
+  graphSim=d3.forceSimulation(data.nodes).force('link',d3.forceLink(validEdges).id(d=>d.id).distance(80)).force('charge',d3.forceManyBody().strength(-200)).force('center',d3.forceCenter(w/2,h/2)).force('collision',d3.forceCollide().radius(25));
+  const link=g.append('g').selectAll('line').data(validEdges).join('line').attr('class','graph-link').attr('stroke-width',d=>Math.max(1,d.weight||1));
+  const node=g.append('g').selectAll('g').data(data.nodes).join('g').attr('class','graph-node').call(d3.drag().on('start',(e,d)=>{if(!e.active)graphSim.alphaTarget(.3).restart();d.fx=d.x;d.fy=d.y}).on('drag',(e,d)=>{d.fx=e.x;d.fy=e.y}).on('end',(e,d)=>{if(!e.active)graphSim.alphaTarget(0);d.fx=null;d.fy=null}));
+  node.append('circle').attr('r',d=>Math.max(8,Math.min(20,(d.weight||d.duration||1)/100+8))).attr('fill',d=>colors[d.kind||d.type]||'#94a3b8').attr('stroke','#fff').attr('stroke-width',2);
+  node.append('text').text(d=>(d.label||d.name||d.id).slice(0,16)).attr('dy','-12').attr('text-anchor','middle').attr('font-size','10').attr('fill','#374151');
+  const tip=d3.select(container).append('div').attr('class','tooltip').style('display','none');
+  node.on('mouseover',(e,d)=>{tip.style('display','block').html('<strong>'+(d.label||d.name||d.id)+'</strong><br/>Type: '+(d.kind||d.type||'-')+(d.duration?'<br/>'+fmtD(d.duration):'')+(d.tokens?'<br/>'+fmtT(d.tokens)+' tokens':''))}).on('mousemove',e=>{tip.style('left',(e.offsetX+15)+'px').style('top',(e.offsetY-10)+'px')}).on('mouseout',()=>tip.style('display','none'));
+  graphSim.on('tick',()=>{link.attr('x1',d=>d.source.x).attr('y1',d=>d.source.y).attr('x2',d=>d.target.x).attr('y2',d=>d.target.y);node.attr('transform',d=>'translate('+d.x+','+d.y+')')});
+}
+
+// Lake status
+async function checkLake(){const s=await fetch(API+'/api/lake/status').then(r=>r.json()).catch(()=>({connected:false}));document.getElementById('lake-status').innerHTML=s.connected?'<span class="text-green-400">● Lake: '+s.sessions+' sessions</span>':'<span class="text-gray-500">○ Lake: offline</span>'}
+
+// Init
+checkLake();loadDashboard();
+</script>
+</body>
+</html>`
+}

--- a/packages/trace-manager/src/web/ngrok.ts
+++ b/packages/trace-manager/src/web/ngrok.ts
@@ -1,0 +1,43 @@
+export async function startNgrokTunnel(port: number): Promise<string> {
+  try {
+    // @ts-ignore — optional dependency, not installed at dev time
+    const ngrok = await import("@ngrok/ngrok")
+    const listener = await (ngrok as any).default.connect({
+      addr: port,
+      authtoken_from_env: true,
+    })
+    const url = listener.url()
+    return url
+  } catch {
+    // Fallback: try the ngrok CLI binary
+    const proc = Bun.spawn(["ngrok", "http", String(port), "--log=stdout", "--log-format=json"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("ngrok timed out")), 15_000)
+      const reader = proc.stdout.getReader()
+
+      async function readLines() {
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          const text = new TextDecoder().decode(value)
+          for (const line of text.split("\n")) {
+            if (!line.trim()) continue
+            try {
+              const parsed = JSON.parse(line)
+              if (parsed.url) {
+                clearTimeout(timeout)
+                resolve(parsed.url)
+                return
+              }
+            } catch {}
+          }
+        }
+      }
+      readLines().catch(reject)
+    })
+  }
+}

--- a/packages/trace-manager/src/web/server.ts
+++ b/packages/trace-manager/src/web/server.ts
@@ -1,0 +1,459 @@
+import { Hono } from "hono"
+import { cors } from "hono/cors"
+import { loadAllTraces, loadTrace } from "../traces"
+import { detectPIIInTrace } from "../pii/detector"
+import { redactTrace } from "../pii/redactor"
+import { publishTrace } from "../publish/publisher"
+import { summarizeTrace, summarizeTraces } from "../summarize/trace-summarizer"
+import { loadOrCreateConfig, saveConfig } from "../consent/consent-store"
+import { LakeManager } from "../lake/lake-manager"
+import { getConversationAnalytics } from "../analytics/conversations"
+import { getUserAnalytics } from "../analytics/users"
+import type { TraceManagerConfig } from "../types"
+import { generateInsights } from "../analytics/insights"
+import { detectIssues, classifySessionTopic } from "../analytics/issues"
+import { renderDashboardHTML } from "./dashboard-ui"
+
+export async function createApp(options?: { lake?: LakeManager }) {
+  const app = new Hono()
+  app.use("/*", cors())
+
+  let lake = options?.lake ?? null
+  const config = await loadOrCreateConfig()
+
+  async function ensureLake(): Promise<LakeManager> {
+    if (!lake) {
+      lake = await LakeManager.create(config.lake.path)
+    }
+    return lake
+  }
+
+  // ── Traces ──
+
+  app.get("/api/traces", async (c) => {
+    const traces = await loadAllTraces()
+    const summaries = traces.map((t) => ({
+      sessionId: t.sessionId,
+      traceId: t.traceId,
+      title: t.metadata.title ?? t.sessionId,
+      model: t.metadata.model,
+      agent: t.metadata.agent,
+      providerId: t.metadata.providerId,
+      startedAt: t.startedAt,
+      endedAt: t.endedAt,
+      duration: t.summary.duration,
+      status: t.summary.status,
+      totalTokens: t.summary.totalTokens,
+      totalCost: t.summary.totalCost,
+      totalToolCalls: t.summary.totalToolCalls,
+      totalGenerations: t.summary.totalGenerations,
+      narrative: t.summary.narrative,
+      topTools: t.summary.topTools ?? [],
+      loops: t.summary.loops ?? [],
+      tokens: t.summary.tokens,
+    }))
+    return c.json({ traces: summaries, total: summaries.length })
+  })
+
+  app.get("/api/traces/:id", async (c) => {
+    const trace = await loadTrace(c.req.param("id"))
+    if (!trace) return c.json({ error: "not found" }, 404)
+    return c.json(trace)
+  })
+
+  app.get("/api/traces/:id/summary", async (c) => {
+    const trace = await loadTrace(c.req.param("id"))
+    if (!trace) return c.json({ error: "not found" }, 404)
+    return c.json(summarizeTrace(trace))
+  })
+
+  // ── PII ──
+
+  app.get("/api/pii/config", async (c) => {
+    const cfg = await loadOrCreateConfig()
+    return c.json(cfg.consent)
+  })
+
+  app.post("/api/pii/config", async (c) => {
+    const body = await c.req.json()
+    const cfg = await loadOrCreateConfig()
+    if (body.piiCategories) cfg.consent.piiCategories = body.piiCategories
+    if (body.customPatterns) cfg.consent.customPatterns = body.customPatterns
+    await saveConfig(cfg)
+    return c.json({ ok: true })
+  })
+
+  app.get("/api/pii/preview/:id", async (c) => {
+    const trace = await loadTrace(c.req.param("id"))
+    if (!trace) return c.json({ error: "not found" }, 404)
+    const findings = detectPIIInTrace(trace)
+    const cfg = await loadOrCreateConfig()
+    return c.json({
+      findings: findings.map((f) => ({
+        category: f.category,
+        field: f.field,
+        spanId: f.spanId,
+        preview: f.match.slice(0, 3) + "***" + f.match.slice(-2),
+        action: cfg.consent.piiCategories[f.category] ?? "redact",
+      })),
+      total: findings.length,
+    })
+  })
+
+  // ── Publish ──
+
+  app.post("/api/publish/:id", async (c) => {
+    const trace = await loadTrace(c.req.param("id"))
+    if (!trace) return c.json({ error: "not found" }, 404)
+    const cfg = await loadOrCreateConfig()
+    const body = await c.req.json().catch(() => ({}))
+    const endpoint = body.endpoint
+      ? { name: "custom", url: body.endpoint, headers: body.headers }
+      : undefined
+    const result = await publishTrace(trace, cfg, endpoint)
+    return c.json(result)
+  })
+
+  // ── Graph ──
+
+  app.get("/api/graph/spans/:id", async (c) => {
+    const trace = await loadTrace(c.req.param("id"))
+    if (!trace) return c.json({ error: "not found" }, 404)
+
+    const nodes = trace.spans.map((s) => ({
+      id: s.spanId,
+      name: s.name,
+      kind: s.kind,
+      status: s.status,
+      duration: s.startTime && s.endTime ? s.endTime - s.startTime : 0,
+      tokens: s.tokens?.total ?? (s.tokens?.input ?? 0) + (s.tokens?.output ?? 0),
+    }))
+    const edges = trace.spans
+      .filter((s) => s.parentSpanId)
+      .map((s) => ({ source: s.parentSpanId!, target: s.spanId }))
+
+    return c.json({ nodes, edges })
+  })
+
+  app.get("/api/graph/dataflow/:id", async (c) => {
+    const trace = await loadTrace(c.req.param("id"))
+    if (!trace) return c.json({ error: "not found" }, 404)
+    const cfg = await loadOrCreateConfig()
+    const findings = detectPIIInTrace(trace)
+
+    const nodes: Array<{ id: string; label: string; type: string }> = []
+    const edges: Array<{ source: string; target: string; label?: string }> = []
+
+    for (const f of findings) {
+      const piiNodeId = `pii-${f.category}-${f.start}`
+      nodes.push({ id: piiNodeId, label: `${f.category}: ${f.match.slice(0, 6)}...`, type: "pii" })
+
+      if (f.spanId) {
+        const spanNode = nodes.find((n) => n.id === f.spanId)
+        if (!spanNode) {
+          const span = trace.spans.find((s) => s.spanId === f.spanId)
+          nodes.push({ id: f.spanId, label: span?.name ?? f.spanId, type: span?.kind ?? "span" })
+        }
+        edges.push({
+          source: f.field.includes("input") ? piiNodeId : f.spanId,
+          target: f.field.includes("input") ? f.spanId : piiNodeId,
+          label: f.field,
+        })
+      }
+    }
+
+    return c.json({ nodes, edges })
+  })
+
+  app.get("/api/graph/entities/:id", async (c) => {
+    const trace = await loadTrace(c.req.param("id"))
+    if (!trace) return c.json({ error: "not found" }, 404)
+
+    const entityPatterns: Array<{ type: string; regex: RegExp }> = [
+      { type: "file", regex: /(?:[\w.-]+\.(?:ts|js|py|go|rs|tsx|jsx|sql|yaml|json|md))\b/g },
+      { type: "function", regex: /(?:function|def|func|fn)\s+(\w+)/g },
+      { type: "command", regex: /(?:npm|bun|pip|cargo|go|git|docker|kubectl)\s+\w+/g },
+    ]
+
+    const entities = new Map<string, { type: string; spans: Set<string> }>()
+
+    for (const span of trace.spans) {
+      const text = [span.input, span.output, span.name].filter(Boolean).join(" ")
+      for (const pattern of entityPatterns) {
+        const regex = new RegExp(pattern.regex.source, pattern.regex.flags)
+        let m: RegExpExecArray | null
+        while ((m = regex.exec(text)) !== null) {
+          const entity = m[1] ?? m[0]
+          if (entity.length < 3) continue
+          const existing = entities.get(entity)
+          if (existing) {
+            existing.spans.add(span.spanId)
+          } else {
+            entities.set(entity, { type: pattern.type, spans: new Set([span.spanId]) })
+          }
+        }
+      }
+    }
+
+    const nodes = Array.from(entities.entries()).map(([name, data]) => ({
+      id: name,
+      label: name,
+      type: data.type,
+      weight: data.spans.size,
+    }))
+
+    const edges: Array<{ source: string; target: string; weight: number }> = []
+    const entityList = Array.from(entities.entries())
+    for (let i = 0; i < entityList.length; i++) {
+      for (let j = i + 1; j < entityList.length; j++) {
+        const shared = [...entityList[i][1].spans].filter((s) => entityList[j][1].spans.has(s))
+        if (shared.length > 0) {
+          edges.push({ source: entityList[i][0], target: entityList[j][0], weight: shared.length })
+        }
+      }
+    }
+
+    return c.json({
+      nodes: nodes.slice(0, 50),
+      edges: edges.sort((a, b) => b.weight - a.weight).slice(0, 100),
+    })
+  })
+
+  // ── Analytics (DuckDB) ──
+
+  app.get("/api/analytics/overview", async (c) => {
+    const traces = await loadAllTraces()
+    const totalTokens = traces.reduce((s, t) => s + t.summary.totalTokens, 0)
+    const totalCost = traces.reduce((s, t) => s + t.summary.totalCost, 0)
+    const totalTools = traces.reduce((s, t) => s + t.summary.totalToolCalls, 0)
+
+    const modelUsage: Record<string, number> = {}
+    const costByModel: Record<string, number> = {}
+    for (const t of traces) {
+      const m = t.metadata.model ?? "unknown"
+      modelUsage[m] = (modelUsage[m] ?? 0) + 1
+      costByModel[m] = (costByModel[m] ?? 0) + t.summary.totalCost
+    }
+
+    return c.json({
+      totalSessions: traces.length,
+      totalTokens,
+      totalCost,
+      totalTools,
+      modelUsage,
+      costByModel,
+      recentSessions: traces.slice(0, 5).map((t) => ({
+        sessionId: t.sessionId,
+        title: t.metadata.title ?? t.sessionId,
+        startedAt: t.startedAt,
+        duration: t.summary.duration,
+        status: t.summary.status,
+      })),
+    })
+  })
+
+  app.get("/api/analytics/conversations", async (c) => {
+    const useLake = c.req.query("source") === "lake"
+    if (useLake) {
+      const l = await ensureLake()
+      return c.json(await getConversationAnalytics(l))
+    }
+    const traces = await loadAllTraces()
+    return c.json(buildInMemoryConvoAnalytics(traces))
+  })
+
+  app.get("/api/analytics/users", async (c) => {
+    const useLake = c.req.query("source") === "lake"
+    if (useLake) {
+      const l = await ensureLake()
+      return c.json(await getUserAnalytics(l))
+    }
+    const traces = await loadAllTraces()
+    return c.json(buildInMemoryUserAnalytics(traces))
+  })
+
+  // ── Lake management ──
+
+  app.post("/api/lake/ingest", async (c) => {
+    const traces = await loadAllTraces()
+    const l = await ensureLake()
+    let ingested = 0
+    for (const t of traces) {
+      await l.ingest(t)
+      ingested++
+    }
+    return c.json({ ingested, total: traces.length })
+  })
+
+  app.get("/api/lake/status", async (c) => {
+    try {
+      const l = await ensureLake()
+      const count = await l.getSessionCount()
+      return c.json({ connected: true, sessions: count, path: config.lake.path })
+    } catch (e) {
+      return c.json({ connected: false, error: String(e) })
+    }
+  })
+
+  // ── Consent ──
+
+  app.get("/api/consent", async (c) => {
+    const cfg = await loadOrCreateConfig()
+    return c.json(cfg)
+  })
+
+  app.post("/api/consent", async (c) => {
+    const body = await c.req.json()
+    const cfg = await loadOrCreateConfig()
+    if (body.piiCategories) cfg.consent.piiCategories = body.piiCategories
+    if (body.autoPublish !== undefined) cfg.consent.autoPublish = body.autoPublish
+    if (body.autoIngest !== undefined) cfg.consent.autoIngest = body.autoIngest
+    cfg.consent.acceptedAt = new Date().toISOString()
+    await saveConfig(cfg)
+    return c.json({ ok: true })
+  })
+
+  // ── Insights ──
+
+  app.get("/api/insights", async (c) => {
+    const traces = await loadAllTraces()
+    return c.json(generateInsights(traces))
+  })
+
+  // ── Issues ──
+
+  app.get("/api/issues", async (c) => {
+    const traces = await loadAllTraces()
+    const issues = detectIssues(traces)
+    return c.json({ issues, total: issues.length })
+  })
+
+  // ── Topic classification ──
+
+  app.get("/api/traces/:id/topics", async (c) => {
+    const trace = await loadTrace(c.req.param("id"))
+    if (!trace) return c.json({ error: "not found" }, 404)
+    return c.json({ topics: classifySessionTopic(trace) })
+  })
+
+  app.get("/api/topics", async (c) => {
+    const traces = await loadAllTraces()
+    const topicCounts: Record<string, number> = {}
+    for (const t of traces) {
+      for (const topic of classifySessionTopic(t)) {
+        topicCounts[topic] = (topicCounts[topic] ?? 0) + 1
+      }
+    }
+    return c.json(Object.entries(topicCounts).map(([topic, count]) => ({ topic, count })).sort((a, b) => b.count - a.count))
+  })
+
+  // ── Trace detail (full spans for detail view) ──
+
+  app.get("/api/traces/:id/detail", async (c) => {
+    const trace = await loadTrace(c.req.param("id"))
+    if (!trace) return c.json({ error: "not found" }, 404)
+    const findings = detectPIIInTrace(trace)
+    const topics = classifySessionTopic(trace)
+    const summary = summarizeTrace(trace)
+
+    const spans = trace.spans.map((s) => ({
+      spanId: s.spanId,
+      parentSpanId: s.parentSpanId,
+      name: s.name,
+      kind: s.kind,
+      status: s.status,
+      startTime: s.startTime,
+      endTime: s.endTime,
+      duration: s.startTime && s.endTime ? s.endTime - s.startTime : null,
+      model: typeof s.model === "string" ? s.model : s.model?.modelId,
+      tokens: s.tokens,
+      cost: s.cost,
+      inputPreview: s.input ? (typeof s.input === "string" ? s.input : JSON.stringify(s.input)).slice(0, 300) : null,
+      outputPreview: s.output ? (typeof s.output === "string" ? s.output : JSON.stringify(s.output)).slice(0, 300) : null,
+      hasInput: !!s.input,
+      hasOutput: !!s.output,
+    }))
+
+    return c.json({
+      sessionId: trace.sessionId,
+      traceId: trace.traceId,
+      metadata: trace.metadata,
+      summary: trace.summary,
+      topics,
+      piiCount: findings.length,
+      piiFindingsPreview: findings.slice(0, 10).map((f) => ({
+        category: f.category,
+        field: f.field,
+        spanId: f.spanId,
+      })),
+      spans,
+      report: summary,
+    })
+  })
+
+  // ── Dashboard UI ──
+
+  app.get("/", (c) => c.html(renderDashboardHTML()))
+
+  return app
+}
+
+function buildInMemoryConvoAnalytics(traces: import("../types").TraceFile[]) {
+  const completed = traces.filter((t) => t.summary.status === "completed")
+  const errored = traces.filter((t) => t.summary.status === "error" || t.summary.status === "crashed")
+  const avg = (arr: number[]) => (arr.length ? arr.reduce((a, b) => a + b, 0) / arr.length : 0)
+  const p = (arr: number[], pct: number) => { const s = [...arr].sort((a, b) => a - b); return s[Math.floor(s.length * pct)] ?? 0 }
+
+  const durations = traces.map((t) => t.summary.duration)
+  const toolFreq: Record<string, number> = {}
+  const toolDur: Record<string, number> = {}
+  for (const t of traces) for (const tt of t.summary.topTools ?? []) {
+    toolFreq[tt.name] = (toolFreq[tt.name] ?? 0) + tt.count
+    toolDur[tt.name] = (toolDur[tt.name] ?? 0) + tt.totalDuration
+  }
+  const topTools = Object.entries(toolFreq).map(([name, count]) => ({ name, count, totalDuration: toolDur[name] ?? 0 })).sort((a, b) => b.count - a.count).slice(0, 10)
+
+  const chains: Record<string, number> = {}
+  for (const t of traces) {
+    const ts = t.spans.filter((s) => s.kind === "tool").sort((a, b) => (a.startTime ?? 0) - (b.startTime ?? 0))
+    for (let i = 0; i < ts.length - 1; i++) chains[`${ts[i].name}→${ts[i + 1].name}`] = (chains[`${ts[i].name}→${ts[i + 1].name}`] ?? 0) + 1
+  }
+  const topChains = Object.entries(chains).map(([pattern, count]) => ({ pattern, count })).sort((a, b) => b.count - a.count).slice(0, 8)
+
+  const turnBuckets: Record<string, number> = { "1-3": 0, "4-8": 0, "9-15": 0, "16+": 0 }
+  for (const t of traces) { const g = t.summary.totalGenerations; if (g <= 3) turnBuckets["1-3"]++; else if (g <= 8) turnBuckets["4-8"]++; else if (g <= 15) turnBuckets["9-15"]++; else turnBuckets["16+"]++ }
+
+  const genDurs = traces.flatMap((t) => t.spans.filter((s) => s.kind === "generation" && s.startTime && s.endTime).map((s) => s.endTime! - s.startTime!))
+
+  return {
+    totalSessions: traces.length, completedSessions: completed.length, erroredSessions: errored.length,
+    successRate: traces.length ? completed.length / traces.length : 0,
+    avgDuration: avg(durations), avgToolCalls: avg(traces.map((t) => t.summary.totalToolCalls)),
+    avgGenerations: avg(traces.map((t) => t.summary.totalGenerations)), avgTokens: avg(traces.map((t) => t.summary.totalTokens)),
+    p50Duration: p(durations, 0.5), p90Duration: p(durations, 0.9),
+    p50Latency: p(genDurs, 0.5), p90Latency: p(genDurs, 0.9), p99Latency: p(genDurs, 0.99),
+    topTools, topChains, turnDistribution: turnBuckets,
+    doomLoops: traces.filter((t) => t.summary.loops?.length).length,
+    toolErrors: traces.reduce((n, t) => n + t.spans.filter((s) => s.kind === "tool" && s.status === "error").length, 0),
+  }
+}
+
+function buildInMemoryUserAnalytics(traces: import("../types").TraceFile[]) {
+  const userMap: Record<string, { sessions: number; tokens: number; cost: number; duration: number; completed: number; toolUsage: Record<string, number>; hourBuckets: number[]; dayBuckets: number[] }> = {}
+  for (const t of traces) {
+    const uid = t.metadata.userId ?? t.metadata.agent ?? t.metadata.providerId ?? "unknown"
+    if (!userMap[uid]) userMap[uid] = { sessions: 0, tokens: 0, cost: 0, duration: 0, completed: 0, toolUsage: {}, hourBuckets: new Array(24).fill(0), dayBuckets: new Array(7).fill(0) }
+    const u = userMap[uid]; u.sessions++; u.tokens += t.summary.totalTokens; u.cost += t.summary.totalCost; u.duration += t.summary.duration
+    if (t.summary.status === "completed") u.completed++
+    const d = new Date(t.startedAt); u.hourBuckets[d.getHours()]++; u.dayBuckets[d.getDay()]++
+    for (const tt of t.summary.topTools ?? []) u.toolUsage[tt.name] = (u.toolUsage[tt.name] ?? 0) + tt.count
+  }
+  const users = Object.entries(userMap).map(([userId, data]) => ({
+    userId, ...data, successRate: data.sessions ? data.completed / data.sessions : 0,
+    topTool: Object.entries(data.toolUsage).sort((a, b) => b[1] - a[1])[0]?.[0] ?? "-",
+  })).sort((a, b) => b.sessions - a.sessions)
+
+  const heatmap: number[][] = Array.from({ length: 7 }, () => new Array(24).fill(0))
+  for (const t of traces) { const d = new Date(t.startedAt); heatmap[d.getDay()][d.getHours()]++ }
+  return { users, heatmap }
+}

--- a/packages/trace-manager/tsconfig.json
+++ b/packages/trace-manager/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "types": ["bun"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "ui"]
+}


### PR DESCRIPTION
## Summary

Adds `packages/trace-manager/` as a new workspace package that provides a complete trace analytics, PII management, and admin review system for altimate-code.

### Core capabilities:
- **Security consent wizard** — interactive terminal flow for PII collection preferences (redact/hash/allow per category)
- **PII detection & redaction** — regex-based detection of emails, API keys, IPs, file paths, SSNs, credit cards, etc., applied before any data leaves the machine
- **Trace summarization** — per-session and bulk narrative summaries with token/cost/duration breakdowns
- **Insights engine** — generates actionable intelligence (not just stats) from trace data: cost concentration, token waste, doom loop detection, cache utilization gaps, tool failure trends
- **Issue detector** — auto-classifies recurring problems across users with severity escalation (frequency-based: 3x→medium, 5x→high, 10x→critical) and topic clustering (Bug Fix, Feature, Refactor, etc.)
- **DuckDB data lake** — trace ingestion into `~/.altimate/trace-lake.duckdb` for querying
- **HTTP publisher** — publishes redacted traces to configurable endpoints
- **Web dashboard** (Hono + Tailwind + D3.js) with 7 pages:
  - Dashboard (insights-driven, key findings front and center)
  - Traces table (double-click any row → full detail view)
  - Trace detail (timeline waterfall, span breakdown, alert banners, narrative)
  - Insights (grouped by severity with evidence, recommendations, metrics)
  - Issues (admin view — severity strip, recurring problems, affected users, suggested fixes)
  - Conversation & User analytics
  - Knowledge graph visualization
- **CLI integration** via `trace-manage` command (consent, summarize, analyze, publish, ingest, dashboard)
- **Plugin integration** via `@opencode-ai/plugin` hooks for auto-ingestion on session complete

### Files changed:
- `packages/trace-manager/` — 22 new files (3,100+ lines)
- `packages/opencode/src/index.ts` — register `trace-manage` CLI command
- `packages/opencode/package.json` — add workspace dependency
- `package.json` — add workspace entry

### Usage:
```bash
cd packages/opencode
bun dev trace-manage consent     # PII consent wizard
bun dev trace-manage summarize   # summarize latest trace
bun dev trace-manage analyze     # insights + issue detection
bun dev trace-manage dashboard   # launch full web dashboard
```

## Test plan

- [x] `bun turbo typecheck` passes across all packages
- [x] `trace-manage consent` — interactive wizard completes, saves config to `~/.altimate/trace-manager.json`
- [x] `trace-manage summarize` — loads traces from `~/.local/share/altimate-code/traces/`, prints narrative summary with PII detection
- [x] `trace-manage analyze` — prints bulk analytics (success rate, tokens, cost, duration)
- [x] `trace-manage dashboard` — serves on localhost, opens browser
- [x] Dashboard: `/api/insights` returns actionable insights with severity/evidence/recommendations
- [x] Dashboard: `/api/issues` returns auto-classified issues with cross-user frequency
- [x] Dashboard: `/api/topics` returns topic distribution
- [x] Dashboard: `/api/traces/:id/detail` returns full span timeline, PII count, topics
- [x] Dashboard: double-click trace row → opens detail page with waterfall, spans, alerts
- [x] Dashboard: Issues page shows severity summary, expandable occurrence tables, suggested fixes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@altimateai/trace-manager` as a new workspace package for PII review, trace analytics, and a web dashboard, integrated into the CLI and server at `/trace-manager`. Provides DuckDB-backed ingestion, optional HTTP publishing, and automatic redaction.

- **New Features**
  - New `packages/trace-manager` with consent wizard and regex-based PII detection/redaction.
  - Summaries, insights, and issue detection with severity/topic classification; conversation and user analytics.
  - DuckDB data lake for ingestion/querying; server auto-ingests local traces on first dashboard request.
  - HTTP publisher that redacts data before sending to configured endpoints.
  - Web dashboard (traces, detail, insights, issues, analytics) with optional ngrok share.
  - `trace-manage` CLI (consent, summarize, analyze, ingest, publish, dashboard) and `@opencode-ai/plugin` hooks for auto-ingestion.
  - Opencode server mounts the dashboard at `/trace-manager`.

- **Migration**
  - Run `bun install`.
  - Set PII preferences: `trace-manage consent`.
  - Optional: ingest with `trace-manage ingest`, then run `trace-manage dashboard` or open `/trace-manager`.
  - Configure publish endpoints via the wizard or `~/.altimate/trace-manager.json`.

<sup>Written for commit a3f1aa7b0389f8ab95b08260b4b97d47b17f82cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Trace Manager: CLI, local web dashboard, plugin and server routes for viewing, summarizing, analyzing, ingesting, and publishing traces (optional share via ngrok)
* **PII / Privacy**
  * Detection, configurable consent, interactive security guide, deterministic redaction/hashing, and publish workflow with redaction reporting
* **Analytics**
  * Conversation and user analytics, insights generation, issue detection, and heatmaps
* **Documentation**
  * Added architecture diagram
* **Chores**
  * Monorepo updated to include new trace-manager package
<!-- end of auto-generated comment: release notes by coderabbit.ai -->