### PR TITLE
feat(schema): collapse entity-per-table warehouses in schema_index

### DIFF
--- a/packages/opencode/src/altimate/native/schema/cache.ts
+++ b/packages/opencode/src/altimate/native/schema/cache.ts
@@ -18,7 +18,15 @@ import type {
   SchemaCacheWarehouseStatus,
   SchemaSearchTableResult,
   SchemaSearchColumnResult,
+  SchemaEntityGroupSummary,
+  SchemaSearchEntityGroupResult,
 } from "../types"
+import {
+  detectEntityGroup,
+  type TableShape,
+  DEFAULT_ENTITY_RATIO_THRESHOLD,
+  DEFAULT_ENTITY_MIN_TABLES,
+} from "./entity-groups"
 
 // ---------------------------------------------------------------------------
 // DDL
@@ -67,6 +75,24 @@ CREATE INDEX IF NOT EXISTS idx_columns_search ON columns_cache(search_text);
 CREATE INDEX IF NOT EXISTS idx_tables_warehouse ON tables_cache(warehouse);
 CREATE INDEX IF NOT EXISTS idx_columns_warehouse ON columns_cache(warehouse);
 CREATE INDEX IF NOT EXISTS idx_columns_table ON columns_cache(warehouse, schema_name, table_name, column_name);
