### PR TITLE
fix: make anti-slop advisory instead of auto-closing legitimate PRs

### DIFF
--- a/.github/workflows/anti-slop.yml
+++ b/.github/workflows/anti-slop.yml
@@ -77,7 +77,13 @@ jobs:
             master
 
           # --- Actions on failure ---
-          close-pr: true
+          # Advisory, not blocking. Too many legitimate team PRs were auto-closed
+          # because the PR template instructs LLMs to prepend "PINEAPPLE"
+          # (honeypot) — any AI-assisted PR from a team member then trips the
+          # blocked-terms check and gets closed 2 minutes after opening. The
+          # labels and failure message still fire, so maintainers retain the
+          # signal and can close manually when warranted. See issue #740.
+          close-pr: false
           lock-pr: false
           failure-add-pr-labels: "needs-review:blocked"
           failure-pr-message: |


### PR DESCRIPTION
## Summary

`anti-slop.yml` auto-closes legitimate team-member PRs within ~2 minutes. Root cause is a self-inflicted honeypot: `pull_request_template.md` instructs any LLM to prepend "PINEAPPLE" to the description, and `anti-slop.yml:50` lists that same word in `blocked-terms`. AI-assisted PRs from team members follow the template instruction and then trip the check — a guaranteed close. PR #739 (a legitimate BQ finops fix with a passing consensus code review and all other CI green) was closed this way.

`anti-slop` has no `TEAM_MEMBERS` carve-out the way `pr-standards.yml` does, so listed members are not exempt. The action's built-in association check only recognizes GitHub's `OWNER`/`MEMBER`/`COLLABORATOR`, not the repo's local `.github/TEAM_MEMBERS` file.

Change: flip `close-pr: true` to `close-pr: false`. All other signals remain — the `needs-review:blocked` label still lands, the failure message still comments, the action still runs on every open/edit/synchronize. Maintainers can close manually when warranted.

## Test plan

- [x] Single-line config change, guarded by an in-file comment explaining why.
- [x] No code paths touched — no unit tests to add.
- [x] Upstream marker check clean (`bun run script/upstream/analyze.ts --markers --base main --strict`).
- [x] Validated locally that `anti-slop` is the only workflow with `close-pr: true` in the fast path (the other auto-closer, `close-stale-prs.yml`, is schedule-driven and unaffected).

## Checklist

- [x] Tests added/updated — N/A (config change).
- [x] Documentation updated — in-file comment added.
- [ ] CHANGELOG updated — N/A (internal workflow change, no user-facing API).

Follow-ups left out of scope and tracked in the issue:

1. Whether `PINEAPPLE` should stay in `blocked-terms` when the template actively induces its inclusion.
2. Whether to add a `TEAM_MEMBERS` carve-out to `anti-slop` mirroring `pr-standards.yml`'s pattern.

Closes #740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Quality check workflow improved: Failed checks no longer automatically close pull requests. Pull requests now remain open for review with status labels and notifications, enabling better assessment of issues before closure decisions are made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `anti-slop` workflow advisory by setting `close-pr: false` to stop auto-closing legitimate team PRs triggered by the PR template’s “PINEAPPLE” word. The check still runs on open/edit/sync, adds the `needs-review:blocked` label, and posts the failure message so maintainers can review and close manually.

<sup>Written for commit 0f66ba7b295fbe66ff5116d459b34c7374725993. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

