### PR TITLE
fix: [AI-734] route Windows upgrade/uninstall to altimate-code, not upstream opencode

### DIFF
--- a/.github/meta/commit.txt
+++ b/.github/meta/commit.txt
@@ -1,3 +1,7 @@
-release: v0.6.0
+fix: wrap isValidDatabricksHost env-fallback in altimate_change markers
+
+The post-push Marker Guard uses `git diff -U5 <pre-push>...HEAD` so the
+hunk for this single added line did not include the surrounding block
+marker 8 lines above. Add an inline marker pair to satisfy strict mode.
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

--- a/packages/opencode/src/altimate/telemetry/index.ts
+++ b/packages/opencode/src/altimate/telemetry/index.ts
@@ -218,9 +218,29 @@ export namespace Telemetry {
         session_id: string
         from_version: string
         to_version: string
-        method: "npm" | "bun" | "brew" | "other"
+        // choco/scoop are retained for telemetry granularity even though
+        // altimate-code is not published to those managers — a user who
+        // explicitly passes --method=choco|scoop hits a structured error
+        // that we want to measure separately from "other" noise.
+        method: "npm" | "bun" | "brew" | "choco" | "scoop" | "other"
         status: "success" | "error"
         error?: string
+      }
+    | {
+        // Emitted ONLY when the user is PROACTIVELY shown an "upgrade available"
+        // notification (autoupdate disabled, autoupdate=notify, or method is
+        // unknown/yarn). NOT emitted from the auto-upgrade error-recovery path
+        // where upgrade_attempted(status=error) already signals the outcome.
+        // Pair with `upgrade_attempted` to compute the proactive notification →
+        // action funnel:
+        //   notified   = count(upgrade_available)
+        //   upgraded   = count(upgrade_attempted where status=success)
+        //   skipped    = notified - upgraded (dedup per machine / cohort)
+        type: "upgrade_available"
+        timestamp: number
+        session_id: string
+        current_version: string
+        latest_version: string
       }
     | {
         type: "session_forked"
@@ -1220,7 +1240,12 @@ export namespace Telemetry {
   }
 
   export function getContext() {
-    return { sessionId, projectId }
+    // altimate_change start — expose machineId so callers can use it as a
+    // stable fallback correlation key when a session has not been established
+    // yet (e.g., CLI-only paths like the upgrade check that runs before
+    // session_start).
+    return { sessionId, projectId, machineId }
+    // altimate_change end
   }
 
   /** Returns true only after init() has completed and telemetry is enabled. */

--- a/packages/opencode/src/cli/cmd/uninstall.ts
+++ b/packages/opencode/src/cli/cmd/uninstall.ts
@@ -128,16 +128,21 @@ async function showRemovalSummary(targets: RemovalTargets, method: Installation.
   }
 
   if (method !== "curl" && method !== "unknown") {
+    // altimate_change start — altimate-code package identifiers
+    // Upstream opencode uninstalled `opencode-ai` (npm) / `opencode` (brew),
+    // which would uninstall the WRONG product for altimate-code users. Also,
+    // altimate-code is not distributed via chocolatey or scoop, so those
+    // entries are dropped (method auto-detection never returns them anyway;
+    // explicit --method=choco|scoop would print the generic method name).
     const cmds: Record<string, string> = {
-      npm: "npm uninstall -g opencode-ai",
-      pnpm: "pnpm uninstall -g opencode-ai",
-      bun: "bun remove -g opencode-ai",
-      yarn: "yarn global remove opencode-ai",
-      brew: "brew uninstall opencode",
-      choco: "choco uninstall opencode",
-      scoop: "scoop uninstall opencode",
+      npm: "npm uninstall -g @altimateai/altimate-code",
+      pnpm: "pnpm uninstall -g @altimateai/altimate-code",
+      bun: "bun remove -g @altimateai/altimate-code",
+      yarn: "yarn global remove @altimateai/altimate-code",
+      brew: "brew uninstall altimate-code",
     }
     prompts.log.info(`  ✓ Package: ${cmds[method] || method}`)
+    // altimate_change end
   }
 }
 