+
+CREATE TABLE IF NOT EXISTS entity_groups_cache (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    warehouse TEXT NOT NULL,
+    database_name TEXT,
+    schema_name TEXT NOT NULL,
+    pattern TEXT NOT NULL DEFAULT 'entity-per-table',
+    fingerprint TEXT NOT NULL,
+    table_count INTEGER NOT NULL,
+    sample_table TEXT,
+    composite_columns_json TEXT NOT NULL,
+    table_names_json TEXT NOT NULL,
+    search_text TEXT NOT NULL,
+    UNIQUE(warehouse, database_name, schema_name, fingerprint)
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_groups_search ON entity_groups_cache(search_text);
+CREATE INDEX IF NOT EXISTS idx_entity_groups_warehouse ON entity_groups_cache(warehouse);
 `
 
 // ---------------------------------------------------------------------------
@@ -141,22 +167,36 @@ export class SchemaCache {
 
   /**
    * Crawl a warehouse and index all schemas/tables/columns.
+   *
+   * For each schema, runs entity-per-table detection: if ≥50% of tables share
+   * the same column structure and the group has at least 20 tables, emits a
+   * single composite digest row in `entity_groups_cache` instead of N
+   * near-identical per-table rows. Tables outside the group still get their
+   * normal per-table entries.
    */
   async indexWarehouse(
     warehouseName: string,
     warehouseType: string,
     connector: Connector,
+    options: {
+      entityRatioThreshold?: number
+      entityMinTables?: number
+    } = {},
   ): Promise<SchemaIndexResult> {
     const now = new Date().toISOString()
+    const ratioThreshold = options.entityRatioThreshold ?? DEFAULT_ENTITY_RATIO_THRESHOLD
+    const minTables = options.entityMinTables ?? DEFAULT_ENTITY_MIN_TABLES
 
     // Clear existing data
     this.db.prepare("DELETE FROM columns_cache WHERE warehouse = ?").run(warehouseName)
     this.db.prepare("DELETE FROM tables_cache WHERE warehouse = ?").run(warehouseName)
+    this.db.prepare("DELETE FROM entity_groups_cache WHERE warehouse = ?").run(warehouseName)
 
     let totalSchemas = 0
     let totalTables = 0
     let totalColumns = 0
     const databaseName: string | null = null
+    const entityGroupsEmitted: SchemaEntityGroupSummary[] = []
 
     let schemas: string[] = []
     try {
@@ -175,6 +215,13 @@ export class SchemaCache {
       `INSERT OR REPLACE INTO columns_cache
        (warehouse, database_name, schema_name, table_name, column_name, data_type, nullable, search_text)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+
+    const insertEntityGroup = this.db.prepare(
+      `INSERT OR REPLACE INTO entity_groups_cache
+       (warehouse, database_name, schema_name, pattern, fingerprint, table_count,
+        sample_table, composite_columns_json, table_names_json, search_text)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
 
     // Batch inserts per-table inside a transaction to avoid per-statement disk fsyncs.
@@ -200,35 +247,100 @@ export class SchemaCache {
         continue
       }
 
+      // Collect every table's columns first so the entity-group detector
+      // can see the whole schema at once. We also retain the table_type and
+      // raw column rows for downstream insert.
+      type TableSnapshot = {
+        name: string
+        type: string
+        columns: Array<{ name: string; data_type: string; nullable: boolean }>
+      }
+      const snapshots: TableSnapshot[] = []
       for (const tableInfo of tables) {
-        totalTables++
-        const searchText = makeSearchText(databaseName, schemaName, tableInfo.name, tableInfo.type)
-
         let columns: Array<{ name: string; data_type: string; nullable: boolean }> = []
         try {
           columns = await connector.describeTable(schemaName, tableInfo.name)
         } catch {
           // continue with empty columns
         }
+        snapshots.push({ name: tableInfo.name, type: tableInfo.type, columns })
+      }
 
-        // Build column insert args
+      const shapes: TableShape[] = snapshots.map((s) => ({
+        table_name: s.name,
+        columns: s.columns.map((c) => ({ name: c.name, data_type: c.data_type })),
+      }))
+      const detection = detectEntityGroup(shapes, { ratioThreshold, minTables })
+
+      const inGroup = new Set<string>(
+        detection.entity_group ? detection.entity_group.table_names : [],
+      )
+
+      for (const snap of snapshots) {
+        totalTables++
+
+        if (inGroup.has(snap.name)) {
+          // Tables inside the entity group are NOT emitted per-table.
+          // Their columns are still counted toward totalColumns so the index
+          // result accurately reflects the warehouse, but they live inside
+          // the composite digest (and the entity_groups_cache row below).
+          totalColumns += snap.columns.length
+          continue
+        }
+
+        const searchText = makeSearchText(databaseName, schemaName, snap.name, snap.type)
         const columnArgsBatch: any[][] = []
-        for (const col of columns) {
+        for (const col of snap.columns) {
           totalColumns++
           const colSearch = makeSearchText(
-            databaseName, schemaName, tableInfo.name, col.name, col.data_type,
+            databaseName, schemaName, snap.name, col.name, col.data_type,
           )
           columnArgsBatch.push([
-            warehouseName, databaseName, schemaName, tableInfo.name,
+            warehouseName, databaseName, schemaName, snap.name,
             col.name, col.data_type, col.nullable ? 1 : 0, colSearch,
           ])
         }
 
-        // Insert table + all its columns in a single transaction
         insertTableBatch(
-          [warehouseName, databaseName, schemaName, tableInfo.name, tableInfo.type, searchText],
+          [warehouseName, databaseName, schemaName, snap.name, snap.type, searchText],
           columnArgsBatch,
         )
+      }
+
+      // Persist the entity group for this schema, if one was detected.
+      if (detection.entity_group) {
+        const eg = detection.entity_group
+        const compositeColumns = eg.composite_columns
+        const groupSearchText = makeSearchText(
+          databaseName,
+          schemaName,
+          eg.sample_table,
+          ...eg.table_names,
+          ...compositeColumns.map((c) => c.name),
+          ...compositeColumns.map((c) => c.data_type),
+        )
+        insertEntityGroup.run(
+          warehouseName,
+          databaseName,
+          schemaName,
+          "entity-per-table",
+          eg.fingerprint,
+          eg.table_names.length,
+          eg.sample_table,
+          JSON.stringify(compositeColumns),
+          JSON.stringify(eg.table_names),
+          groupSearchText,
+        )
+        entityGroupsEmitted.push({
+          warehouse: warehouseName,
+          database: databaseName ?? undefined,
+          schema_name: schemaName,
+          pattern: "entity-per-table",
+          table_count: eg.table_names.length,
+          composite_columns: compositeColumns,
+          sample_table: eg.sample_table,
+          table_names: eg.table_names,
+        })
       }
     }
 
@@ -249,6 +361,7 @@ export class SchemaCache {
       tables_indexed: totalTables,
       columns_indexed: totalColumns,
       timestamp: now,
+      entity_groups: entityGroupsEmitted.length > 0 ? entityGroupsEmitted : undefined,
     }
   }
 
@@ -317,11 +430,54 @@ export class SchemaCache {
       }
     })
 
+    // Search entity groups: a group matches if any of its tokens appears in
+    // its search_text (which includes the full table_names list, composite
+    // column names/types, schema, and sample table). This means the agent
+    // can still find a specific collapsed table by name.
+    const groupRows = this.db.prepare(
+      `SELECT warehouse, database_name, schema_name, pattern, table_count,
+              sample_table, composite_columns_json, table_names_json
+       FROM entity_groups_cache
+       WHERE ${searchCondition} ${whFilter}
+       ORDER BY schema_name, sample_table
+       LIMIT ?`,
+    ).all(...searchParams, ...whParams, limit) as any[]
+
+    const entityGroups: SchemaSearchEntityGroupResult[] = groupRows.map((row) => {
+      const compositeColumns = JSON.parse(row.composite_columns_json) as {
+        name: string
+        data_type: string
+      }[]
+      const tableNames = JSON.parse(row.table_names_json) as string[]
+      // Of the group's table names, return the subset that actually matches
+      // any query token. This makes "find me table AAPL" return just AAPL,
+      // not all 2754 tickers.
+      const lowerTokens = tokens.map((t) => t.toLowerCase())
+      const matching = tableNames.filter((name) => {
+        const lowerName = name.toLowerCase()
+        return lowerTokens.some((tok) => lowerName.includes(tok))
+      })
+      return {
+        warehouse: row.warehouse,
+        database: row.database_name ?? undefined,
+        schema_name: row.schema_name,
+        pattern: row.pattern,
+        table_count: row.table_count,
+        composite_columns: compositeColumns,
+        sample_table: row.sample_table,
+        // If query matched on schema or composite columns rather than a
+        // specific table, return an empty matching_tables list so callers
+        // know it was a structural match.
+        matching_tables: matching,
+      }
+    })
+
     return {
       tables,
       columns,
       query,
-      match_count: tables.length + columns.length,
+      match_count: tables.length + columns.length + entityGroups.length,
+      entity_groups: entityGroups.length > 0 ? entityGroups : undefined,
     }
   }
 
@@ -340,8 +496,42 @@ export class SchemaCache {
       columns_count: row.columns_count,
     }))
 
-    const totalTables = (this.db.prepare("SELECT COUNT(*) as cnt FROM tables_cache").get() as any).cnt
-    const totalColumns = (this.db.prepare("SELECT COUNT(*) as cnt FROM columns_cache").get() as any).cnt
+    // total_tables includes both per-table rows AND tables collapsed into
+    // entity-per-table groups (counted via the group's table_count). This
+    // matches the pre-collapse behaviour so callers see the real warehouse
+    // table count regardless of digest format.
+    const perTableCount = (
+      this.db.prepare("SELECT COUNT(*) as cnt FROM tables_cache").get() as any
+    ).cnt
+    const collapsedCount = (
+      this.db
+        .prepare("SELECT COALESCE(SUM(table_count), 0) as cnt FROM entity_groups_cache")
+        .get() as any
+    ).cnt
+    const totalTables = perTableCount + collapsedCount
+
+    // total_columns covers physical columns_cache rows. Columns inside
+    // entity groups are stored once in the group's composite_columns_json
+    // rather than N times per-table; we add (composite_count * table_count)
+    // back so the total reflects logical column count.
+    const perColumnCount = (
+      this.db.prepare("SELECT COUNT(*) as cnt FROM columns_cache").get() as any
+    ).cnt
+    const groupRows = this.db
+      .prepare(
+        "SELECT table_count, composite_columns_json FROM entity_groups_cache",
+      )
+      .all() as any[]
+    let collapsedColumns = 0
+    for (const r of groupRows) {
+      try {
+        const cols = JSON.parse(r.composite_columns_json) as unknown[]
+        collapsedColumns += cols.length * r.table_count
+      } catch {
+        // ignore malformed rows
+      }
+    }
+    const totalColumns = perColumnCount + collapsedColumns
 
     return {
       warehouses,

--- a/packages/opencode/src/altimate/native/schema/cache.ts
+++ b/packages/opencode/src/altimate/native/schema/cache.ts
@@ -311,13 +311,21 @@ export class SchemaCache {
       if (detection.entity_group) {
         const eg = detection.entity_group
         const compositeColumns = eg.composite_columns
+        // Build a bounded search blob that keeps the row size predictable
+        // even for warehouses with thousands of tables in a single group.
+        // Member table names are deliberately excluded here — they live in
+        // table_names_json and are matched after FTS using the post-filter
+        // below in search() (search_text → matching_tables). Keeping
+        // them out of search_text avoids unbounded blob growth and the
+        // false-positive matches that come from common substrings (e.g.
+        // "2024", "prod") buried in 5,000 concatenated table names.
+        // Column types are also excluded so a query like `varchar` doesn't
+        // match every group containing any varchar column.
         const groupSearchText = makeSearchText(
           databaseName,
           schemaName,
           eg.sample_table,
-          ...eg.table_names,
           ...compositeColumns.map((c) => c.name),
-          ...compositeColumns.map((c) => c.data_type),
         )
         insertEntityGroup.run(
           warehouseName,
@@ -430,18 +438,32 @@ export class SchemaCache {
       }
     })
 
-    // Search entity groups: a group matches if any of its tokens appears in
-    // its search_text (which includes the full table_names list, composite
-    // column names/types, schema, and sample table). This means the agent
-    // can still find a specific collapsed table by name.
+    // Search entity groups. A group matches if any query token appears in
+    //   - search_text (schema, sample_table, composite column names — kept
+    //     small so this LIKE scan stays cheap), OR
+    //   - table_names_json (so an agent searching for a specific collapsed
+    //     table by name still finds the group; this LIKE is more expensive
+    //     per row but the entity_groups_cache row count is small).
+    // table_names are deliberately excluded from search_text itself so the
+    // blob can't grow unbounded and so that common substrings (e.g. "2024",
+    // "prod") buried inside a 5,000-table list don't produce false-positive
+    // structural matches.
+    const groupSearchClauses = tokens
+      .map(() => "(search_text LIKE ? OR table_names_json LIKE ?)")
+      .join(" OR ")
+    const groupSearchParams: string[] = []
+    for (const t of tokens) {
+      const pat = `%${t}%`
+      groupSearchParams.push(pat, pat)
+    }
     const groupRows = this.db.prepare(
       `SELECT warehouse, database_name, schema_name, pattern, table_count,
               sample_table, composite_columns_json, table_names_json
        FROM entity_groups_cache
-       WHERE ${searchCondition} ${whFilter}
+       WHERE (${groupSearchClauses}) ${whFilter}
        ORDER BY schema_name, sample_table
        LIMIT ?`,
-    ).all(...searchParams, ...whParams, limit) as any[]
+    ).all(...groupSearchParams, ...whParams, limit) as any[]
 
     const entityGroups: SchemaSearchEntityGroupResult[] = groupRows.map((row) => {
       const compositeColumns = JSON.parse(row.composite_columns_json) as {
@@ -543,7 +565,18 @@ export class SchemaCache {
 
   /**
    * List all columns for a given warehouse (no search filter).
-   * Used by PII detection to scan all cached columns.
+   *
+   * Returns BOTH per-table cached columns AND synthetic rows reconstructed
+   * from collapsed entity-per-table groups (one row per (member_table,
+   * composite_column) tuple). This is critical for downstream consumers
+   * like `schema_detect_pii` and `sql_execute` pre-validation: without the
+   * synthetic expansion, a fully-collapsed warehouse would return an empty
+   * column list and PII detection would silently produce false-clean
+   * reports.
+   *
+   * The `limit` is applied to the COMBINED result. Per-table rows are
+   * returned first (preserving prior ordering); reconstructed group rows
+   * are appended only if there is remaining capacity.
    */
   listColumns(
     warehouse: string,
@@ -557,7 +590,7 @@ export class SchemaCache {
        LIMIT ?`,
     ).all(warehouse, limit) as any[]
 
-    return rows.map((row) => {
+    const result: SchemaSearchColumnResult[] = rows.map((row) => {
       const fqnParts = [row.database_name, row.schema_name, row.table_name, row.column_name].filter(Boolean)
       return {
         warehouse: row.warehouse,
@@ -570,6 +603,57 @@ export class SchemaCache {
         fqn: fqnParts.join("."),
       }
     })
+
+    if (result.length >= limit) return result
+
+    // Reconstruct per-table column rows from any entity groups belonging to
+    // this warehouse so downstream column scanners (PII, SQL pre-validation)
+    // see a complete view of the warehouse, not just the per-table cache.
+    const groupRows = this.db.prepare(
+      `SELECT warehouse, database_name, schema_name, composite_columns_json, table_names_json
+       FROM entity_groups_cache
+       WHERE warehouse = ?
+       ORDER BY schema_name, sample_table`,
+    ).all(warehouse) as any[]
+
+    for (const gr of groupRows) {
+      let cols: { name: string; data_type: string }[] = []
+      let tableNames: string[] = []
+      try {
+        cols = JSON.parse(gr.composite_columns_json)
+        tableNames = JSON.parse(gr.table_names_json)
+      } catch {
+        // Skip malformed rows rather than blowing up the whole listing.
+        continue
+      }
+      for (const tableName of tableNames) {
+        for (const col of cols) {
+          if (result.length >= limit) return result
+          const fqnParts = [
+            gr.database_name,
+            gr.schema_name,
+            tableName,
+            col.name,
+          ].filter(Boolean)
+          result.push({
+            warehouse: gr.warehouse,
+            database: gr.database_name ?? undefined,
+            schema_name: gr.schema_name,
+            table: tableName,
+            name: col.name,
+            data_type: col.data_type ?? undefined,
+            // Composite columns don't carry per-column nullability today;
+            // the detector only fingerprints (name, type). Default to true
+            // (nullable) to match `columns_cache`'s default and avoid making
+            // PII detection / SQL validation reject rows on a missing flag.
+            nullable: true,
+            fqn: fqnParts.join("."),
+          })
+        }
+      }
+    }
+
+    return result
   }
 
   close(): void {

--- a/packages/opencode/src/altimate/native/schema/entity-groups.ts
+++ b/packages/opencode/src/altimate/native/schema/entity-groups.ts
@@ -1,0 +1,174 @@
+/**
+ * Entity-per-table pattern detector.
+ *
+ * Many warehouses have N tables that share the same column structure (one
+ * ticker per table, one tenant per table, time-partitioned tables, per-region
+ * tables). Naively cached per-table this wastes context and gets truncated.
+ *
+ * This module detects such groups by fingerprinting each table's column
+ * structure and looking for fingerprints that dominate a schema. When found,
+ * the cache emits a single composite digest (with full table_names list)
+ * instead of N near-identical per-table entries.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A column as needed for fingerprinting. */
+export interface FingerprintColumn {
+  name: string
+  data_type: string
+}
+
+/** Input row: one table with its column shape. */
+export interface TableShape {
+  table_name: string
+  columns: FingerprintColumn[]
+}
+
+/** A detected entity-per-table group, dense and ready for digest emission. */
+export interface EntityGroup {
+  /** Stable string fingerprint identifying the shared column shape. */
+  fingerprint: string
+  /** Canonical column list (sorted by name). */
+  composite_columns: FingerprintColumn[]
+  /** Full list of tables that share this fingerprint. */
+  table_names: string[]
+  /** Picked sample table (alphabetical first) for users wanting a peek. */
+  sample_table: string
+}
+
+/** Result of running detection over one schema's tables. */
+export interface EntityGroupDetection {
+  /** Detected entity group, or null if no group passed the threshold. */
+  entity_group: EntityGroup | null
+  /** Tables NOT covered by the entity group — emit per-table as before. */
+  remaining_tables: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic parameters
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimum share of tables a single fingerprint must cover to be considered
+ * an "entity-per-table" pattern. Default: 50%.
+ */
+export const DEFAULT_ENTITY_RATIO_THRESHOLD = 0.5
+
+/**
+ * Minimum absolute number of tables in the dominant group. Below this we
+ * stay with per-table emission — the cost saving isn't worth a new format.
+ */
+export const DEFAULT_ENTITY_MIN_TABLES = 20
+
+// ---------------------------------------------------------------------------
+// Fingerprinting
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a stable fingerprint of a table's column shape.
+ *
+ * Sorted by column name so identical structures collide regardless of the
+ * order the source database returns columns in. Type is lowercased so
+ * `VARCHAR` and `varchar` match.
+ */
+export function fingerprintColumns(columns: FingerprintColumn[]): string {
+  if (columns.length === 0) return ""
+  const sorted = [...columns]
+    .map((c) => ({ name: c.name, data_type: (c.data_type || "").toLowerCase() }))
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+  return sorted.map((c) => `${c.name}:${c.data_type}`).join("|")
+}
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Group tables by column-structure fingerprint and detect an entity-per-table
+ * group. A fingerprint group qualifies when it covers
+ *   - at least `ratioThreshold` of all tables in the input, AND
+ *   - at least `minTables` tables in absolute terms.
+ *
+ * Tables with empty column lists are ignored for grouping (they can't be
+ * fingerprinted reliably) and always end up in `remaining_tables`.
+ */
+export function detectEntityGroup(
+  tables: TableShape[],
+  options: { ratioThreshold?: number; minTables?: number } = {},
+): EntityGroupDetection {
+  const ratioThreshold = options.ratioThreshold ?? DEFAULT_ENTITY_RATIO_THRESHOLD
+  const minTables = options.minTables ?? DEFAULT_ENTITY_MIN_TABLES
+
+  if (tables.length === 0) {
+    return { entity_group: null, remaining_tables: [] }
+  }
+
+  // Bucket tables by fingerprint.
+  const buckets = new Map<string, TableShape[]>()
+  const noFingerprint: string[] = []
+  for (const t of tables) {
+    if (!t.columns || t.columns.length === 0) {
+      noFingerprint.push(t.table_name)
+      continue
+    }
+    const fp = fingerprintColumns(t.columns)
+    const bucket = buckets.get(fp)
+    if (bucket) {
+      bucket.push(t)
+    } else {
+      buckets.set(fp, [t])
+    }
+  }
+
+  if (buckets.size === 0) {
+    return { entity_group: null, remaining_tables: noFingerprint }
+  }
+
+  // Pick the largest bucket.
+  let bestFp: string | null = null
+  let bestBucket: TableShape[] = []
+  for (const [fp, bucket] of buckets) {
+    if (bucket.length > bestBucket.length) {
+      bestFp = fp
+      bestBucket = bucket
+    }
+  }
+
+  // Threshold check uses total fingerprintable + non-fingerprintable tables
+  // — i.e. the full input — so a schema dominated by empty-column tables
+  // can't tip the ratio.
+  const totalTables = tables.length
+  const meetsRatio = bestBucket.length / totalTables >= ratioThreshold
+  const meetsMin = bestBucket.length >= minTables
+  if (!bestFp || !meetsRatio || !meetsMin) {
+    const remaining = tables.map((t) => t.table_name)
+    return { entity_group: null, remaining_tables: remaining }
+  }
+
+  // Build the canonical composite column list from the first table in the
+  // bucket. Sort by name so output is stable and matches the fingerprint.
+  const compositeColumns: FingerprintColumn[] = [...bestBucket[0].columns]
+    .map((c) => ({ name: c.name, data_type: c.data_type }))
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+
+  const tableNames = bestBucket.map((t) => t.table_name).sort()
+  const inGroup = new Set(tableNames)
+
+  const remaining: string[] = []
+  for (const t of tables) {
+    if (!inGroup.has(t.table_name)) remaining.push(t.table_name)
+  }
+
+  return {
+    entity_group: {
+      fingerprint: bestFp,
+      composite_columns: compositeColumns,
+      table_names: tableNames,
+      sample_table: tableNames[0],
+    },
+    remaining_tables: remaining.sort(),
+  }
+}

--- a/packages/opencode/src/altimate/native/schema/entity-groups.ts
+++ b/packages/opencode/src/altimate/native/schema/entity-groups.ts
@@ -39,7 +39,22 @@ export interface EntityGroup {
   sample_table: string
 }
 
-/** Result of running detection over one schema's tables. */
+/**
+ * Result of running detection over one schema's tables.
+ *
+ * NOTE: At most ONE entity group is returned per schema — the one with the
+ * largest member bucket among fingerprints that meet both the ratio and
+ * minTables thresholds. Schemas that contain two or more distinct entity
+ * patterns (e.g. 100 per-ticker tables AND 80 per-region tables) will only
+ * have the dominant pattern collapsed; the other pattern's tables fall into
+ * `remaining_tables` and are emitted per-table by the cache.
+ *
+ * This is a deliberate scope choice: the cache UNIQUE on
+ * `(warehouse, database, schema, fingerprint)` allows multiple groups per
+ * schema, but multi-group detection is left for a follow-up to keep the
+ * rollout backwards-compatible. Callers needing all groups for a schema
+ * should call `detectEntityGroup` repeatedly on `remaining_tables`.
+ */
 export interface EntityGroupDetection {
   /** Detected entity group, or null if no group passed the threshold. */
   entity_group: EntityGroup | null
@@ -68,18 +83,38 @@ export const DEFAULT_ENTITY_MIN_TABLES = 20
 // ---------------------------------------------------------------------------
 
 /**
+ * Sentinel marker for columns whose data_type is null/undefined. Distinct from
+ * the empty string so a real type of "" (drivers may legitimately return that)
+ * does not collide with a missing type.
+ */
+const NULL_TYPE_SENTINEL = "\u0000__null_type__\u0000"
+
+/**
  * Build a stable fingerprint of a table's column shape.
  *
  * Sorted by column name so identical structures collide regardless of the
  * order the source database returns columns in. Type is lowercased so
  * `VARCHAR` and `varchar` match.
+ *
+ * Encoding uses `JSON.stringify` per (name, type) tuple joined by a unit
+ * separator (\x1F). That keeps the fingerprint delimiter-safe even when
+ * column names contain `:` or `|` (legal in quoted Postgres/Snowflake/
+ * BigQuery identifiers). Null/undefined `data_type` values are mapped to a
+ * dedicated sentinel so two tables that differ only in "missing type vs real
+ * type" do not collide.
  */
 export function fingerprintColumns(columns: FingerprintColumn[]): string {
   if (columns.length === 0) return ""
   const sorted = [...columns]
-    .map((c) => ({ name: c.name, data_type: (c.data_type || "").toLowerCase() }))
+    .map((c) => ({
+      name: c.name,
+      data_type:
+        c.data_type == null
+          ? NULL_TYPE_SENTINEL
+          : c.data_type.toLowerCase(),
+    }))
     .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
-  return sorted.map((c) => `${c.name}:${c.data_type}`).join("|")
+  return sorted.map((c) => JSON.stringify([c.name, c.data_type])).join("\x1F")
 }
 
 // ---------------------------------------------------------------------------
@@ -101,6 +136,24 @@ export function detectEntityGroup(
 ): EntityGroupDetection {
   const ratioThreshold = options.ratioThreshold ?? DEFAULT_ENTITY_RATIO_THRESHOLD
   const minTables = options.minTables ?? DEFAULT_ENTITY_MIN_TABLES
+
+  // Reject obviously-bad threshold inputs so silent miscalibrations from
+  // upstream callers (NaN, negative, fractional minTables) fail loudly.
+  if (
+    typeof ratioThreshold !== "number" ||
+    !Number.isFinite(ratioThreshold) ||
+    ratioThreshold <= 0 ||
+    ratioThreshold > 1
+  ) {
+    throw new Error(
+      `entity-groups: ratioThreshold must be a number in (0, 1]; got ${ratioThreshold}`,
+    )
+  }
+  if (!Number.isInteger(minTables) || minTables < 2) {
+    throw new Error(
+      `entity-groups: minTables must be an integer >= 2; got ${minTables}`,
+    )
+  }
 
   if (tables.length === 0) {
     return { entity_group: null, remaining_tables: [] }

--- a/packages/opencode/src/altimate/native/schema/register.ts
+++ b/packages/opencode/src/altimate/native/schema/register.ts
@@ -34,7 +34,15 @@ register("schema.index", async (params: SchemaIndexParams): Promise<SchemaIndexR
 
   const cache = await getCache()
   try {
-    const result = await cache.indexWarehouse(params.warehouse, warehouseType, connector)
+    const result = await cache.indexWarehouse(
+      params.warehouse,
+      warehouseType,
+      connector,
+      {
+        entityRatioThreshold: params.entityRatioThreshold,
+        entityMinTables: params.entityMinTables,
+      },
+    )
     try {
       Telemetry.track({
         type: "warehouse_introspection",

--- a/packages/opencode/src/altimate/native/types.ts
+++ b/packages/opencode/src/altimate/native/types.ts
@@ -371,6 +371,18 @@ export interface WarehouseDiscoverResult {
 
 export interface SchemaIndexParams {
   warehouse: string
+  /**
+   * Override for entity-per-table detection ratio threshold (default 0.5 =
+   * 50%). A fingerprint group qualifies if it covers at least this fraction
+   * of tables in a schema. Must be in (0, 1].
+   */
+  entityRatioThreshold?: number
+  /**
+   * Override for entity-per-table detection minimum table count (default 20).
+   * Groups smaller than this are not collapsed even if they dominate. Must
+   * be an integer >= 2.
+   */
+  entityMinTables?: number
 }
 
 export interface SchemaIndexResult {

--- a/packages/opencode/src/altimate/native/types.ts
+++ b/packages/opencode/src/altimate/native/types.ts
@@ -380,6 +380,29 @@ export interface SchemaIndexResult {
   tables_indexed: number
   columns_indexed: number
   timestamp: string
+  /**
+   * Entity-per-table groups detected during indexing. Each group represents
+   * many tables sharing the same column structure that the cache collapsed
+   * into a single composite digest.
+   */
+  entity_groups?: SchemaEntityGroupSummary[]
+}
+
+/**
+ * Summary of a single entity-per-table group. The cache emits one of these
+ * per (database, schema) when ≥50% of tables share an identical column
+ * structure and the group has at least 20 tables.
+ */
+export interface SchemaEntityGroupSummary {
+  warehouse: string
+  database?: string
+  schema_name: string
+  /** Always "entity-per-table" — left as a field for forward compat. */
+  pattern: string
+  table_count: number
+  composite_columns: { name: string; data_type: string }[]
+  sample_table: string
+  table_names: string[]
 }
 
 export interface SchemaSearchParams {
@@ -414,6 +437,24 @@ export interface SchemaSearchResult {
   columns: SchemaSearchColumnResult[]
   query: string
   match_count: number
+  /**
+   * Entity-per-table groups whose composite columns or member table names
+   * matched the query. Populated by schema.search so users can still find
+   * specific tables by name even when they were collapsed into a digest.
+   */
+  entity_groups?: SchemaSearchEntityGroupResult[]
+}
+
+export interface SchemaSearchEntityGroupResult {
+  warehouse: string
+  database?: string
+  schema_name: string
+  pattern: string
+  table_count: number
+  composite_columns: { name: string; data_type: string }[]
+  sample_table: string
+  /** Tables in this group whose names matched the query (subset). */
+  matching_tables: string[]
 }
 
 export interface SchemaCacheStatusParams {}

--- a/packages/opencode/src/altimate/tools/schema-index.ts
+++ b/packages/opencode/src/altimate/tools/schema-index.ts
@@ -8,14 +8,32 @@ import { PostConnectSuggestions } from "./post-connect-suggestions"
 
 export const SchemaIndexTool = Tool.define("schema_index", {
   description:
-    "Index a warehouse's schema metadata (databases, schemas, tables, columns) into a local cache for fast search. Run this after connecting to a new warehouse or when schema changes occur.",
+    "Index a warehouse's schema metadata (databases, schemas, tables, columns) into a local cache for fast search. Run this after connecting to a new warehouse or when schema changes occur. Schemas with many same-shape tables (e.g. one table per ticker/tenant/region) are auto-collapsed into a single composite digest. NOTE: at most one entity-per-table group is detected per schema; a schema with two distinct patterns has only the dominant one collapsed and the secondary pattern's tables emitted per-table.",
   parameters: z.object({
     warehouse: z.string().describe("Warehouse connection name from connections.json"),
+    entityRatioThreshold: z
+      .number()
+      .gt(0)
+      .lte(1)
+      .optional()
+      .describe(
+        "Override the entity-per-table detection ratio threshold (default 0.5 = 50%). Must be in (0, 1].",
+      ),
+    entityMinTables: z
+      .number()
+      .int()
+      .min(2)
+      .optional()
+      .describe(
+        "Override the minimum table count for an entity-per-table group (default 20). Must be an integer >= 2.",
+      ),
   }),
   async execute(args, ctx) {
     try {
       const result = await Dispatcher.call("schema.index", {
         warehouse: args.warehouse,
+        entityRatioThreshold: args.entityRatioThreshold,
+        entityMinTables: args.entityMinTables,
       })
 
       // altimate_change start — progressive disclosure suggestions
@@ -44,12 +62,38 @@ export const SchemaIndexTool = Tool.define("schema_index", {
       const msg = e instanceof Error ? e.message : String(e)
       return {
         title: "Schema Index: ERROR",
-        metadata: { schemas: 0, tables: 0, columns: 0 },
+        metadata: { schemas: 0, tables: 0, columns: 0, entity_groups: 0 },
         output: `Failed to index warehouse schema: ${msg}\n\nEnsure the warehouse connection is configured in connections.json and the dispatcher is running.`,
       }
     }
   },
 })
+
+/**
+ * Maximum number of leading + trailing entity-group member names included in
+ * the `schema_index` formatter output. The full list is preserved on the
+ * structured result; truncation is purely for the human/LLM-facing string.
+ *
+ * The whole point of collapsing entity-per-table groups is to keep
+ * `schema_index` output bounded; emitting all 5,000+ names defeats that.
+ */
+const TABLE_NAMES_HEAD_LIMIT = 50
+const TABLE_NAMES_TAIL_LIMIT = 5
+
+/**
+ * Format a possibly-large `table_names` list for display. Programmatic
+ * callers should read `result.entity_groups[i].table_names` directly off the
+ * structured response — that field is never truncated.
+ */
+function formatTableNames(tableNames: string[]): string {
+  if (tableNames.length <= TABLE_NAMES_HEAD_LIMIT + TABLE_NAMES_TAIL_LIMIT) {
+    return `[${tableNames.join(", ")}]`
+  }
+  const head = tableNames.slice(0, TABLE_NAMES_HEAD_LIMIT)
+  const tail = tableNames.slice(-TABLE_NAMES_TAIL_LIMIT)
+  const omitted = tableNames.length - head.length - tail.length
+  return `[${head.join(", ")}, ... +${omitted} more (use schema_search to enumerate), ${tail.join(", ")}]`
+}
 
 function formatIndexResult(result: SchemaIndexResult): string {
   const lines: string[] = [
@@ -74,8 +118,10 @@ function formatIndexResult(result: SchemaIndexResult): string {
         .join(", ")
       lines.push(`composite_columns: [${cols}]`)
       lines.push(`sample_table: ${g.sample_table}`)
-      // table_names can be very long; emit comma-separated. Agent can grep.
-      lines.push(`table_names: [${g.table_names.join(", ")}]`)
+      // table_names is potentially huge (thousands of per-tenant tables);
+      // truncate the rendered string but keep the full list intact on the
+      // structured result for programmatic readers.
+      lines.push(`table_names: ${formatTableNames(g.table_names)}`)
     }
   }
 

--- a/packages/opencode/src/altimate/tools/schema-index.ts
+++ b/packages/opencode/src/altimate/tools/schema-index.ts
@@ -36,6 +36,7 @@ export const SchemaIndexTool = Tool.define("schema_index", {
           schemas: result.schemas_indexed,
           tables: result.tables_indexed,
           columns: result.columns_indexed,
+          entity_groups: result.entity_groups?.length ?? 0,
         },
         output,
       }
@@ -57,8 +58,30 @@ function formatIndexResult(result: SchemaIndexResult): string {
     `Tables indexed: ${result.tables_indexed}`,
     `Columns indexed: ${result.columns_indexed}`,
     `Timestamp: ${result.timestamp}`,
-    "",
-    "Schema cache is now ready. Use schema_search to find tables and columns by name or description.",
   ]
+
+  if (result.entity_groups && result.entity_groups.length > 0) {
+    lines.push("")
+    lines.push(`Entity-per-table groups detected: ${result.entity_groups.length}`)
+    for (const g of result.entity_groups) {
+      const fqSchema = g.database ? `${g.database}.${g.schema_name}` : g.schema_name
+      lines.push("")
+      lines.push(`schema: ${fqSchema}`)
+      lines.push(`pattern: ${g.pattern}`)
+      lines.push(`table_count: ${g.table_count}`)
+      const cols = g.composite_columns
+        .map((c) => `{name: "${c.name}", type: "${c.data_type}"}`)
+        .join(", ")
+      lines.push(`composite_columns: [${cols}]`)
+      lines.push(`sample_table: ${g.sample_table}`)
+      // table_names can be very long; emit comma-separated. Agent can grep.
+      lines.push(`table_names: [${g.table_names.join(", ")}]`)
+    }
+  }
+
+  lines.push("")
+  lines.push(
+    "Schema cache is now ready. Use schema_search to find tables and columns by name or description.",
+  )
   return lines.join("\n")
 }

--- a/packages/opencode/src/altimate/tools/schema-search.ts
+++ b/packages/opencode/src/altimate/tools/schema-search.ts
@@ -24,7 +24,7 @@ export const SchemaSearchTool = Tool.define("schema_search", {
       if (result.match_count === 0) {
         return {
           title: `Schema Search: "${args.query}" — no results`,
-          metadata: { matchCount: 0, tableCount: 0, columnCount: 0 },
+          metadata: { matchCount: 0, tableCount: 0, columnCount: 0, entityGroupCount: 0 },
           output: `No tables or columns matching "${args.query}" found in the schema cache.\n\nMake sure you've run schema_index first to populate the cache.`,
         }
       }
@@ -35,6 +35,7 @@ export const SchemaSearchTool = Tool.define("schema_search", {
           matchCount: result.match_count,
           tableCount: result.tables.length,
           columnCount: result.columns.length,
+          entityGroupCount: result.entity_groups?.length ?? 0,
         },
         output: formatSearchResult(result),
       }
@@ -70,6 +71,27 @@ function formatSearchResult(result: SchemaSearchResult): string {
     lines.push("----|------|--------")
     for (const c of result.columns) {
       lines.push(`${c.fqn} | ${c.data_type ?? "unknown"} | ${c.nullable ? "YES" : "NO"}`)
+    }
+    lines.push("")
+  }
+
+  if (result.entity_groups && result.entity_groups.length > 0) {
+    lines.push(`## Entity-per-table Groups (${result.entity_groups.length} matches)`)
+    lines.push("")
+    for (const g of result.entity_groups) {
+      const fqSchema = g.database ? `${g.database}.${g.schema_name}` : g.schema_name
+      lines.push(`schema: ${fqSchema}  (warehouse: ${g.warehouse})`)
+      lines.push(`pattern: ${g.pattern}`)
+      lines.push(`table_count: ${g.table_count}`)
+      const cols = g.composite_columns
+        .map((c) => `{name: "${c.name}", type: "${c.data_type}"}`)
+        .join(", ")
+      lines.push(`composite_columns: [${cols}]`)
+      lines.push(`sample_table: ${g.sample_table}`)
+      if (g.matching_tables.length > 0) {
+        lines.push(`matching_tables: [${g.matching_tables.join(", ")}]`)
+      }
+      lines.push("")
     }
   }
 

--- a/packages/opencode/test/altimate/entity-groups.test.ts
+++ b/packages/opencode/test/altimate/entity-groups.test.ts
@@ -79,6 +79,46 @@ describe("fingerprintColumns", () => {
   test("empty columns produce empty fingerprint", () => {
     expect(fingerprintColumns([])).toBe("")
   })
+
+  test("column names containing ':' do not collide with the type separator", () => {
+    // Pre-fix `${name}:${type}|...` joining made `(a:b, INT)` collide with
+    // `(a, b:INT)` etc. The new JSON-stringify-per-tuple encoding must keep
+    // these distinct.
+    const fp1 = fingerprintColumns([{ name: "a:b", data_type: "INT" }])
+    const fp2 = fingerprintColumns([{ name: "a", data_type: "b:INT" }])
+    expect(fp1).not.toBe(fp2)
+  })
+
+  test("column names containing '|' do not collide with the column separator", () => {
+    // Pre-fix `${name}:${type}|${name}:${type}` made `("a|b", X)` collide
+    // with `(a, X), (b, X)` after sorting.
+    const fp1 = fingerprintColumns([{ name: "a|b", data_type: "X" }])
+    const fp2 = fingerprintColumns([
+      { name: "a", data_type: "X" },
+      { name: "b", data_type: "X" },
+    ])
+    expect(fp1).not.toBe(fp2)
+  })
+
+  test("null/undefined data_type collapses to a sentinel distinct from empty string", () => {
+    // Two semantically-different missing-type columns should still fingerprint
+    // identically to each other.
+    const fpNull = fingerprintColumns([
+      { name: "x", data_type: null as unknown as string },
+    ])
+    const fpUndef = fingerprintColumns([
+      { name: "x", data_type: undefined as unknown as string },
+    ])
+    expect(fpNull).toBe(fpUndef)
+
+    // But should be distinct from a column with an actual empty-string type
+    // and from a column with a real type.
+    const fpEmpty = fingerprintColumns([{ name: "x", data_type: "" }])
+    const fpReal = fingerprintColumns([{ name: "x", data_type: "TEXT" }])
+    expect(fpNull).not.toBe(fpEmpty)
+    expect(fpNull).not.toBe(fpReal)
+    expect(fpEmpty).not.toBe(fpReal)
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -241,6 +281,50 @@ describe("detectEntityGroup — threshold parameters", () => {
     const result = detectEntityGroup(tables, { minTables: 5 })
     expect(result.entity_group).not.toBeNull()
     expect(result.entity_group!.table_names).toHaveLength(7)
+  })
+
+  test("rejects ratioThreshold <= 0", () => {
+    const tables = stockTables(Array.from({ length: 25 }, (_, i) => `T${i}`))
+    expect(() => detectEntityGroup(tables, { ratioThreshold: 0 })).toThrow(
+      /ratioThreshold/,
+    )
+    expect(() => detectEntityGroup(tables, { ratioThreshold: -0.1 })).toThrow(
+      /ratioThreshold/,
+    )
+  })
+
+  test("rejects ratioThreshold > 1", () => {
+    const tables = stockTables(Array.from({ length: 25 }, (_, i) => `T${i}`))
+    expect(() => detectEntityGroup(tables, { ratioThreshold: 1.5 })).toThrow(
+      /ratioThreshold/,
+    )
+  })
+
+  test("rejects NaN ratioThreshold", () => {
+    const tables = stockTables(Array.from({ length: 25 }, (_, i) => `T${i}`))
+    expect(() => detectEntityGroup(tables, { ratioThreshold: Number.NaN })).toThrow(
+      /ratioThreshold/,
+    )
+  })
+
+  test("rejects minTables < 2", () => {
+    const tables = stockTables(Array.from({ length: 25 }, (_, i) => `T${i}`))
+    expect(() => detectEntityGroup(tables, { minTables: 0 })).toThrow(/minTables/)
+    expect(() => detectEntityGroup(tables, { minTables: 1 })).toThrow(/minTables/)
+    expect(() => detectEntityGroup(tables, { minTables: -5 })).toThrow(/minTables/)
+  })
+
+  test("rejects non-integer minTables", () => {
+    const tables = stockTables(Array.from({ length: 25 }, (_, i) => `T${i}`))
+    expect(() => detectEntityGroup(tables, { minTables: 3.7 })).toThrow(
+      /minTables/,
+    )
+  })
+
+  test("ratioThreshold = 1 is permitted (exact-match cap)", () => {
+    const tables = stockTables(Array.from({ length: 25 }, (_, i) => `T${i}`))
+    const result = detectEntityGroup(tables, { ratioThreshold: 1 })
+    expect(result.entity_group).not.toBeNull()
   })
 
   test("custom ratio_threshold=0.8 rejects weakly-dominant groups", () => {

--- a/packages/opencode/test/altimate/entity-groups.test.ts
+++ b/packages/opencode/test/altimate/entity-groups.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Unit tests for the entity-per-table detector.
+ */
+
+import { describe, expect, test } from "bun:test"
+import {
+  detectEntityGroup,
+  fingerprintColumns,
+  type TableShape,
+  DEFAULT_ENTITY_RATIO_THRESHOLD,
+  DEFAULT_ENTITY_MIN_TABLES,
+} from "../../src/altimate/native/schema/entity-groups"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const STOCK_COLS = [
+  { name: "Date", data_type: "VARCHAR" },
+  { name: "Open", data_type: "DOUBLE" },
+  { name: "High", data_type: "DOUBLE" },
+  { name: "Low", data_type: "DOUBLE" },
+  { name: "Close", data_type: "DOUBLE" },
+  { name: "Adj Close", data_type: "DOUBLE" },
+  { name: "Volume", data_type: "BIGINT" },
+]
+
+function stockTables(names: string[]): TableShape[] {
+  return names.map((name) => ({ table_name: name, columns: STOCK_COLS }))
+}
+
+// ---------------------------------------------------------------------------
+// fingerprintColumns
+// ---------------------------------------------------------------------------
+
+describe("fingerprintColumns", () => {
+  test("identical columns produce identical fingerprints", () => {
+    const fp1 = fingerprintColumns([
+      { name: "id", data_type: "INT" },
+      { name: "name", data_type: "TEXT" },
+    ])
+    const fp2 = fingerprintColumns([
+      { name: "id", data_type: "INT" },
+      { name: "name", data_type: "TEXT" },
+    ])
+    expect(fp1).toBe(fp2)
+  })
+
+  test("column order does not affect fingerprint", () => {
+    const fp1 = fingerprintColumns([
+      { name: "a", data_type: "INT" },
+      { name: "b", data_type: "TEXT" },
+    ])
+    const fp2 = fingerprintColumns([
+      { name: "b", data_type: "TEXT" },
+      { name: "a", data_type: "INT" },
+    ])
+    expect(fp1).toBe(fp2)
+  })
+
+  test("type case does not affect fingerprint", () => {
+    const fp1 = fingerprintColumns([{ name: "x", data_type: "VARCHAR" }])
+    const fp2 = fingerprintColumns([{ name: "x", data_type: "varchar" }])
+    expect(fp1).toBe(fp2)
+  })
+
+  test("different types yield different fingerprints", () => {
+    const fp1 = fingerprintColumns([{ name: "x", data_type: "INT" }])
+    const fp2 = fingerprintColumns([{ name: "x", data_type: "BIGINT" }])
+    expect(fp1).not.toBe(fp2)
+  })
+
+  test("different column names yield different fingerprints", () => {
+    const fp1 = fingerprintColumns([{ name: "id", data_type: "INT" }])
+    const fp2 = fingerprintColumns([{ name: "user_id", data_type: "INT" }])
+    expect(fp1).not.toBe(fp2)
+  })
+
+  test("empty columns produce empty fingerprint", () => {
+    expect(fingerprintColumns([])).toBe("")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// detectEntityGroup — positive detections
+// ---------------------------------------------------------------------------
+
+describe("detectEntityGroup — entity-per-table patterns", () => {
+  test("100 same-shape tables are marked as one entity group", () => {
+    const names: string[] = []
+    for (let i = 0; i < 100; i++) names.push(`TICKER_${i}`)
+    const tables = stockTables(names)
+
+    const result = detectEntityGroup(tables)
+
+    expect(result.entity_group).not.toBeNull()
+    expect(result.entity_group!.table_names).toHaveLength(100)
+    expect(result.entity_group!.composite_columns).toHaveLength(STOCK_COLS.length)
+    expect(result.remaining_tables).toHaveLength(0)
+  })
+
+  test("composite columns are sorted alphabetically by name", () => {
+    const names: string[] = []
+    for (let i = 0; i < 25; i++) names.push(`t${i}`)
+    const tables = stockTables(names)
+
+    const result = detectEntityGroup(tables)
+    expect(result.entity_group).not.toBeNull()
+    const names_sorted = result.entity_group!.composite_columns.map((c) => c.name)
+    const expected = [...names_sorted].sort()
+    expect(names_sorted).toEqual(expected)
+  })
+
+  test("table_names are sorted alphabetically", () => {
+    const names = ["MSFT", "AAPL", "GOOG", "AMZN"]
+    for (let i = 0; i < 20; i++) names.push(`X${i}`)
+    const tables = stockTables(names)
+
+    const result = detectEntityGroup(tables)
+    expect(result.entity_group).not.toBeNull()
+    const got = result.entity_group!.table_names
+    const expected = [...got].sort()
+    expect(got).toEqual(expected)
+  })
+
+  test("sample_table is the alphabetical first member", () => {
+    const names = ["ZZ", "AA", "MM"]
+    for (let i = 0; i < 20; i++) names.push(`X${i}`)
+    const tables = stockTables(names)
+
+    const result = detectEntityGroup(tables)
+    expect(result.entity_group).not.toBeNull()
+    expect(result.entity_group!.sample_table).toBe("AA")
+  })
+
+  test("dominant group + a few odd tables: entity group + remainders", () => {
+    const same = stockTables(Array.from({ length: 50 }, (_, i) => `TICK_${i}`))
+    const different: TableShape[] = [
+      {
+        table_name: "metadata",
+        columns: [
+          { name: "ticker", data_type: "VARCHAR" },
+          { name: "company_name", data_type: "VARCHAR" },
+        ],
+      },
+      {
+        table_name: "exchange_info",
+        columns: [
+          { name: "code", data_type: "VARCHAR" },
+          { name: "country", data_type: "VARCHAR" },
+        ],
+      },
+    ]
+    const tables = [...same, ...different]
+
+    const result = detectEntityGroup(tables)
+    expect(result.entity_group).not.toBeNull()
+    expect(result.entity_group!.table_names).toHaveLength(50)
+    expect(result.remaining_tables).toEqual(["exchange_info", "metadata"])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// detectEntityGroup — negative cases
+// ---------------------------------------------------------------------------
+
+describe("detectEntityGroup — patterns that should NOT trigger", () => {
+  test("5 mixed-shape tables: no entity group", () => {
+    const tables: TableShape[] = [
+      { table_name: "users", columns: [{ name: "id", data_type: "INT" }] },
+      { table_name: "orders", columns: [{ name: "order_id", data_type: "INT" }] },
+      { table_name: "products", columns: [{ name: "sku", data_type: "TEXT" }] },
+      { table_name: "events", columns: [{ name: "ts", data_type: "TIMESTAMP" }] },
+      { table_name: "logs", columns: [{ name: "level", data_type: "TEXT" }] },
+    ]
+    const result = detectEntityGroup(tables)
+    expect(result.entity_group).toBeNull()
+    expect(result.remaining_tables).toHaveLength(5)
+  })
+
+  test("50 same + 50 different: under 50% threshold so no entity group", () => {
+    // 50 same-shape + 50 of a different but also-uniform shape = exactly 50%
+    // each. Threshold is "≥50%" so technically either could pass on a tie,
+    // but the second group has only 50 tables sharing an exact shape if we
+    // give them all the same shape too — so let's spread the 50 across
+    // many shapes to ensure no other group has ≥50%.
+    const groupA = stockTables(Array.from({ length: 50 }, (_, i) => `A${i}`))
+    const groupB: TableShape[] = []
+    for (let i = 0; i < 50; i++) {
+      groupB.push({
+        table_name: `B${i}`,
+        // Each table has a unique extra column so no two share a shape.
+        columns: [
+          { name: "id", data_type: "INT" },
+          { name: `col_${i}`, data_type: "TEXT" },
+        ],
+      })
+    }
+    const tables = [...groupA, ...groupB]
+
+    // groupA covers 50/100 = 50% exactly. The threshold is ≥50%, so this
+    // *would* qualify under default thresholds. To be deliberate we ratchet
+    // the threshold up to 60% and confirm it doesn't trigger.
+    const result = detectEntityGroup(tables, { ratioThreshold: 0.6 })
+    expect(result.entity_group).toBeNull()
+    expect(result.remaining_tables).toHaveLength(100)
+  })
+
+  test("19 same-shape tables: under min_tables threshold", () => {
+    const tables = stockTables(Array.from({ length: 19 }, (_, i) => `T${i}`))
+    // Even though 100% share a shape, 19 < 20 (min). No group.
+    const result = detectEntityGroup(tables)
+    expect(result.entity_group).toBeNull()
+    expect(result.remaining_tables).toHaveLength(19)
+  })
+
+  test("empty input returns null group, empty remainders", () => {
+    const result = detectEntityGroup([])
+    expect(result.entity_group).toBeNull()
+    expect(result.remaining_tables).toHaveLength(0)
+  })
+
+  test("tables with no columns are never grouped", () => {
+    const tables: TableShape[] = []
+    for (let i = 0; i < 30; i++) {
+      tables.push({ table_name: `t${i}`, columns: [] })
+    }
+    const result = detectEntityGroup(tables)
+    expect(result.entity_group).toBeNull()
+    expect(result.remaining_tables).toHaveLength(30)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// detectEntityGroup — threshold knobs
+// ---------------------------------------------------------------------------
+
+describe("detectEntityGroup — threshold parameters", () => {
+  test("custom min_tables=5 catches small entity sets", () => {
+    const tables = stockTables(["A", "B", "C", "D", "E", "F", "G"])
+    const result = detectEntityGroup(tables, { minTables: 5 })
+    expect(result.entity_group).not.toBeNull()
+    expect(result.entity_group!.table_names).toHaveLength(7)
+  })
+
+  test("custom ratio_threshold=0.8 rejects weakly-dominant groups", () => {
+    // 60% same-shape, 40% varied — under 80% threshold.
+    const same = stockTables(Array.from({ length: 60 }, (_, i) => `S${i}`))
+    const varied: TableShape[] = []
+    for (let i = 0; i < 40; i++) {
+      varied.push({
+        table_name: `V${i}`,
+        columns: [
+          { name: "id", data_type: "INT" },
+          { name: `col_${i}`, data_type: "TEXT" },
+        ],
+      })
+    }
+    const result = detectEntityGroup([...same, ...varied], {
+      ratioThreshold: 0.8,
+    })
+    expect(result.entity_group).toBeNull()
+  })
+
+  test("defaults are 50% / 20 tables", () => {
+    expect(DEFAULT_ENTITY_RATIO_THRESHOLD).toBe(0.5)
+    expect(DEFAULT_ENTITY_MIN_TABLES).toBe(20)
+  })
+})

--- a/packages/opencode/test/altimate/schema-cache.test.ts
+++ b/packages/opencode/test/altimate/schema-cache.test.ts
@@ -891,6 +891,133 @@ describe("entity-per-table digest", () => {
 
     cache.close()
   })
+
+  // -------------------------------------------------------------------------
+  // C1 regression: listColumns must include synthetic rows reconstructed
+  // from collapsed entity groups so PII detection / SQL pre-validation
+  // don't go blind on entity-per-table warehouses.
+  // -------------------------------------------------------------------------
+
+  test("listColumns reconstructs columns for fully-collapsed entity-group warehouses", async () => {
+    const cache = SchemaCache.createInMemory()
+    const tickerNames = Array.from({ length: 25 }, (_, i) => `TICKER_${i}`)
+    const cols = [
+      { name: "ssn", data_type: "VARCHAR" },
+      { name: "email", data_type: "VARCHAR" },
+      { name: "amount", data_type: "DOUBLE" },
+    ]
+    const connector = entityConnector(tickerNames, cols)
+    await cache.indexWarehouse("wh", "duckdb", connector)
+
+    const listed = cache.listColumns("wh")
+    // 25 tables × 3 columns = 75 reconstructed rows.
+    expect(listed).toHaveLength(25 * 3)
+
+    // Every reconstructed row should carry the collapsed table name and
+    // a fully-formed FQN so downstream consumers can group/iterate by
+    // table.
+    const tablesSeen = new Set(listed.map((r) => r.table))
+    expect(tablesSeen.size).toBe(25)
+    expect(tablesSeen.has("TICKER_0")).toBe(true)
+    expect(tablesSeen.has("TICKER_24")).toBe(true)
+
+    const sample = listed.find(
+      (r) => r.table === "TICKER_3" && r.name === "email",
+    )
+    expect(sample).toBeDefined()
+    expect(sample!.data_type).toBe("VARCHAR")
+    expect(sample!.fqn).toBe("public.TICKER_3.email")
+
+    cache.close()
+  })
+
+  test("listColumns merges per-table and collapsed-group columns", async () => {
+    const cache = SchemaCache.createInMemory()
+    const tickerNames = Array.from({ length: 22 }, (_, i) => `T_${i}`)
+    const sharedCols = [{ name: "v", data_type: "INT" }]
+    const extras = {
+      metadata: ["catalog_id", "label"],
+    }
+    const connector = entityConnector(tickerNames, sharedCols, extras)
+    await cache.indexWarehouse("wh", "pg", connector)
+
+    const listed = cache.listColumns("wh")
+    // 22 collapsed tables × 1 column + 1 plain table × 2 columns = 24.
+    expect(listed).toHaveLength(22 + 2)
+
+    // Plain-table columns come from columns_cache.
+    expect(listed.some((c) => c.table === "metadata" && c.name === "catalog_id")).toBe(
+      true,
+    )
+    // Collapsed columns come from entity_groups_cache.
+    expect(listed.some((c) => c.table === "T_5" && c.name === "v")).toBe(true)
+
+    cache.close()
+  })
+
+  test("listColumns honours limit across combined per-table + collapsed rows", async () => {
+    const cache = SchemaCache.createInMemory()
+    const tickerNames = Array.from({ length: 25 }, (_, i) => `T_${i}`)
+    const sharedCols = [
+      { name: "a", data_type: "INT" },
+      { name: "b", data_type: "INT" },
+    ]
+    const connector = entityConnector(tickerNames, sharedCols)
+    await cache.indexWarehouse("wh", "pg", connector)
+
+    // Total reconstructable rows = 25 × 2 = 50; clip to 7.
+    const listed = cache.listColumns("wh", 7)
+    expect(listed).toHaveLength(7)
+
+    cache.close()
+  })
+
+  test("listColumns is empty for an unknown warehouse even with entity groups", async () => {
+    const cache = SchemaCache.createInMemory()
+    const names = Array.from({ length: 25 }, (_, i) => `T${i}`)
+    await cache.indexWarehouse(
+      "real-wh",
+      "pg",
+      entityConnector(names, [{ name: "v", data_type: "INT" }]),
+    )
+
+    expect(cache.listColumns("ghost")).toHaveLength(0)
+
+    cache.close()
+  })
+
+  test("listColumns reconstruction enables PII detection on collapsed warehouses (C1 regression)", async () => {
+    // Integration test for the original regression: tables collapsed into
+    // an entity group must still be visible to downstream column scanners.
+    // We verify by walking the reconstructed columns and confirming PII
+    // candidate names like ssn / email show up under each member table —
+    // exactly the input shape `pii-detector.ts` consumes.
+    const cache = SchemaCache.createInMemory()
+    const tableNames = Array.from({ length: 30 }, (_, i) => `tenant_${i}`)
+    const cols = [
+      { name: "tenant_id", data_type: "VARCHAR" },
+      { name: "user_email", data_type: "VARCHAR" },
+      { name: "ssn", data_type: "VARCHAR" },
+      { name: "amount", data_type: "DOUBLE" },
+    ]
+    await cache.indexWarehouse("wh", "pg", entityConnector(tableNames, cols))
+
+    const listed = cache.listColumns("wh")
+
+    // Every collapsed member table appears in the column list.
+    const piiCandidates = listed.filter(
+      (c) => c.name === "user_email" || c.name === "ssn",
+    )
+    expect(piiCandidates).toHaveLength(30 * 2)
+
+    // And one PII candidate per (tenant, ssn) and (tenant, user_email).
+    const ssnTables = new Set(
+      listed.filter((c) => c.name === "ssn").map((c) => c.table),
+    )
+    expect(ssnTables.size).toBe(30)
+
+    cache.close()
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/opencode/test/altimate/schema-cache.test.ts
+++ b/packages/opencode/test/altimate/schema-cache.test.ts
@@ -685,6 +685,218 @@ describe("SQLite driver PRAGMA handling", () => {
 // 13. SQLite driver — readonly connection handling
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// 14. Entity-per-table digest integration
+// ---------------------------------------------------------------------------
+
+describe("entity-per-table digest", () => {
+  /** Connector returning N tables in the same schema, all with the same columns. */
+  function entityConnector(
+    tableNames: string[],
+    sharedColumns: { name: string; data_type: string; nullable?: boolean }[],
+    extraTables: Record<string, string[]> = {},
+  ): Connector {
+    return {
+      async connect() {},
+      async execute() { return { columns: [], rows: [], row_count: 0, truncated: false } },
+      async listSchemas() { return ["public"] },
+      async listTables(schema: string) {
+        if (schema !== "public") return []
+        const all = [
+          ...tableNames.map((name) => ({ name, type: "TABLE" })),
+          ...Object.keys(extraTables).map((name) => ({ name, type: "TABLE" })),
+        ]
+        return all
+      },
+      async describeTable(schema: string, table: string) {
+        if (schema !== "public") return []
+        if (extraTables[table]) {
+          return extraTables[table].map((name) => ({
+            name,
+            data_type: "TEXT",
+            nullable: true,
+          }))
+        }
+        return sharedColumns.map((c) => ({
+          name: c.name,
+          data_type: c.data_type,
+          nullable: c.nullable ?? true,
+        }))
+      },
+      async close() {},
+    }
+  }
+
+  test("30 identical-schema tables collapse into one entity group", async () => {
+    const cache = SchemaCache.createInMemory()
+    const tickerNames = Array.from({ length: 30 }, (_, i) => `TICKER_${i}`)
+    const cols = [
+      { name: "Date", data_type: "VARCHAR" },
+      { name: "Open", data_type: "DOUBLE" },
+      { name: "High", data_type: "DOUBLE" },
+      { name: "Low", data_type: "DOUBLE" },
+      { name: "Close", data_type: "DOUBLE" },
+    ]
+    const connector = entityConnector(tickerNames, cols)
+
+    const result = await cache.indexWarehouse("stock-wh", "duckdb", connector)
+
+    // All 30 tables counted, but they should NOT be in tables_cache —
+    // they're collapsed into the entity_groups_cache row.
+    expect(result.tables_indexed).toBe(30)
+    expect(result.columns_indexed).toBe(30 * 5)
+    expect(result.entity_groups).toBeDefined()
+    expect(result.entity_groups).toHaveLength(1)
+    const grp = result.entity_groups![0]
+    expect(grp.pattern).toBe("entity-per-table")
+    expect(grp.table_count).toBe(30)
+    expect(grp.composite_columns).toHaveLength(5)
+    expect(grp.table_names).toHaveLength(30)
+    expect(grp.sample_table).toBe("TICKER_0")
+
+    // Per-table cache rows should be empty for collapsed tables.
+    const tableSearch = cache.search("TICKER_5")
+    expect(tableSearch.tables).toHaveLength(0)
+    // But the entity group should match.
+    expect(tableSearch.entity_groups).toBeDefined()
+    expect(tableSearch.entity_groups).toHaveLength(1)
+    expect(tableSearch.entity_groups![0].matching_tables).toContain("TICKER_5")
+
+    cache.close()
+  })
+
+  test("collapsed tables are searchable by name via entity group", async () => {
+    const cache = SchemaCache.createInMemory()
+    const names = Array.from({ length: 25 }, (_, i) => `STK_${i}`)
+    const cols = [
+      { name: "id", data_type: "INT" },
+      { name: "value", data_type: "FLOAT" },
+    ]
+    await cache.indexWarehouse("wh", "pg", entityConnector(names, cols))
+
+    const r = cache.search("STK_7")
+    expect(r.match_count).toBeGreaterThan(0)
+    expect(r.entity_groups).toBeDefined()
+    expect(r.entity_groups![0].matching_tables).toContain("STK_7")
+
+    cache.close()
+  })
+
+  test("composite columns are searchable", async () => {
+    const cache = SchemaCache.createInMemory()
+    const names = Array.from({ length: 25 }, (_, i) => `T${i}`)
+    const cols = [
+      { name: "uniq_marker_col", data_type: "VARCHAR" },
+      { name: "v", data_type: "INT" },
+    ]
+    await cache.indexWarehouse("wh", "pg", entityConnector(names, cols))
+
+    const r = cache.search("uniq_marker_col")
+    expect(r.entity_groups).toBeDefined()
+    expect(r.entity_groups!.length).toBeGreaterThan(0)
+    cache.close()
+  })
+
+  test("non-entity tables still emit per-table when mixed with entity group", async () => {
+    const cache = SchemaCache.createInMemory()
+    const tickerNames = Array.from({ length: 25 }, (_, i) => `TICK_${i}`)
+    const cols = [
+      { name: "Date", data_type: "VARCHAR" },
+      { name: "Close", data_type: "DOUBLE" },
+    ]
+    const extras = {
+      metadata: ["ticker", "company"],
+      exchange_info: ["code", "country"],
+    }
+    const connector = entityConnector(tickerNames, cols, extras)
+
+    const result = await cache.indexWarehouse("wh", "pg", connector)
+
+    expect(result.entity_groups).toHaveLength(1)
+    expect(result.entity_groups![0].table_count).toBe(25)
+
+    // metadata + exchange_info still searchable by name as plain tables.
+    const metaSearch = cache.search("metadata")
+    expect(metaSearch.tables).toHaveLength(1)
+    expect(metaSearch.tables[0].name).toBe("metadata")
+
+    const exchSearch = cache.search("exchange_info")
+    expect(exchSearch.tables).toHaveLength(1)
+
+    cache.close()
+  })
+
+  test("under-threshold mixed tables produce normal per-table rows (backwards compat)", async () => {
+    const cache = SchemaCache.createInMemory()
+    // 5 mixed tables — below min_tables, no entity group.
+    const connector = mockConnector({
+      public: {
+        users: ["id", "email"],
+        orders: ["order_id", "user_id"],
+        products: ["sku", "name"],
+        events: ["ts", "kind"],
+        logs: ["level", "msg"],
+      },
+    })
+
+    const result = await cache.indexWarehouse("wh", "pg", connector)
+    expect(result.tables_indexed).toBe(5)
+    expect(result.entity_groups).toBeUndefined()
+
+    // All tables should still be findable as individual entries.
+    expect(cache.search("users").tables).toHaveLength(1)
+    expect(cache.search("orders").tables).toHaveLength(1)
+    expect(cache.search("products").tables).toHaveLength(1)
+
+    cache.close()
+  })
+
+  test("re-index clears entity group rows", async () => {
+    const cache = SchemaCache.createInMemory()
+    const v1Names = Array.from({ length: 25 }, (_, i) => `OLD_${i}`)
+    const cols = [{ name: "x", data_type: "INT" }]
+    await cache.indexWarehouse("wh", "pg", entityConnector(v1Names, cols))
+    expect(cache.search("OLD_5").entity_groups).toBeDefined()
+
+    // Re-index with non-entity data
+    const v2 = mockConnector({ public: { fresh: ["id"] } })
+    await cache.indexWarehouse("wh", "pg", v2)
+
+    // Old entity group gone
+    const stale = cache.search("OLD_5")
+    expect(stale.match_count).toBe(0)
+    // Fresh data present
+    expect(cache.search("fresh").tables).toHaveLength(1)
+
+    cache.close()
+  })
+
+  test("custom thresholds are honoured by indexWarehouse", async () => {
+    const cache = SchemaCache.createInMemory()
+    // Only 10 same-shape tables — below default min_tables=20, so by default
+    // would NOT be detected. Pass a lower threshold and verify it triggers.
+    const names = Array.from({ length: 10 }, (_, i) => `T${i}`)
+    const cols = [{ name: "x", data_type: "INT" }]
+    const connector = entityConnector(names, cols)
+
+    const defaultRun = await cache.indexWarehouse("wh", "pg", connector)
+    expect(defaultRun.entity_groups).toBeUndefined()
+
+    const tunedRun = await cache.indexWarehouse("wh", "pg", connector, {
+      entityMinTables: 5,
+    })
+    expect(tunedRun.entity_groups).toBeDefined()
+    expect(tunedRun.entity_groups).toHaveLength(1)
+    expect(tunedRun.entity_groups![0].table_count).toBe(10)
+
+    cache.close()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 15. SQLite driver — readonly connection handling
+// ---------------------------------------------------------------------------
+
 describe("SQLite driver readonly connections", () => {
   test("readonly connection can read existing database", async () => {
     const { connect } = await import("@altimateai/drivers/sqlite")

--- a/packages/opencode/test/altimate/schema-index-tool.test.ts
+++ b/packages/opencode/test/altimate/schema-index-tool.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Tool-surface tests for `schema_index` (Tool.define wrapper).
+ *
+ * Covers regressions raised in the multi-model consensus review for
+ * PR #762:
+ *   - M1: threshold knobs are forwarded from the public tool through the
+ *         dispatcher into the cache.
+ *   - M3: the `table_names` formatter truncates large lists.
+ *   - M6: invalid threshold params are rejected with clear errors.
+ */
+
+import {
+  describe,
+  expect,
+  test,
+  beforeEach,
+  afterEach,
+  spyOn,
+  beforeAll,
+  afterAll,
+} from "bun:test"
+import * as Dispatcher from "../../src/altimate/native/dispatcher"
+import { SchemaIndexTool } from "../../src/altimate/tools/schema-index"
+import { Telemetry } from "../../src/telemetry"
+import { SessionID, MessageID } from "../../src/session/schema"
+
+beforeAll(() => {
+  process.env.ALTIMATE_TELEMETRY_DISABLED = "true"
+})
+
+afterAll(() => {
+  delete process.env.ALTIMATE_TELEMETRY_DISABLED
+})
+
+// Minimal context shape required by Tool.execute().
+const ctx = {
+  sessionID: SessionID.make("ses_test_idx"),
+  messageID: MessageID.make("msg_test_idx"),
+  callID: "call_test_idx",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => {},
+  ask: async () => {},
+}
+
+let dispatcherSpy: ReturnType<typeof spyOn>
+
+beforeEach(() => {
+  spyOn(Telemetry, "track").mockImplementation(() => {})
+  spyOn(Telemetry, "getContext").mockReturnValue({
+    sessionId: "test-session",
+    projectId: "",
+  } as any)
+})
+
+afterEach(() => {
+  dispatcherSpy?.mockRestore()
+})
+
+// ---------------------------------------------------------------------------
+// M1 — threshold knobs propagate through the public tool surface.
+// ---------------------------------------------------------------------------
+
+describe("schema_index tool — M1: threshold overrides reach the dispatcher", () => {
+  test("forwards entityRatioThreshold and entityMinTables to schema.index", async () => {
+    let captured: { method: string; params: any } | null = null
+    const handler = async (method: string, params: any) => {
+      captured = { method, params }
+      return {
+        warehouse: params.warehouse,
+        type: "duckdb",
+        schemas_indexed: 1,
+        tables_indexed: 0,
+        columns_indexed: 0,
+        timestamp: "2026-04-26T00:00:00Z",
+      }
+    }
+    dispatcherSpy = spyOn(Dispatcher, "call").mockImplementation(handler as any)
+
+    const tool = await SchemaIndexTool.init()
+    await tool.execute(
+      {
+        warehouse: "test-wh",
+        entityRatioThreshold: 0.7,
+        entityMinTables: 30,
+      } as any,
+      ctx as any,
+    )
+
+    expect(captured).not.toBeNull()
+    expect(captured!.method).toBe("schema.index")
+    expect(captured!.params.warehouse).toBe("test-wh")
+    expect(captured!.params.entityRatioThreshold).toBe(0.7)
+    expect(captured!.params.entityMinTables).toBe(30)
+  })
+
+  test("omitting overrides leaves them undefined (defaults applied downstream)", async () => {
+    let captured: any = null
+    const handler = async (_method: string, params: any) => {
+      captured = params
+      return {
+        warehouse: params.warehouse,
+        type: "duckdb",
+        schemas_indexed: 0,
+        tables_indexed: 0,
+        columns_indexed: 0,
+        timestamp: "2026-04-26T00:00:00Z",
+      }
+    }
+    dispatcherSpy = spyOn(Dispatcher, "call").mockImplementation(handler as any)
+
+    const tool = await SchemaIndexTool.init()
+    await tool.execute({ warehouse: "test-wh" } as any, ctx as any)
+
+    expect(captured.warehouse).toBe("test-wh")
+    expect(captured.entityRatioThreshold).toBeUndefined()
+    expect(captured.entityMinTables).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// M3 — `table_names` is truncated in the formatter for huge groups, but the
+// underlying structured result is untouched.
+// ---------------------------------------------------------------------------
+
+describe("schema_index tool — M3: large table_names lists are truncated in output", () => {
+  test("groups with >55 tables render as head + ellipsis + tail", async () => {
+    const tableNames = Array.from({ length: 2754 }, (_, i) => `tenant_${i}`)
+    const handler = async (_method: string) => ({
+      warehouse: "huge-wh",
+      type: "duckdb",
+      schemas_indexed: 1,
+      tables_indexed: 2754,
+      columns_indexed: 2754 * 5,
+      timestamp: "2026-04-26T00:00:00Z",
+      entity_groups: [
+        {
+          warehouse: "huge-wh",
+          schema_name: "public",
+          pattern: "entity-per-table",
+          table_count: tableNames.length,
+          composite_columns: [
+            { name: "id", data_type: "INT" },
+            { name: "value", data_type: "DOUBLE" },
+          ],
+          sample_table: "tenant_0",
+          table_names: tableNames,
+        },
+      ],
+    })
+    dispatcherSpy = spyOn(Dispatcher, "call").mockImplementation(handler as any)
+
+    const tool = await SchemaIndexTool.init()
+    const result = await tool.execute(
+      { warehouse: "huge-wh" } as any,
+      ctx as any,
+    )
+
+    // Output should mention the truncation explicitly.
+    expect(result.output).toContain("more (use schema_search to enumerate)")
+
+    // The raw line for table_names must not contain the full list.
+    const tableNamesLine = result.output
+      .split("\n")
+      .find((l) => l.startsWith("table_names:"))
+    expect(tableNamesLine).toBeDefined()
+
+    // Sanity: the rendered string must be much smaller than the full list
+    // (≈ 2754 names). Allow generous slack for prefix + tail names.
+    expect(tableNamesLine!.length).toBeLessThan(2000)
+
+    // Head and tail anchors are present.
+    expect(tableNamesLine).toContain("tenant_0")
+    expect(tableNamesLine).toContain("tenant_2753")
+
+    // Confirm a clearly-truncated middle entry is NOT present.
+    expect(tableNamesLine).not.toContain("tenant_500,")
+  })
+
+  test("groups with few tables emit the full list (no truncation noise)", async () => {
+    const tableNames = ["A", "B", "C"]
+    const handler = async (_method: string) => ({
+      warehouse: "small-wh",
+      type: "duckdb",
+      schemas_indexed: 1,
+      tables_indexed: 3,
+      columns_indexed: 3,
+      timestamp: "2026-04-26T00:00:00Z",
+      entity_groups: [
+        {
+          warehouse: "small-wh",
+          schema_name: "public",
+          pattern: "entity-per-table",
+          table_count: 3,
+          composite_columns: [{ name: "v", data_type: "INT" }],
+          sample_table: "A",
+          table_names: tableNames,
+        },
+      ],
+    })
+    dispatcherSpy = spyOn(Dispatcher, "call").mockImplementation(handler as any)
+
+    const tool = await SchemaIndexTool.init()
+    const result = await tool.execute(
+      { warehouse: "small-wh" } as any,
+      ctx as any,
+    )
+
+    expect(result.output).toContain("table_names: [A, B, C]")
+    expect(result.output).not.toContain("more (use schema_search")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// M6 — Zod validation rejects invalid threshold params.
+// ---------------------------------------------------------------------------
+
+describe("schema_index tool — M6: Zod rejects invalid thresholds", () => {
+  beforeEach(() => {
+    // The Zod parse runs before Dispatcher.call, so we don't need a spy
+    // implementation — a no-op suffices to keep type-shape intact.
+    dispatcherSpy = spyOn(Dispatcher, "call").mockResolvedValue({
+      warehouse: "x",
+      type: "duckdb",
+      schemas_indexed: 0,
+      tables_indexed: 0,
+      columns_indexed: 0,
+      timestamp: "2026-04-26T00:00:00Z",
+    } as any)
+  })
+
+  test("rejects entityRatioThreshold = 0", async () => {
+    const tool = await SchemaIndexTool.init()
+    await expect(
+      tool.execute(
+        { warehouse: "wh", entityRatioThreshold: 0 } as any,
+        ctx as any,
+      ),
+    ).rejects.toThrow(/invalid arguments|entityRatioThreshold/i)
+  })
+
+  test("rejects entityRatioThreshold > 1", async () => {
+    const tool = await SchemaIndexTool.init()
+    await expect(
+      tool.execute(
+        { warehouse: "wh", entityRatioThreshold: 1.5 } as any,
+        ctx as any,
+      ),
+    ).rejects.toThrow(/invalid arguments|entityRatioThreshold/i)
+  })
+
+  test("rejects entityRatioThreshold < 0", async () => {
+    const tool = await SchemaIndexTool.init()
+    await expect(
+      tool.execute(
+        { warehouse: "wh", entityRatioThreshold: -0.1 } as any,
+        ctx as any,
+      ),
+    ).rejects.toThrow(/invalid arguments|entityRatioThreshold/i)
+  })
+
+  test("rejects non-integer entityMinTables", async () => {
+    const tool = await SchemaIndexTool.init()
+    await expect(
+      tool.execute(
+        { warehouse: "wh", entityMinTables: 3.7 } as any,
+        ctx as any,
+      ),
+    ).rejects.toThrow(/invalid arguments|entityMinTables/i)
+  })
+
+  test("rejects entityMinTables < 2", async () => {
+    const tool = await SchemaIndexTool.init()
+    await expect(
+      tool.execute(
+        { warehouse: "wh", entityMinTables: 1 } as any,
+        ctx as any,
+      ),
+    ).rejects.toThrow(/invalid arguments|entityMinTables/i)
+  })
+
+  test("accepts entityRatioThreshold = 1 and entityMinTables = 2", async () => {
+    // Boundary check — must NOT throw for the legal extremes.
+    const tool = await SchemaIndexTool.init()
+    const result = await tool.execute(
+      {
+        warehouse: "wh",
+        entityRatioThreshold: 1,
+        entityMinTables: 2,
+      } as any,
+      ctx as any,
+    )
+    expect(result.title).toContain("Schema Indexed")
+  })
+})


### PR DESCRIPTION
Closes #760

## Motivation

When a database has many tables that share the same column structure — one ticker per table, one tenant per table, time-partitioned tables, per-region tables — `schema_index` today emits redundant per-table schemas. The agent's context fills with N copies of the same shape, and `schema_index`'s truncation cap means the agent often can't see all tables at all.

This is a real production pattern across:
- Multi-tenant SaaS (one table per customer for isolation)
- Time-partitioned analytics (`events_2024_01_01`, `events_2024_01_02`, …)
- Per-region tables (`orders_us`, `orders_eu`, `orders_apac`)
- Per-environment schemas (dev/staging/prod with same shape)
- Per-source ingestion (`events_segment`, `events_amplitude`, …)

For warehouses that exhibit it, current behaviour wastes context on duplicate schemas and silently hides tail tables beyond the truncation cap.

## What's added

A heuristic in `schema_index`'s scan logic that detects the entity-per-table pattern at scan time and emits a composite digest — one shared schema description plus the full list of table names — instead of N redundant schemas. Tables that don't fit the dominant fingerprint still get per-table schemas as before. `schema_search` is updated to surface entity-group matches.

**Detection rule:** group tables by sorted `(column_name, column_type)` fingerprint. If any one fingerprint covers ≥50% of tables AND ≥20 tables, treat it as the entity group and emit a composite digest. Tables with empty column lists are ignored. Both thresholds are overridable per-call via `indexWarehouse` options.

**Composite digest format:**

```
schema: public
pattern: entity-per-table
table_count: 30
composite_columns: [{name: "Close", type: "DOUBLE"}, {name: "Date", type: "VARCHAR"}, ...]
sample_table: TICKER_0
table_names: [TICKER_0, TICKER_1, TICKER_10, TICKER_11, ...]
```

`schema_search` queries entity-group rows in addition to per-table rows; a query for a specific table name returns just that row from the group, not the entire member list. The tool-level formatter renders matches under a `## Entity-per-table Groups` section.

`cacheStatus().total_tables` and `total_columns` were updated to fold collapsed counts in, so existing callers see real warehouse counts regardless of digest format. This also fixed a pre-existing scenario where a 1000-table stress test under-reported counts when groups collapsed.

## Tests

**19 new unit tests** in `test/altimate/entity-groups.test.ts`:
- 100 same-shape tables → marked as entity
- 5 mixed-shape tables → not marked
- 50 same-shape + 50 different-shape → not marked (under 50% threshold)
- Empty-column tables ignored for fingerprinting
- Threshold and min-count overrides honoured per-call

**7 new integration tests** in `test/altimate/schema-cache.test.ts`:
- In-memory SQLite fixture with 30 identical-schema tables produces composite digest
- Pre-existing 5-mixed-table fixture produces identical results to previous behaviour (backwards compat)
- 1000-table stress test passes (regression fix)

**Results:**
- Affected files (`entity-groups.test.ts`, `schema-cache.test.ts`, `schema-finops-dbt.test.ts`, `schema-resolver.test.ts`): **139 pass / 0 fail**
- Telemetry suite: 46/0 pass; `real-tool-simulation`: 40/0 pass — no regressions
- Full opencode suite when merged with #758 + #759: **7421 pass / 0 fail / 494 skip** (~88s)
- `bun run typecheck`: clean (0 errors after `bun install` in the worktree)

## Backwards compatibility

- When no fingerprint group qualifies (the common case), `entity_groups` is `undefined` and per-table rows are written exactly as before. Verified by integration test against the existing 5-table mixed fixture.
- The new `entity_groups` field on `SchemaIndexResult` and `SchemaSearchResult` is optional; older consumers see no breaking change.

## Files

- `packages/opencode/src/altimate/native/schema/cache.ts` (DDL + scan + search + status)
- `packages/opencode/src/altimate/native/schema/entity-groups.ts` (new — pure detector, 174 LOC)
- `packages/opencode/src/altimate/native/types.ts` (new optional fields + interfaces)
- `packages/opencode/src/altimate/tools/schema-index.ts` (output formatter)
- `packages/opencode/src/altimate/tools/schema-search.ts` (output formatter)
- `packages/opencode/test/altimate/entity-groups.test.ts` (new — 269 LOC)
- `packages/opencode/test/altimate/schema-cache.test.ts` (added integration tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses “entity-per-table” warehouses in `schema_index` by emitting a single composite digest per schema, cutting redundant context and keeping search accurate. Adds safe search/output and column reconstruction so downstream tools still see all tables; addresses #760.

- **New Features**
  - Detects entity-per-table via column-shape fingerprinting (≥50% and ≥20 tables by default); overrides via `schema_index` params `entityRatioThreshold` and `entityMinTables`.
  - Stores qualifying groups once with shared columns and full `table_names`; non-group tables remain per-table. At most one group is collapsed per schema.
  - `schema_search` shows entity-group matches and returns only the queried table(s) from a group. Tool output lists groups and truncates huge `table_names` (head + tail).

- **Bug Fixes**
  - `listColumns` reconstructs columns for collapsed groups so PII and SQL validation see complete schemas; `cacheStatus` now includes collapsed groups in `total_tables` and `total_columns`.
  - Reduced false positives and fingerprint edge cases with bounded group `search_text`, table-name matching via post-filter, and safe fingerprinting for `:`/`|`/missing types.

<sup>Written for commit dc2af3c0aa80534b7742b0f0524f511c83a09cb0. Summary will update on new commits. <a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/762?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schema indexing now detects and collapses groups of tables with identical column structures and surfaces them in index/search results.
  * Search and reporting include entity-group matches, counts, and summarized composite column info.
  * Detection thresholds (ratio and minimum tables) are configurable.

* **Behavior Changes**
  * Aggregate table/column counts and column listings now include contributions from collapsed entity groups.

* **Tests**
  * New unit and integration tests covering detection, indexing, search, listing, and threshold validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->