@@ -179,34 +184,31 @@ async function executeUninstall(method: Installation.Method, targets: RemovalTar
   }
 
   if (method !== "curl" && method !== "unknown") {
+    // altimate_change start — altimate-code package identifiers
+    // See the matching block in showRemovalSummary for full rationale.
+    // choco/scoop are intentionally absent: altimate-code is not distributed
+    // there, and the old Windows UAC (choco-elevation) fallback branch is
+    // removed along with them.
     const cmds: Record<string, string[]> = {
-      npm: ["npm", "uninstall", "-g", "opencode-ai"],
-      pnpm: ["pnpm", "uninstall", "-g", "opencode-ai"],
-      bun: ["bun", "remove", "-g", "opencode-ai"],
-      yarn: ["yarn", "global", "remove", "opencode-ai"],
-      brew: ["brew", "uninstall", "opencode"],
-      choco: ["choco", "uninstall", "opencode"],
-      scoop: ["scoop", "uninstall", "opencode"],
+      npm: ["npm", "uninstall", "-g", "@altimateai/altimate-code"],
+      pnpm: ["pnpm", "uninstall", "-g", "@altimateai/altimate-code"],
+      bun: ["bun", "remove", "-g", "@altimateai/altimate-code"],
+      yarn: ["yarn", "global", "remove", "@altimateai/altimate-code"],
+      brew: ["brew", "uninstall", "altimate-code"],
     }
 
     const cmd = cmds[method]
     if (cmd) {
       spinner.start(`Running ${cmd.join(" ")}...`)
-      const result = await Process.run(method === "choco" ? ["choco", "uninstall", "opencode", "-y", "-r"] : cmd, {
-        nothrow: true,
-      })
+      const result = await Process.run(cmd, { nothrow: true })
       if (result.code !== 0) {
         spinner.stop(`Package manager uninstall failed: exit code ${result.code}`, 1)
-        const text = `${result.stdout.toString("utf8")}\n${result.stderr.toString("utf8")}`
-        if (method === "choco" && text.includes("not running from an elevated command shell")) {
-          prompts.log.warn(`You may need to run '${cmd.join(" ")}' from an elevated command shell`)
-        } else {
-          prompts.log.warn(`You may need to run manually: ${cmd.join(" ")}`)
-        }
+        prompts.log.warn(`You may need to run manually: ${cmd.join(" ")}`)
       } else {
         spinner.stop("Package removed")
       }
     }
+    // altimate_change end
   }
 
   if (method === "curl" && targets.binary) {

--- a/packages/opencode/src/cli/cmd/upgrade.ts
+++ b/packages/opencode/src/cli/cmd/upgrade.ts
@@ -17,7 +17,12 @@ export const UpgradeCommand = {
         alias: "m",
         describe: "installation method to use",
         type: "string",
-        choices: ["curl", "npm", "pnpm", "bun", "brew", "choco", "scoop"],
+        // altimate_change start — choco/scoop removed: altimate-code is not
+        // distributed via chocolatey or scoop, and Installation.upgrade()
+        // hard-fails these methods with a helpful error. Offering them in
+        // `--help` would lead users into that failure path.
+        choices: ["curl", "npm", "pnpm", "bun", "brew"],
+        // altimate_change end
       })
   },
   handler: async (args: { target?: string; method?: string }) => {
@@ -58,12 +63,12 @@ export const UpgradeCommand = {
     if (err) {
       spinner.stop("Upgrade failed", 1)
       if (err instanceof Installation.UpgradeFailedError) {
-        // necessary because choco only allows install/upgrade in elevated terminals
-        if (method === "choco" && err.data.stderr.includes("not running from an elevated command shell")) {
-          prompts.log.error("Please run the terminal as Administrator and try again")
-        } else {
-          prompts.log.error(err.data.stderr)
-        }
+        // altimate_change start — choco/scoop now synthesize their own helpful
+        // stderr ("altimate-code is not distributed via choco..."), so the old
+        // `method === "choco" && stderr.includes("not running from an elevated
+        // command shell")` branch was unreachable. Print the stderr directly.
+        prompts.log.error(err.data.stderr)
+        // altimate_change end
       } else if (err instanceof Error) prompts.log.error(err.message)
       prompts.outro("Done")
       return

--- a/packages/opencode/src/cli/upgrade.ts
+++ b/packages/opencode/src/cli/upgrade.ts
@@ -56,6 +56,14 @@ export function isValidVersion(version: string): boolean {
   return /^\d+\.\d+\.\d+/.test(version.replace(/^v/, ""))
 }
 
+/**
+ * Tracks the (version, machineId|cli) pairs for which we have already emitted
+ * an `upgrade_available` telemetry event in this process, so repeated upgrade()
+ * calls for the same target don't inflate the notified-denominator in the
+ * notification → upgrade funnel.
+ */
+const _notifiedVersions = new Set<string>()
+
 export async function upgrade() {
   const config = await Config.global()
   const method = await Installation.method()
@@ -76,7 +84,43 @@ export async function upgrade() {
     return
   }
 
-  const notify = () => Bus.publish(Installation.Event.UpdateAvailable, { version: latest })
+  const publishUpdate = () => Bus.publish(Installation.Event.UpdateAvailable, { version: latest })
+
+  /**
+   * Proactively notify the user that an upgrade is available AND emit the
+   * `upgrade_available` telemetry so we can measure the notification → upgrade
+   * funnel. Called from the autoupdate=disabled, autoupdate=notify, and
+   * unknown/yarn paths — NOT from the auto-upgrade error-recovery path
+   * (that path already emits `upgrade_attempted(status=error)`, and mixing
+   * the two signals conflates "proactive notification" with "error recovery
+   * notification"). Deduped per (machineId|session, version) within the
+   * process so repeated upgrade() calls don't double-count.
+   */
+  const notify = async () => {
+    try {
+      const { Telemetry } = await import("@/altimate/telemetry")
+      const ctx = Telemetry.getContext()
+      // Prefer machineId for dedup when a session has not started yet (the
+      // upgrade check runs early in CLI startup). Falling back to sessionId
+      // keeps the key stable within an established session; "cli" is a last
+      // resort so the key is never empty.
+      const correlationId = ctx.sessionId || ctx.machineId || "cli"
+      const dedupKey = `${correlationId}:${latest}`
+      if (_notifiedVersions.has(dedupKey)) return publishUpdate()
+      _notifiedVersions.add(dedupKey)
+      Telemetry.track({
+        type: "upgrade_available",
+        timestamp: Date.now(),
+        session_id: correlationId,
+        current_version: Installation.VERSION,
+        latest_version: latest,
+      })
+    } catch (err) {
+      // Telemetry is observability; it must never block the user-facing toast.
+      log.warn("upgrade_available telemetry failed", { error: String(err) })
+    }
+    return publishUpdate()
+  }
 
   // Always notify when update is available, regardless of autoupdate setting
   if (config.autoupdate === false || Flag.OPENCODE_DISABLE_AUTOUPDATE) {
@@ -97,8 +141,13 @@ export async function upgrade() {
   await Installation.upgrade(method, latest)
     .then(() => Bus.publish(Installation.Event.Updated, { version: latest }))
     .catch(async (err) => {
+      // Auto-upgrade failed (e.g., choco/scoop hard-fail, npm exit code). Show
+      // the toast so the user knows a new version exists, but DO NOT emit
+      // `upgrade_available` — `upgrade_attempted(status=error)` already carries
+      // this signal, and emitting both would invert the natural funnel order
+      // (attempt before notification).
       log.warn("auto-upgrade failed, notifying instead", { error: String(err), method, target: latest })
-      await notify()
+      await publishUpdate()
     })
 }
 // altimate_change end

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -33,7 +33,15 @@ export namespace Installation {
     }).then((x) => x.text)
   }
 
-  async function upgradeCurl(target: string) {
+  // altimate_change start — explicit UpgradeResult type
+  // Shape shared by Process.run() and upgradeCurl() results plus the
+  // synthesized failure results used for unsupported methods (choco/scoop).
+  // Using a named type avoids `as Awaited<ReturnType<typeof upgradeCurl>>`
+  // casts that silently accept mismatches if the real return shape drifts.
+  type UpgradeResult = { code: number; stdout: Buffer; stderr: Buffer }
+  // altimate_change end
+
+  async function upgradeCurl(target: string): Promise<UpgradeResult> {
     const body = await fetch("https://altimate.ai/install").then((res) => {
       if (!res.ok) throw new Error(res.statusText)
       return res.text()
@@ -127,14 +135,20 @@ export namespace Installation {
         command: () => text(["brew", "list", "--formula", "altimate-code"]),
       },
       // altimate_change end
+      // altimate_change start — choco/scoop are supported as an input (--method=choco)
+      // so callers still type-check, but we do NOT auto-detect them. The sentinel
+      // commands below return empty strings; combined with the `installedName`
+      // check further down, these entries can never match. Auto-detecting would
+      // match upstream `opencode` (the wrong product) installed alongside.
       {
         name: "scoop" as const,
-        command: () => text(["scoop", "list", "opencode"]),
+        command: () => Promise.resolve(""),
       },
       {
         name: "choco" as const,
-        command: () => text(["choco", "list", "--limit-output", "opencode"]),
+        command: () => Promise.resolve(""),
       },
+      // altimate_change end
     ]
 
     checks.sort((a, b) => {
@@ -148,8 +162,9 @@ export namespace Installation {
     for (const check of checks) {
       const output = await check.command()
       // altimate_change start — package names for detection
-      const installedName =
-        check.name === "brew" ? "altimate-code" : check.name === "choco" || check.name === "scoop" ? "opencode" : "@altimateai/altimate-code"
+      // choco/scoop entries above are sentinels (empty-string commands), so
+      // they can never match here; only brew + npm-family can resolve.
+      const installedName = check.name === "brew" ? "altimate-code" : "@altimateai/altimate-code"
       // altimate_change end
       if (output.includes(installedName)) {
         return check.name
@@ -177,7 +192,7 @@ export namespace Installation {
   // altimate_change end
 
   export async function upgrade(method: Method, target: string) {
-    let result: Awaited<ReturnType<typeof upgradeCurl>> | undefined
+    let result: UpgradeResult | undefined
     switch (method) {
       case "curl":
         result = await upgradeCurl(target)
@@ -221,20 +236,40 @@ export namespace Installation {
         break
       }
 
+      // altimate_change start — choco/scoop not supported; return a helpful error
+      // (in place of upstream's `choco upgrade opencode` / `scoop install opencode`,
+      // which install the wrong product).
       case "choco":
-        result = await Process.run(["choco", "upgrade", "opencode", `--version=${target}`, "-y"], { nothrow: true })
+      case "scoop": {
+        const msg =
+          `altimate-code is not distributed via ${method}. ` +
+          `Reinstall via npm (\`npm install -g @altimateai/altimate-code\`), ` +
+          `Homebrew (\`brew install AltimateAI/tap/altimate-code\`), ` +
+          `or the install script at https://altimate.ai/install`
+        result = {
+          code: 1,
+          stdout: Buffer.from(""),
+          stderr: Buffer.from(msg),
+        } satisfies UpgradeResult
         break
-      case "scoop":
-        result = await Process.run(["scoop", "install", `opencode@${target}`], { nothrow: true })
-        break
+      }
+      // altimate_change end
       default:
         throw new Error(`Unknown method: ${method}`)
     }
     // altimate_change start — telemetry for upgrade result
-    const telemetryMethod = (["npm", "bun", "brew"].includes(method) ? method : "other") as "npm" | "bun" | "brew" | "other"
+    // choco/scoop are retained as distinct values so analytics can distinguish
+    // Windows users hitting the unsupported-method path from generic "other"
+    // failures. See the upgrade_attempted event definition in telemetry/index.ts.
+    const telemetryMethod = (["npm", "bun", "brew", "choco", "scoop"].includes(method) ? method : "other") as
+      | "npm"
+      | "bun"
+      | "brew"
+      | "choco"
+      | "scoop"
+      | "other"
     if (!result || result.code !== 0) {
-      const stderr =
-        method === "choco" ? "not running from an elevated command shell" : result?.stderr.toString("utf8") || ""
+      const stderr = result?.stderr.toString("utf8") || ""
       const T = await getTelemetry()
       T.track({
         type: "upgrade_attempted",
@@ -323,28 +358,13 @@ export namespace Installation {
         .then((data: any) => data.version)
     }
 
-    if (detectedMethod === "choco") {
-      return fetch(
-        "https://community.chocolatey.org/api/v2/Packages?$filter=Id%20eq%20%27opencode%27%20and%20IsLatestVersion&$select=Version",
-        { headers: { Accept: "application/json;odata=verbose" } },
-      )
-        .then((res) => {
-          if (!res.ok) throw new Error(res.statusText)
-          return res.json()
-        })
-        .then((data: any) => data.d.results[0].Version)
-    }
-
-    if (detectedMethod === "scoop") {
-      return fetch("https://raw.githubusercontent.com/ScoopInstaller/Main/master/bucket/opencode.json", {
-        headers: { Accept: "application/json" },
-      })
-        .then((res) => {
-          if (!res.ok) throw new Error(res.statusText)
-          return res.json()
-        })
-        .then((data: any) => data.version)
-    }
+    // altimate_change start — choco/scoop not supported; fall through to GitHub releases API
+    // Upstream opencode queried chocolatey/scoop for the `opencode` package, which
+    // returns the wrong product's version. altimate-code is not published to
+    // either manager, so treat these methods like any other: use GitHub releases
+    // as the source of truth. This keeps `latest()` returning the right version
+    // even if detection somehow surfaced choco/scoop (e.g., via --method=choco).
+    // altimate_change end
 
     return fetch("https://api.github.com/repos/AltimateAI/altimate-code/releases/latest")
       .then((res) => {

--- a/packages/opencode/test/altimate/telemetry-safety.test.ts
+++ b/packages/opencode/test/altimate/telemetry-safety.test.ts
@@ -29,7 +29,7 @@ const trackSpy = spyOn(Telemetry, "track").mockImplementation((event: any) => {
 
 const getContextSpy = spyOn(Telemetry, "getContext").mockImplementation(() => {
   if (shouldThrow) throw new Error("getContext EXPLOSION")
-  return { sessionId: "test-session", projectId: "test-project" }
+  return { sessionId: "test-session", projectId: "test-project", machineId: "test-machine" }
 })
 
 afterAll(() => {

--- a/packages/opencode/test/install/upgrade-method.test.ts
+++ b/packages/opencode/test/install/upgrade-method.test.ts
@@ -68,6 +68,124 @@ describe("brew latest() version resolution", () => {
   })
 })
 
+// altimate_change start — choco/scoop are NOT supported for altimate-code
+describe("choco/scoop routing", () => {
+  test("method() does not auto-detect choco by querying `choco list`", () => {
+    // Auto-detect would match against UPSTREAM `opencode` installed alongside,
+    // misrouting altimate-code upgrades to the wrong product. The sentinel
+    // command must never exec a shell — it returns an empty promise instead.
+    expect(INSTALLATION_SRC).not.toMatch(/"choco",\s*"list"/)
+  })
+
+  test("method() does not auto-detect scoop by querying `scoop list`", () => {
+    expect(INSTALLATION_SRC).not.toMatch(/"scoop",\s*"list"/)
+  })
+
+  test("latest() does not query upstream chocolatey feed", () => {
+    expect(INSTALLATION_SRC).not.toContain("community.chocolatey.org")
+  })
+
+  test("latest() does not query upstream scoop bucket", () => {
+    expect(INSTALLATION_SRC).not.toContain("ScoopInstaller/Main/master/bucket/opencode.json")
+  })
+
+  test("upgrade() for choco/scoop returns a helpful error, not the wrong product", () => {
+    // No `choco upgrade opencode` or `scoop install opencode@...` anywhere
+    expect(INSTALLATION_SRC).not.toMatch(/"choco",\s*"upgrade",\s*"opencode"/)
+    expect(INSTALLATION_SRC).not.toMatch(/"scoop",\s*"install",\s*`opencode@/)
+    // Error message points the user to a supported install path
+    expect(INSTALLATION_SRC).toContain("altimate-code is not distributed via")
+    expect(INSTALLATION_SRC).toContain("https://altimate.ai/install")
+  })
+
+  test("upgrade() for choco/scoop emits upgrade_attempted status=error telemetry", () => {
+    // The error-result object flows through the existing telemetry emission
+    // block, so no separate emission is needed. Validate the result shape
+    // exists (non-zero code + populated stderr) instead of duplicating track().
+    expect(INSTALLATION_SRC).toMatch(/case "choco":\s*case "scoop"/)
+    expect(INSTALLATION_SRC).toMatch(/code:\s*1/)
+  })
+
+  test("telemetryMethod preserves choco/scoop for analytics granularity", () => {
+    // Earlier revision collapsed choco/scoop to "other" in telemetry. Now they
+    // are retained so Windows users hitting the unsupported-method path are
+    // distinguishable from truly generic "other" failures.
+    expect(INSTALLATION_SRC).toMatch(/\["npm",\s*"bun",\s*"brew",\s*"choco",\s*"scoop"\]\.includes\(method\)/)
+  })
+
+  test("UpgradeResult named type exists (replaces as Awaited<ReturnType<...>> cast)", () => {
+    expect(INSTALLATION_SRC).toMatch(/type UpgradeResult\s*=/)
+    // And the synthesized choco/scoop result uses `satisfies UpgradeResult`
+    // rather than a loose `as` cast. Check for an actual code occurrence of
+    // the cast (trailing line break after the `>`), excluding backtick-wrapped
+    // mentions in doc comments.
+    expect(INSTALLATION_SRC).toContain("satisfies UpgradeResult")
+    expect(INSTALLATION_SRC).not.toMatch(/}\s*as Awaited<ReturnType<typeof upgradeCurl>>/)
+  })
+})
+
+describe("cmd/upgrade.ts — choco/scoop CLI hygiene", () => {
+  const CMD_UPGRADE_SRC = fs.readFileSync(
+    path.resolve(import.meta.dir, "../../src/cli/cmd/upgrade.ts"),
+    "utf-8",
+  )
+
+  test("--method no longer exposes choco or scoop as valid choices", () => {
+    // Users reading `altimate upgrade --help` must not see unsupported methods
+    // that would lead them into the hard-fail path.
+    expect(CMD_UPGRADE_SRC).toMatch(/choices:\s*\["curl",\s*"npm",\s*"pnpm",\s*"bun",\s*"brew"\]/)
+    // Stricter: the choices list must not contain choco or scoop anywhere.
+    const choicesMatch = CMD_UPGRADE_SRC.match(/choices:\s*\[([^\]]*)\]/)
+    expect(choicesMatch).not.toBeNull()
+    expect(choicesMatch![1]).not.toMatch(/"choco"/)
+    expect(choicesMatch![1]).not.toMatch(/"scoop"/)
+  })
+
+  test("dead 'elevated command shell' branch removed from error handler", () => {
+    // After the installation.ts fix, choco stderr is the synthesized
+    // "altimate-code is not distributed via..." message, which never
+    // contains the upstream choco UAC error string. The conditional branch
+    // that checked for it is unreachable and must be removed.
+    expect(CMD_UPGRADE_SRC).not.toMatch(/method === "choco"\s*&&\s*err\.data\.stderr\.includes\(/)
+    expect(CMD_UPGRADE_SRC).not.toContain("not running from an elevated command shell")
+    expect(CMD_UPGRADE_SRC).not.toContain("Please run the terminal as Administrator")
+  })
+})
+
+describe("cmd/uninstall.ts — altimate-code package identifiers", () => {
+  const UNINSTALL_SRC = fs.readFileSync(
+    path.resolve(import.meta.dir, "../../src/cli/cmd/uninstall.ts"),
+    "utf-8",
+  )
+
+  test("does not uninstall upstream opencode-ai via npm/pnpm/bun/yarn", () => {
+    // Pre-fix: `npm uninstall -g opencode-ai` would fail silently (wrong
+    // product) or uninstall upstream opencode if present. Must use altimate.
+    expect(UNINSTALL_SRC).not.toMatch(/"(npm|pnpm|bun|yarn)",?\s*(?:"global")?,?\s*"(?:uninstall|remove)",?\s*"-g"?,?\s*"opencode-ai"/)
+    expect(UNINSTALL_SRC).not.toMatch(/"opencode-ai"/)
+  })
+
+  test("does not uninstall upstream opencode via brew", () => {
+    expect(UNINSTALL_SRC).not.toMatch(/"brew",\s*"uninstall",\s*"opencode"/)
+    expect(UNINSTALL_SRC).not.toMatch(/brew uninstall opencode\b/)
+  })
+
+  test("uses altimate-code package names", () => {
+    expect(UNINSTALL_SRC).toContain("@altimateai/altimate-code")
+    expect(UNINSTALL_SRC).toContain('"brew", "uninstall", "altimate-code"')
+  })
+
+  test("does not attempt choco or scoop uninstall (we don't publish there)", () => {
+    expect(UNINSTALL_SRC).not.toMatch(/"choco",\s*"uninstall"/)
+    expect(UNINSTALL_SRC).not.toMatch(/"scoop",\s*"uninstall"/)
+    // The old choco-specific "-y -r" flag branch and "elevated command shell"
+    // check are both unreachable now and must be removed.
+    expect(UNINSTALL_SRC).not.toContain('"-y", "-r"')
+    expect(UNINSTALL_SRC).not.toContain("not running from an elevated command shell")
+  })
+})
+// altimate_change end
+
 describe("upgrade execution", () => {
   test("npm upgrade uses scoped package name", () => {
     expect(INSTALLATION_SRC).toContain("@altimateai/altimate-code@${target}")

--- a/packages/opencode/test/installation/installation.test.ts
+++ b/packages/opencode/test/installation/installation.test.ts
@@ -18,30 +18,58 @@ describe("installation", () => {
     expect(await Installation.latest("unknown")).toBe("1.2.3")
   })
 
-  test("reads scoop manifest versions", async () => {
-    globalThis.fetch = (async () =>
-      new Response(JSON.stringify({ version: "2.3.4" }), {
+  // altimate_change start — choco/scoop now fall through to GitHub API
+  // We do not publish altimate-code to chocolatey or scoop. Upstream opencode
+  // queried those registries for the "opencode" package (WRONG product); the
+  // fix falls through to the GitHub releases API so `latest()` returns the
+  // correct altimate-code version even when --method=choco|scoop is passed.
+  test("scoop falls through to GitHub releases (altimate-code is not on scoop)", async () => {
+    const urls: string[] = []
+    globalThis.fetch = (async (url: string) => {
+      urls.push(url)
+      return new Response(JSON.stringify({ tag_name: "v0.6.0" }), {
         status: 200,
         headers: { "content-type": "application/json" },
-      })) as unknown as typeof fetch
+      })
+    }) as unknown as typeof fetch
 
-    expect(await Installation.latest("scoop")).toBe("2.3.4")
+    expect(await Installation.latest("scoop")).toBe("0.6.0")
+    // Must NOT hit the upstream scoop bucket for `opencode.json`
+    expect(urls.some((u) => u.includes("raw.githubusercontent.com") && u.includes("opencode.json"))).toBe(false)
+    // MUST hit the altimate-code GitHub releases API
+    expect(urls.some((u) => u.includes("api.github.com/repos/AltimateAI/altimate-code/releases/latest"))).toBe(true)
   })
 
-  test("reads chocolatey feed versions", async () => {
-    globalThis.fetch = (async () =>
-      new Response(
-        JSON.stringify({
-          d: {
-            results: [{ Version: "3.4.5" }],
-          },
-        }),
-        {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        },
-      )) as unknown as typeof fetch
+  test("choco falls through to GitHub releases (altimate-code is not on chocolatey)", async () => {
+    const urls: string[] = []
+    globalThis.fetch = (async (url: string) => {
+      urls.push(url)
+      return new Response(JSON.stringify({ tag_name: "v0.6.0" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }) as unknown as typeof fetch
 
-    expect(await Installation.latest("choco")).toBe("3.4.5")
+    expect(await Installation.latest("choco")).toBe("0.6.0")
+    // Must NOT hit the upstream chocolatey feed for `opencode`
+    expect(urls.some((u) => u.includes("community.chocolatey.org"))).toBe(false)
+    // MUST hit the altimate-code GitHub releases API
+    expect(urls.some((u) => u.includes("api.github.com/repos/AltimateAI/altimate-code/releases/latest"))).toBe(true)
   })
+
+  test("upgrade('choco', ...) throws UpgradeFailedError with helpful message", async () => {
+    await expect(Installation.upgrade("choco", "0.6.0")).rejects.toBeInstanceOf(Installation.UpgradeFailedError)
+    const err = await Installation.upgrade("choco", "0.6.0").catch((e) => e)
+    expect(err.data.stderr).toContain("altimate-code is not distributed via choco")
+    expect(err.data.stderr).toContain("@altimateai/altimate-code")
+    expect(err.data.stderr).toContain("https://altimate.ai/install")
+  })
+
+  test("upgrade('scoop', ...) throws UpgradeFailedError with helpful message", async () => {
+    const err = await Installation.upgrade("scoop", "0.6.0").catch((e) => e)
+    expect(err).toBeInstanceOf(Installation.UpgradeFailedError)
+    expect(err.data.stderr).toContain("altimate-code is not distributed via scoop")
+    expect(err.data.stderr).toContain("altimate-code")
+  })
+  // altimate_change end
 })

--- a/packages/opencode/test/installation/upgrade-available-telemetry.test.ts
+++ b/packages/opencode/test/installation/upgrade-available-telemetry.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Validates the upgrade_available telemetry contract.
+ *
+ * Bug context: before this was added, `upgrade_attempted` (status=success|error)
+ * was the only upgrade signal in telemetry. That gave us "upgrade finished"
+ * but not "user was told an upgrade exists". We couldn't distinguish
+ *   (a) users don't see the notification  from
+ *   (b) users see it and ignore
+ * The new `upgrade_available` event, emitted from `cli/upgrade.ts`'s notify(),
+ * closes that gap. Pair it with `upgrade_attempted` success to compute the
+ * proactive notification → action funnel.
+ *
+ * Semantic rules encoded in the tests below:
+ *   1. Event fires only on PROACTIVE notification paths
+ *      (autoupdate=disabled, autoupdate=notify, unknown/yarn method),
+ *      NOT from the auto-upgrade error-recovery path.
+ *   2. Event is deduped per (correlation_id, latest_version) within a process
+ *      so repeated upgrade() calls don't inflate the notified-denominator.
+ *   3. Correlation uses session_id when available, falling back to machine_id,
+ *      then "cli" as a last resort — never empty.
+ *   4. Telemetry failure must never block the user-facing Bus.publish.
+ */
+import { describe, test, expect } from "bun:test"
+import fs from "fs"
+import path from "path"
+
+const TELEMETRY_SRC = fs.readFileSync(
+  path.resolve(import.meta.dir, "../../src/altimate/telemetry/index.ts"),
+  "utf-8",
+)
+const CLI_UPGRADE_SRC = fs.readFileSync(
+  path.resolve(import.meta.dir, "../../src/cli/upgrade.ts"),
+  "utf-8",
+)
+
+describe("upgrade_available telemetry event type", () => {
+  test("event type is defined in the Telemetry.Event union", () => {
+    expect(TELEMETRY_SRC).toContain('type: "upgrade_available"')
+    expect(TELEMETRY_SRC).toContain("current_version: string")
+    expect(TELEMETRY_SRC).toContain("latest_version: string")
+  })
+
+  test("event carries session_id and timestamp like other events", () => {
+    const match = TELEMETRY_SRC.match(/type:\s*"upgrade_available"[\s\S]*?\}/)
+    expect(match).not.toBeNull()
+    const block = match![0]
+    expect(block).toContain("timestamp: number")
+    expect(block).toContain("session_id: string")
+  })
+
+  test("upgrade_attempted method union keeps choco/scoop for Windows granularity", () => {
+    // Earlier the union was only "npm" | "bun" | "brew" | "other". Windows
+    // users hitting choco/scoop would be indistinguishable from truly generic
+    // "other" failures. The expanded union preserves that signal.
+    const upgradeAttemptedBlock = TELEMETRY_SRC.match(/type:\s*"upgrade_attempted"[\s\S]*?\}/)
+    expect(upgradeAttemptedBlock).not.toBeNull()
+    expect(upgradeAttemptedBlock![0]).toContain('"choco"')
+    expect(upgradeAttemptedBlock![0]).toContain('"scoop"')
+  })
+})
+
+describe("upgrade_available emission site (cli/upgrade.ts)", () => {
+  test("notify() emits upgrade_available AND publishes UpdateAvailable", () => {
+    expect(CLI_UPGRADE_SRC).toContain('type: "upgrade_available"')
+    expect(CLI_UPGRADE_SRC).toContain("Bus.publish(Installation.Event.UpdateAvailable")
+  })
+
+  test("telemetry failure does not block the user-facing notification", () => {
+    // The whole notify() body must include a try/catch around Telemetry.track
+    // AND a publishUpdate() call OUTSIDE the try/catch (so Bus.publish still
+    // runs if telemetry throws).
+    const notifyFn = CLI_UPGRADE_SRC.match(
+      /const notify\s*=\s*async[\s\S]*?return publishUpdate\(\)\s*\n\s*\}/,
+    )
+    expect(notifyFn).not.toBeNull()
+    expect(notifyFn![0]).toContain("try {")
+    expect(notifyFn![0]).toContain("} catch")
+    // Track call comes before catch; publishUpdate comes after the catch block
+    const telemetryIdx = notifyFn![0].indexOf('type: "upgrade_available"')
+    const catchIdx = notifyFn![0].indexOf("} catch")
+    const publishIdx = notifyFn![0].lastIndexOf("return publishUpdate()")
+    expect(telemetryIdx).toBeGreaterThanOrEqual(0)
+    expect(telemetryIdx).toBeLessThan(catchIdx)
+    expect(catchIdx).toBeLessThan(publishIdx)
+  })
+
+  test("uses lazy import to avoid telemetry → installation circular dep", () => {
+    expect(CLI_UPGRADE_SRC).toContain('await import("@/altimate/telemetry")')
+  })
+
+  test("current_version reads from Installation.VERSION (normalized, no v-prefix)", () => {
+    expect(CLI_UPGRADE_SRC).toContain("current_version: Installation.VERSION")
+  })
+
+  test("latest_version reads from the resolved `latest` local", () => {
+    expect(CLI_UPGRADE_SRC).toContain("latest_version: latest")
+  })
+})
+
+describe("upgrade_available correlation ID fallback (n1 fix)", () => {
+  test("prefers sessionId, falls back to machineId, then 'cli'", () => {
+    // The notify() body should read Telemetry.getContext() and pick the
+    // first non-empty value among sessionId, machineId, "cli". This keeps
+    // funnel correlation stable even before session_start fires (the
+    // upgrade check runs early in CLI startup).
+    expect(CLI_UPGRADE_SRC).toMatch(/ctx\.sessionId\s*\|\|\s*ctx\.machineId\s*\|\|\s*"cli"/)
+  })
+
+  test("Telemetry.getContext() exposes machineId", () => {
+    // getContext must return machineId so the correlation fallback works.
+    const getContextFn = TELEMETRY_SRC.match(/export function getContext\(\)[\s\S]*?\n\s*\}/)
+    expect(getContextFn).not.toBeNull()
+    expect(getContextFn![0]).toContain("machineId")
+  })
+})
+
+describe("upgrade_available dedup (m9 fix)", () => {
+  test("emits at most once per (correlation, version) in the same process", () => {
+    // Module-level Set tracks already-notified versions; repeated upgrade()
+    // calls for the same target will NOT re-emit the event.
+    expect(CLI_UPGRADE_SRC).toMatch(/_notifiedVersions\s*=\s*new Set<string>\(\)/)
+    // dedup key combines correlation and version
+    expect(CLI_UPGRADE_SRC).toContain("`${correlationId}:${latest}`")
+    expect(CLI_UPGRADE_SRC).toContain("_notifiedVersions.has(dedupKey)")
+    expect(CLI_UPGRADE_SRC).toContain("_notifiedVersions.add(dedupKey)")
+  })
+
+  test("dedup guard skips telemetry but still publishes the Bus event", () => {
+    // If we already notified this version, a subsequent notify() call must
+    // still show the toast (publishUpdate) — the user hasn't changed state,
+    // but we shouldn't swallow the UI event. We just skip the telemetry.
+    const notifyBody = CLI_UPGRADE_SRC.match(
+      /const notify\s*=\s*async[\s\S]*?return publishUpdate\(\)\s*\n\s*\}/,
+    )
+    expect(notifyBody).not.toBeNull()
+    expect(notifyBody![0]).toMatch(/if\s*\(_notifiedVersions\.has\(dedupKey\)\)\s*return publishUpdate\(\)/)
+  })
+})
+
+describe("upgrade_available suppression in error-recovery path (m8 fix)", () => {
+  test("auto-upgrade catch handler calls publishUpdate() directly, NOT notify()", () => {
+    // When auto-upgrade fails (e.g., choco/scoop synthesized failure), we
+    // must still show the toast but MUST NOT emit upgrade_available — the
+    // existing upgrade_attempted(status=error) already carries that signal,
+    // and emitting both inverts the natural funnel order (attempt before
+    // notification). Locate the catch handler by the distinctive log.warn
+    // call and verify the body contains publishUpdate, not notify.
+    const catchStart = CLI_UPGRADE_SRC.indexOf(".catch(async (err)")
+    expect(catchStart).toBeGreaterThanOrEqual(0)
+    // Take a generous slice that's guaranteed to include the full catch body.
+    const slice = CLI_UPGRADE_SRC.slice(catchStart, catchStart + 1500)
+    expect(slice).toContain("auto-upgrade failed, notifying instead")
+    expect(slice).toContain("await publishUpdate()")
+    // The catch handler must NOT call notify() — which would emit telemetry.
+    // Bound the check to the catch handler's body so we don't false-positive
+    // against notify() calls earlier in the file.
+    const catchBodyEnd = slice.indexOf("})", slice.indexOf("await publishUpdate()"))
+    expect(catchBodyEnd).toBeGreaterThan(0)
+    const catchBody = slice.slice(0, catchBodyEnd)
+    expect(catchBody).not.toMatch(/await notify\(\)/)
+  })
+
+  test("publishUpdate is factored out as a named helper", () => {
+    // Having publishUpdate as a separate function lets the catch handler
+    // show the toast without triggering telemetry.
+    expect(CLI_UPGRADE_SRC).toMatch(
+      /const publishUpdate\s*=\s*\(\)\s*=>\s*Bus\.publish\(Installation\.Event\.UpdateAvailable/,
+    )
+  })
+})

--- a/packages/opencode/test/installation/version.test.ts
+++ b/packages/opencode/test/installation/version.test.ts
@@ -57,29 +57,33 @@ describe("Installation.latest() returns clean versions", () => {
     expect(version.startsWith("v")).toBe(false)
   })
 
-  test("scoop manifest: returns clean version", async () => {
+  // altimate_change start — choco/scoop fall through to GitHub releases
+  // We do not publish altimate-code to chocolatey or scoop. latest() for these
+  // methods falls through to the GitHub releases API (same path as "unknown").
+  test("scoop: falls through to GitHub releases (altimate-code is not on scoop)", async () => {
     globalThis.fetch = (async () =>
-      new Response(JSON.stringify({ version: "2.3.4" }), {
+      new Response(JSON.stringify({ tag_name: "v0.6.0" }), {
         status: 200,
         headers: { "content-type": "application/json" },
       })) as unknown as typeof fetch
 
     const version = await Installation.latest("scoop")
-    expect(version).toBe("2.3.4")
+    expect(version).toBe("0.6.0")
     expect(version.startsWith("v")).toBe(false)
   })
 
-  test("chocolatey feed: returns clean version", async () => {
+  test("choco: falls through to GitHub releases (altimate-code is not on chocolatey)", async () => {
     globalThis.fetch = (async () =>
-      new Response(
-        JSON.stringify({ d: { results: [{ Version: "3.4.5" }] } }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      )) as unknown as typeof fetch
+      new Response(JSON.stringify({ tag_name: "v0.6.0" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch
 
     const version = await Installation.latest("choco")
-    expect(version).toBe("3.4.5")
+    expect(version).toBe("0.6.0")
     expect(version.startsWith("v")).toBe(false)
   })
+  // altimate_change end
 })
 
 describe("version comparison for upgrade skip", () => {


### PR DESCRIPTION
### What does this PR do?

Fixes a production bug where Windows users were being auto-upgraded to `1.14.19` — the **upstream** `sst/opencode` version — because four code paths still referenced upstream package identifiers. Also closes the adjacent bug in `altimate uninstall` that had the same class of misrouting.

**Observed in telemetry:**

```
upgrade_attempted from=0.6.0 to=1.14.19 method=other status=error
  error="not running from an elevated command shell" × 5
```

**Scope of the fix (`packages/opencode/src/` paths):**

- `installation/index.ts` — `method()` no longer auto-detects choco/scoop (sentinel entries keep the `Method` type union intact without matching); `latest()` falls through to GitHub releases; `upgrade()` synthesizes a helpful error result that flows through existing telemetry; extracted `type UpgradeResult` to replace a fragile `as Awaited<ReturnType<...>>` cast; `telemetryMethod` preserves choco/scoop granularity.
- `cli/cmd/upgrade.ts` — removed `choco`/`scoop` from `--method` choices, removed dead "elevated command shell" branch.
- `cli/cmd/uninstall.ts` — updated package names to `@altimateai/altimate-code` / `altimate-code`, dropped choco/scoop commands, removed UAC fallback.
- `cli/upgrade.ts` + `altimate/telemetry/index.ts` — new `upgrade_available` telemetry event. Emitted only on proactive notification paths (NOT from the auto-upgrade error-recovery catch). Deduped per `(correlationId:version)` via a module-level Set. `correlationId` falls back `sessionId → machineId → "cli"`. Telemetry failure never blocks the Bus.publish that shows the toast. Exposed `machineId` on `Telemetry.getContext()` return.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Observability / telemetry change
- [ ] Documentation update

### Issue for this PR

Closes #734

### How did you verify your code works?

- [x] `bun turbo typecheck` — 5/5 packages pass
- [x] 88 relevant installation / upgrade / uninstall tests pass (6 files, 225 assertions)
- [x] Wider sweep: 2,856 altimate-area tests + 490 CLI tests pass (pre-existing tui-worker segfault unrelated)
- [x] Marker check: `bun run script/upstream/analyze.ts --markers --base main --strict` clean
- [x] Multi-model code review (9 models including Claude) — all blocking issues addressed before commit
- [x] Added runtime behavioral tests for `Installation.upgrade("choco"/"scoop", ...)` throwing with the expected message
- [x] Added source-level regression guards for `--method` choices, dead-branch removal, package names, telemetryMethod union, notify dedup, error-recovery suppression, machineId fallback, and UpgradeResult named type

### Checklist

- [x] Followed conventional commit format (`fix: [AI-734] ...`)
- [x] Wrapped all changes to upstream-shared files in `// altimate_change start / end` markers
- [x] Updated existing tests that relied on old choco/scoop behavior
- [x] Added tests for new behavior (runtime + source-level)
- [x] Ran marker check locally before commit
- [x] Ran linters / typecheck locally before commit
- [x] Ran `/consensus:code-review` before commit (9-model panel)
- [x] Updated telemetry event type definition alongside the emission site
- [x] Verified the fix against production telemetry findings (stuck user `12c7c779`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-734]: https://altimateai.atlassian.net/browse/AI-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * Removed support for Chocolatey and Scoop package managers in upgrade and uninstall operations.

* **New Features**
  * Added proactive upgrade availability tracking to notify users of new versions.

* **Changes**
  * Updated package identifiers across package managers: npm-family packages now use `@altimateai/altimate-code`, Homebrew uses `altimate-code`.
  * Expanded upgrade method selection to support curl, npm, pnpm, bun, and brew.
  * Enhanced telemetry context to include machine-based correlation for better upgrade tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows upgrade/uninstall routing to target `@altimateai/altimate-code` (npm-family) and `altimate-code` (Homebrew), preventing accidental upgrades to upstream `opencode`. Adds proactive `upgrade_available` telemetry to measure the notify → upgrade funnel. Addresses AI-734.

- **Bug Fixes**
  - Removed `choco`/`scoop` from auto-detect and CLI `--method` choices; `latest()` now falls back to GitHub releases; `upgrade()` for `choco`/`scoop` returns a clear “not distributed here” error.
  - Updated uninstall commands to use `@altimateai/altimate-code` and `altimate-code`; removed Windows UAC branch tied to Chocolatey.
  - Preserved `choco`/`scoop` in upgrade telemetry method for analytics; propagate real stderr; introduced `UpgradeResult` type.
  - Expanded and updated tests to guard routing, CLI choices, telemetry, and fallbacks.

- **New Features**
  - Added `upgrade_available` telemetry: emitted only on proactive notifications, deduped per `(correlationId:version)`, with correlation falling back `sessionId → machineId → "cli"`. Telemetry failures never block the toast.

<sup>Written for commit d2531c805afa7609b00c8424683956441d66bedf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

