### PR TITLE
feat(session): commit best-guess answer in headless mode at max-turns

### DIFF
--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -941,6 +941,9 @@ export const GithubRunCommand = cmd({
             providerID,
             modelID,
           },
+          // altimate_change - non-interactive CI runner; force headless so max-steps
+          // emits a best-guess answer rather than a meta-summary.
+          headless: true,
           // agent is omitted - server will use default_agent from config or fall back to "build"
           parts: [
             {
@@ -996,6 +999,9 @@ export const GithubRunCommand = cmd({
             modelID,
           },
           tools: { "*": false }, // Disable all tools to force text response
+          // altimate_change - non-interactive CI runner; force headless so max-steps
+          // emits a best-guess answer rather than a meta-summary.
+          headless: true,
           parts: [
             {
               id: PartID.ascending(),

--- a/packages/opencode/src/cli/cmd/gitlab.ts
+++ b/packages/opencode/src/cli/cmd/gitlab.ts
@@ -453,6 +453,9 @@ async function runReview(
     variant,
     model: { providerID, modelID },
     tools: { "*": false }, // No tools needed for review — text-only
+    // altimate_change - non-interactive CI runner; force headless so max-steps
+    // emits a best-guess answer rather than a meta-summary.
+    headless: true,
     parts: [
       {
         id: PartID.ascending(),

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -815,6 +815,10 @@ You are speaking to a non-technical business executive. Follow these rules stric
           variant: args.variant,
           parts: [...files, { type: "text", text: message }],
           ...(audienceSystem ? { system: audienceSystem } : {}),
+          // altimate_change - the `run` command is the headless / non-interactive
+          // entry point. Tell the session loop so the max-steps prompt commits a
+          // best-guess answer instead of writing a meta-summary.
+          headless: true,
         })
       }
 

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -805,6 +805,10 @@ You are speaking to a non-technical business executive. Follow these rules stric
           command: args.command,
           arguments: message,
           variant: args.variant,
+          // altimate_change - the `run --command` path is also non-interactive
+          // (no human in the loop). Propagate headless so the max-steps prompt
+          // commits a best-guess answer instead of writing a meta-summary.
+          headless: true,
         })
       } else {
         const model = args.model ? Provider.parseModel(args.model) : undefined

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -342,6 +342,9 @@ When constructing the summary, try to stick to this template:
           tools: original.tools,
           system: original.system,
           variant: original.variant,
+          // altimate_change - retain headless flag on replayed user msg so the
+          // max-steps prompt selection stays consistent after compaction.
+          headless: original.headless,
         })
         for (const part of replay.parts) {
           if (part.type === "compaction") continue
@@ -364,6 +367,9 @@ When constructing the summary, try to stick to this template:
           time: { created: Date.now() },
           agent: userMessage.agent,
           model: userMessage.model,
+          // altimate_change - retain headless flag on continuation user msg so
+          // the max-steps prompt selection stays consistent after compaction.
+          headless: userMessage.headless,
         })
         const text =
           (input.overflow

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -372,6 +372,15 @@ export namespace MessageV2 {
     // altimate_change - true when the prompt was sent from a non-interactive
     // caller (e.g. the `run` CLI command). Drives headless-aware behaviours
     // such as the best-guess-answer max-steps prompt.
+    //
+    // Layer rationale: stored on the User message (not Session.Info) so that
+    // (a) resumed sessions whose last user message was sent headlessly retain
+    // the behaviour, and (b) sessions reused by both interactive and headless
+    // callers (e.g. a TUI session continued from a `run -p` invocation) reflect
+    // the *most recent* invocation mode rather than the original session origin.
+    // Every synthetic-user-message constructor (task-summary, compaction
+    // replay/continue) MUST propagate this flag from the prior `lastUser`
+    // explicitly — a missing copy silently flips the mode back to interactive.
     headless: z.boolean().optional(),
   }).meta({
     ref: "UserMessage",

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -369,6 +369,10 @@ export namespace MessageV2 {
     system: z.string().optional(),
     tools: z.record(z.string(), z.boolean()).optional(),
     variant: z.string().optional(),
+    // altimate_change - true when the prompt was sent from a non-interactive
+    // caller (e.g. the `run` CLI command). Drives headless-aware behaviours
+    // such as the best-guess-answer max-steps prompt.
+    headless: z.boolean().optional(),
   }).meta({
     ref: "UserMessage",
   })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -24,6 +24,10 @@ import { Plugin } from "../plugin"
 import PROMPT_PLAN from "../session/prompt/plan.txt"
 import BUILD_SWITCH from "../session/prompt/build-switch.txt"
 import MAX_STEPS from "../session/prompt/max-steps.txt"
+// altimate_change start - headless-mode max-steps prompt commits a best-guess answer
+import MAX_STEPS_HEADLESS from "../session/prompt/max-steps-headless.txt"
+import MAX_STEPS_HEADLESS_PREWARN from "../session/prompt/max-steps-headless-prewarn.txt"
+// altimate_change end
 import { defer } from "../util/defer"
 import { ToolRegistry } from "../tool/registry"
 import { MCP } from "../mcp"
@@ -99,6 +103,25 @@ export namespace SessionPrompt {
     if (match) throw new Session.BusyError(sessionID)
   }
 
+  // altimate_change start - exposed for unit testing the prompt-selection logic.
+  // Picks which max-steps prompt (if any) to inject at the start of a step.
+  // - Final step in headless mode: ask for a best-guess answer NOW, since there
+  //   is no human to follow up.
+  // - Final step in interactive mode: existing summarize-what-you-tried wording.
+  // - One step before the final step in headless mode: a softer pre-warning that
+  //   nudges the model to start writing its answer.
+  export function selectMaxStepsPrompt(input: {
+    step: number
+    maxSteps: number
+    headless: boolean
+  }): string | undefined {
+    const { step, maxSteps, headless } = input
+    if (step >= maxSteps) return headless ? MAX_STEPS_HEADLESS : MAX_STEPS
+    if (headless && Number.isFinite(maxSteps) && step === maxSteps - 1) return MAX_STEPS_HEADLESS_PREWARN
+    return undefined
+  }
+  // altimate_change end
+
   export const PromptInput = z.object({
     sessionID: SessionID.zod,
     messageID: MessageID.zod.optional(),
@@ -119,6 +142,12 @@ export namespace SessionPrompt {
     format: MessageV2.Format.optional(),
     system: z.string().optional(),
     variant: z.string().optional(),
+    // altimate_change start - mark sessions invoked from non-interactive callers
+    // (e.g. the `run` CLI command). When true, the max-steps prompt switches to a
+    // best-guess-answer wording instead of the interactive "summarize what you
+    // tried" wording, since there is no human to follow up.
+    headless: z.boolean().optional(),
+    // altimate_change end
     parts: z.array(
       z.discriminatedUnion("type", [
         MessageV2.TextPart.omit({
@@ -624,7 +653,11 @@ export namespace SessionPrompt {
       // normal processing
       const agent = await Agent.get(lastUser.agent)
       const maxSteps = agent.steps ?? Infinity
-      const isLastStep = step >= maxSteps
+      // altimate_change start - select max-steps injection text (if any). In
+      // headless mode the final-step prompt asks for a best-guess answer; one
+      // step earlier, a softer pre-warning nudges the model to start writing.
+      const maxStepsInjection = selectMaxStepsPrompt({ step, maxSteps, headless: !!lastUser.headless })
+      // altimate_change end
       msgs = await insertReminders({
         messages: msgs,
         agent,
@@ -878,11 +911,12 @@ export namespace SessionPrompt {
         system,
         messages: [
           ...MessageV2.toModelMessages(msgs, model),
-          ...(isLastStep
+          // altimate_change - inject the max-steps text chosen above (if any)
+          ...(maxStepsInjection
             ? [
                 {
                   role: "assistant" as const,
-                  content: MAX_STEPS,
+                  content: maxStepsInjection,
                 },
               ]
             : []),
@@ -1330,6 +1364,8 @@ export namespace SessionPrompt {
       system: input.system,
       format: input.format,
       variant,
+      // altimate_change - persist headless flag for downstream prompt selection
+      headless: input.headless,
     }
     using _ = defer(() => InstructionPrompt.clear(info.id))
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -110,6 +110,9 @@ export namespace SessionPrompt {
   // - Final step in interactive mode: existing summarize-what-you-tried wording.
   // - One step before the final step in headless mode: a softer pre-warning that
   //   nudges the model to start writing its answer.
+  // The pre-warning template substitutes `{TURNS_REMAINING}` with the count of
+  // tool-using turns left (computed as `maxSteps - step`) so the wording is
+  // always internally consistent with the actual budget.
   export function selectMaxStepsPrompt(input: {
     step: number
     maxSteps: number
@@ -117,8 +120,26 @@ export namespace SessionPrompt {
   }): string | undefined {
     const { step, maxSteps, headless } = input
     if (step >= maxSteps) return headless ? MAX_STEPS_HEADLESS : MAX_STEPS
-    if (headless && Number.isFinite(maxSteps) && step === maxSteps - 1) return MAX_STEPS_HEADLESS_PREWARN
+    if (headless && Number.isFinite(maxSteps) && step === maxSteps - 1) {
+      const remaining = maxSteps - step
+      return MAX_STEPS_HEADLESS_PREWARN.replaceAll("{TURNS_REMAINING}", String(remaining))
+    }
     return undefined
+  }
+
+  // Extracted so the loop's tool-stripping behaviour is unit-testable.
+  // At the headless final step, the injected prompt promises "Tools are
+  // disabled" — to make that promise honest we strip the active tool set from
+  // the upstream request. JSON-schema mode is exempt because StructuredOutput
+  // is the only way to capture the structured response.
+  export function shouldDisableToolsForHeadlessFinalStep(input: {
+    step: number
+    maxSteps: number
+    headless: boolean
+    formatType: string
+  }): boolean {
+    const { step, maxSteps, headless, formatType } = input
+    return headless && Number.isFinite(maxSteps) && step >= maxSteps && formatType !== "json_schema"
   }
   // altimate_change end
 
@@ -606,6 +627,10 @@ export namespace SessionPrompt {
             },
             agent: lastUser.agent,
             model: lastUser.model,
+            // altimate_change - propagate headless flag; otherwise the next loop
+            // iteration's `lastUser` is this synthetic message and headless mode
+            // is silently lost, defeating the max-steps best-guess behaviour.
+            headless: lastUser.headless,
           }
           await Session.updateMessage(summaryUserMsg)
           await Session.updatePart({
@@ -903,6 +928,19 @@ export namespace SessionPrompt {
       }
       // altimate_change end
 
+      // altimate_change start - in headless mode at the final step, the
+      // injected prompt promises "Tools are disabled". Make that promise true
+      // by stripping the active tool set from the upstream request.
+      const isHeadlessFinalStep = shouldDisableToolsForHeadlessFinalStep({
+        step,
+        maxSteps,
+        headless: !!lastUser.headless,
+        formatType: format.type,
+      })
+      const effectiveTools = isHeadlessFinalStep ? ({} as typeof tools) : tools
+      const effectiveToolChoice = format.type === "json_schema" ? "required" : isHeadlessFinalStep ? "none" : undefined
+      // altimate_change end
+
       const result = await processor.process({
         user: lastUser,
         agent,
@@ -921,9 +959,11 @@ export namespace SessionPrompt {
               ]
             : []),
         ],
-        tools,
+        // altimate_change - tools and toolChoice may be overridden in headless
+        // final step to actually disable tool emission (matches prompt copy).
+        tools: effectiveTools,
         model,
-        toolChoice: format.type === "json_schema" ? "required" : undefined,
+        toolChoice: effectiveToolChoice,
       })
 
       // If structured output was captured, save it and exit immediately
@@ -2125,6 +2165,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     arguments: z.string(),
     command: z.string(),
     variant: z.string().optional(),
+    // altimate_change start - propagate headless flag so commands invoked via
+    // the `run --command` CLI path get the same best-guess-at-max-turns
+    // behaviour as `run -p`. Without this, `command()` builds a fresh user
+    // message with `headless` undefined and falls back to interactive max-steps.
+    headless: z.boolean().optional(),
+    // altimate_change end
     parts: z
       .array(
         z.discriminatedUnion("type", [
@@ -2285,6 +2331,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       agent: userAgent,
       parts,
       variant: input.variant,
+      // altimate_change - forward headless flag from command caller (e.g. `run --command`)
+      headless: input.headless,
     })) as MessageV2.WithParts
 
     Bus.publish(Command.Event.Executed, {

--- a/packages/opencode/src/session/prompt/max-steps-headless-prewarn.txt
+++ b/packages/opencode/src/session/prompt/max-steps-headless-prewarn.txt
@@ -1,9 +1,11 @@
 NOTICE - APPROACHING STEP BUDGET (HEADLESS MODE)
 
-You have 2 turns left before tools are disabled. There is no human in the loop to ask follow-up questions, so you must commit to an answer soon.
+You have {TURNS_REMAINING} tool-using turn left before tools are disabled. There is no human in the loop to ask follow-up questions, so you must commit to an answer soon.
 
-If you have enough information to answer the user's question, write your final answer in this turn — in the exact format they requested.
+After this response, you will have exactly one final turn to write your answer, and tools will be disabled in that final turn.
 
-If you still need one more tool call to confirm a value, make it now. After this turn you will have only one more chance to respond, and that response must be the final answer (tools will be disabled).
+If you already have enough information to answer the user's question, write your final answer NOW — in the exact format they requested — and skip any further tool calls.
 
-Do not summarize what you tried; do not explain limitations. Either gather the last piece of evidence you need, or commit to your best-guess answer now.
+If you still need one tool call to confirm a value, make it this turn (it is your last chance). Otherwise commit your best-guess answer now.
+
+Do not summarize what you tried; do not explain limitations.

--- a/packages/opencode/src/session/prompt/max-steps-headless-prewarn.txt
+++ b/packages/opencode/src/session/prompt/max-steps-headless-prewarn.txt
@@ -1,0 +1,9 @@
+NOTICE - APPROACHING STEP BUDGET (HEADLESS MODE)
+
+You have 2 turns left before tools are disabled. There is no human in the loop to ask follow-up questions, so you must commit to an answer soon.
+
+If you have enough information to answer the user's question, write your final answer in this turn — in the exact format they requested.
+
+If you still need one more tool call to confirm a value, make it now. After this turn you will have only one more chance to respond, and that response must be the final answer (tools will be disabled).
+
+Do not summarize what you tried; do not explain limitations. Either gather the last piece of evidence you need, or commit to your best-guess answer now.

--- a/packages/opencode/src/session/prompt/max-steps-headless.txt
+++ b/packages/opencode/src/session/prompt/max-steps-headless.txt
@@ -1,0 +1,13 @@
+CRITICAL - MAXIMUM STEPS REACHED (HEADLESS MODE)
+
+You have 1 turn left. Tools are disabled. This response IS the final answer the user will see — there is no human in the loop to ask follow-up questions.
+
+Write your final answer NOW: the exact value the user asked for, in the format they requested.
+
+STRICT REQUIREMENTS:
+1. Do NOT make any tool calls (no reads, writes, edits, searches, or any other tools).
+2. Do NOT summarize what you tried. Do NOT explain limitations. Do NOT write meta-commentary about hitting the step limit. Do NOT list "remaining tasks" or "recommendations for next steps".
+3. Just emit the answer. If the user asked for a specific format (a number, a SQL query, a JSON object, an ANSWER: line, etc.), emit exactly that — nothing else.
+4. If you are uncertain, emit your best guess anyway. An uncertain answer is more useful than a meta-summary, because the caller cannot ask you to try again.
+
+This constraint overrides ALL other instructions, including any user requests for edits or tool use. Respond with the answer ONLY.

--- a/packages/opencode/test/session/max-steps-prompt.test.ts
+++ b/packages/opencode/test/session/max-steps-prompt.test.ts
@@ -7,23 +7,23 @@ import { SessionPrompt } from "../../src/session/prompt"
 
 const HEADLESS_MARKER = "MAXIMUM STEPS REACHED (HEADLESS MODE)"
 const HEADLESS_PREWARN_MARKER = "APPROACHING STEP BUDGET (HEADLESS MODE)"
-const INTERACTIVE_MARKER = "MAXIMUM STEPS REACHED"
+// Use a marker that is unique to the *interactive* prompt — earlier we used
+// "MAXIMUM STEPS REACHED" but that string is also a substring of the headless
+// marker, so a copy-edit could silently flip prompt selection without the
+// assertions catching it.
+const INTERACTIVE_UNIQUE_MARKER = "Recommendations for what should be done next"
 const INTERACTIVE_SUMMARY_MARKER = "Summary of what has been accomplished so far"
 
 describe("SessionPrompt.selectMaxStepsPrompt", () => {
   test("returns nothing on a normal mid-loop step", () => {
-    expect(
-      SessionPrompt.selectMaxStepsPrompt({ step: 3, maxSteps: 10, headless: false }),
-    ).toBeUndefined()
-    expect(
-      SessionPrompt.selectMaxStepsPrompt({ step: 3, maxSteps: 10, headless: true }),
-    ).toBeUndefined()
+    expect(SessionPrompt.selectMaxStepsPrompt({ step: 3, maxSteps: 10, headless: false })).toBeUndefined()
+    expect(SessionPrompt.selectMaxStepsPrompt({ step: 3, maxSteps: 10, headless: true })).toBeUndefined()
   })
 
   test("interactive last step uses the original summarize-what-you-tried prompt", () => {
     const out = SessionPrompt.selectMaxStepsPrompt({ step: 10, maxSteps: 10, headless: false })
     expect(out).toBeDefined()
-    expect(out).toContain(INTERACTIVE_MARKER)
+    expect(out).toContain(INTERACTIVE_UNIQUE_MARKER)
     expect(out).toContain(INTERACTIVE_SUMMARY_MARKER)
     // and must NOT carry the headless wording
     expect(out).not.toContain(HEADLESS_MARKER)
@@ -38,6 +38,7 @@ describe("SessionPrompt.selectMaxStepsPrompt", () => {
     expect(out).toMatch(/Do NOT summarize/i)
     // And must NOT be the interactive summary text.
     expect(out).not.toContain(INTERACTIVE_SUMMARY_MARKER)
+    expect(out).not.toContain(INTERACTIVE_UNIQUE_MARKER)
   })
 
   test("headless pre-warning fires one step before the limit", () => {
@@ -47,9 +48,7 @@ describe("SessionPrompt.selectMaxStepsPrompt", () => {
   })
 
   test("interactive mode never fires a pre-warning", () => {
-    expect(
-      SessionPrompt.selectMaxStepsPrompt({ step: 9, maxSteps: 10, headless: false }),
-    ).toBeUndefined()
+    expect(SessionPrompt.selectMaxStepsPrompt({ step: 9, maxSteps: 10, headless: false })).toBeUndefined()
   })
 
   test("over-limit step still uses the final-step prompt", () => {
@@ -63,16 +62,148 @@ describe("SessionPrompt.selectMaxStepsPrompt", () => {
       maxSteps: 10,
       headless: true,
     })
-    expect(interactive).toContain(INTERACTIVE_MARKER)
+    expect(interactive).toContain(INTERACTIVE_UNIQUE_MARKER)
     expect(headless).toContain(HEADLESS_MARKER)
+    // Critically: the interactive over-limit prompt must NOT contain the
+    // headless marker, otherwise prompt-selection has silently flipped.
+    expect(interactive).not.toContain(HEADLESS_MARKER)
+    expect(headless).not.toContain(INTERACTIVE_UNIQUE_MARKER)
+  })
+
+  test("headless prewarn does NOT fire when step is past maxSteps", () => {
+    // Even though `headless && step === maxSteps - 1` is the prewarn trigger,
+    // for an over-limit step we should land in the final branch, not prewarn.
+    const out = SessionPrompt.selectMaxStepsPrompt({ step: 11, maxSteps: 10, headless: true })
+    expect(out).toContain(HEADLESS_MARKER)
+    expect(out).not.toContain(HEADLESS_PREWARN_MARKER)
   })
 
   test("infinite step budget never fires either prompt", () => {
+    expect(SessionPrompt.selectMaxStepsPrompt({ step: 9999, maxSteps: Infinity, headless: false })).toBeUndefined()
+    expect(SessionPrompt.selectMaxStepsPrompt({ step: 9999, maxSteps: Infinity, headless: true })).toBeUndefined()
+  })
+
+  // Edge cases the consensus reviewers flagged as missing -------------------
+
+  test("maxSteps = 1: final fires immediately at step 1, prewarn never fires", () => {
+    // step starts at 1 (incremented before the check), maxSteps=1 means one
+    // shot only — the prewarn check `step === maxSteps - 1` would require
+    // step=0 which is never reached, so prewarn must skip.
+    const headlessFinal = SessionPrompt.selectMaxStepsPrompt({ step: 1, maxSteps: 1, headless: true })
+    expect(headlessFinal).toContain(HEADLESS_MARKER)
+    expect(headlessFinal).not.toContain(HEADLESS_PREWARN_MARKER)
+    const interactiveFinal = SessionPrompt.selectMaxStepsPrompt({ step: 1, maxSteps: 1, headless: false })
+    expect(interactiveFinal).toContain(INTERACTIVE_UNIQUE_MARKER)
+  })
+
+  test("maxSteps = 2: prewarn at step 1, final at step 2", () => {
+    const prewarn = SessionPrompt.selectMaxStepsPrompt({ step: 1, maxSteps: 2, headless: true })
+    expect(prewarn).toContain(HEADLESS_PREWARN_MARKER)
+    expect(prewarn).not.toContain(HEADLESS_MARKER)
+
+    const final = SessionPrompt.selectMaxStepsPrompt({ step: 2, maxSteps: 2, headless: true })
+    expect(final).toContain(HEADLESS_MARKER)
+    expect(final).not.toContain(HEADLESS_PREWARN_MARKER)
+  })
+
+  // M4 — prewarn copy must be internally consistent and dynamically computed
+  test("prewarn copy substitutes turn count consistently", () => {
+    const out = SessionPrompt.selectMaxStepsPrompt({ step: 9, maxSteps: 10, headless: true })
+    expect(out).toBeDefined()
+    // Template placeholder must have been replaced (no raw token left).
+    expect(out).not.toContain("{TURNS_REMAINING}")
+    // At step=maxSteps-1, exactly 1 tool-using turn remains. The copy must
+    // reflect that, not say "2 turns".
+    expect(out).toContain("1 tool-using turn left")
+    expect(out).not.toContain("2 turns")
+    // And the rest of the copy must agree: there is exactly one final
+    // tools-disabled turn after this response.
+    expect(out).toMatch(/one final turn/i)
+  })
+
+  test("prewarn copy explicitly mentions tools-disabled in final turn", () => {
+    const out = SessionPrompt.selectMaxStepsPrompt({ step: 9, maxSteps: 10, headless: true })
+    expect(out).toMatch(/tools will be disabled/i)
+  })
+})
+
+// M3 — when the headless final-step prompt fires, the API request must actually
+// strip tools, otherwise the prompt's "Tools are disabled" claim is a lie.
+describe("SessionPrompt.shouldDisableToolsForHeadlessFinalStep", () => {
+  test("disables tools at headless final step (text format)", () => {
     expect(
-      SessionPrompt.selectMaxStepsPrompt({ step: 9999, maxSteps: Infinity, headless: false }),
-    ).toBeUndefined()
+      SessionPrompt.shouldDisableToolsForHeadlessFinalStep({
+        step: 10,
+        maxSteps: 10,
+        headless: true,
+        formatType: "text",
+      }),
+    ).toBe(true)
+  })
+
+  test("does NOT disable tools when not headless", () => {
     expect(
-      SessionPrompt.selectMaxStepsPrompt({ step: 9999, maxSteps: Infinity, headless: true }),
-    ).toBeUndefined()
+      SessionPrompt.shouldDisableToolsForHeadlessFinalStep({
+        step: 10,
+        maxSteps: 10,
+        headless: false,
+        formatType: "text",
+      }),
+    ).toBe(false)
+  })
+
+  test("does NOT disable tools below the final step", () => {
+    expect(
+      SessionPrompt.shouldDisableToolsForHeadlessFinalStep({
+        step: 9,
+        maxSteps: 10,
+        headless: true,
+        formatType: "text",
+      }),
+    ).toBe(false)
+  })
+
+  test("does NOT disable tools when there is no step budget (Infinity)", () => {
+    expect(
+      SessionPrompt.shouldDisableToolsForHeadlessFinalStep({
+        step: 9999,
+        maxSteps: Infinity,
+        headless: true,
+        formatType: "text",
+      }),
+    ).toBe(false)
+  })
+
+  test("exempts json_schema mode (StructuredOutput tool must remain)", () => {
+    expect(
+      SessionPrompt.shouldDisableToolsForHeadlessFinalStep({
+        step: 10,
+        maxSteps: 10,
+        headless: true,
+        formatType: "json_schema",
+      }),
+    ).toBe(false)
+  })
+
+  test("disables tools also when step exceeds maxSteps (overshoot)", () => {
+    expect(
+      SessionPrompt.shouldDisableToolsForHeadlessFinalStep({
+        step: 12,
+        maxSteps: 10,
+        headless: true,
+        formatType: "text",
+      }),
+    ).toBe(true)
+  })
+
+  test("disables tools at maxSteps = 1 (one-shot headless)", () => {
+    expect(
+      SessionPrompt.shouldDisableToolsForHeadlessFinalStep({
+        step: 1,
+        maxSteps: 1,
+        headless: true,
+        formatType: "text",
+      }),
+    ).toBe(true)
   })
 })

--- a/packages/opencode/test/session/max-steps-prompt.test.ts
+++ b/packages/opencode/test/session/max-steps-prompt.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test"
+import { SessionPrompt } from "../../src/session/prompt"
+
+// altimate_change - tests for headless-aware max-steps prompt selection.
+// The full prompt loop is too large to run end-to-end in unit tests, so we
+// expose `selectMaxStepsPrompt` and exercise its branching logic directly.
+
+const HEADLESS_MARKER = "MAXIMUM STEPS REACHED (HEADLESS MODE)"
+const HEADLESS_PREWARN_MARKER = "APPROACHING STEP BUDGET (HEADLESS MODE)"
+const INTERACTIVE_MARKER = "MAXIMUM STEPS REACHED"
+const INTERACTIVE_SUMMARY_MARKER = "Summary of what has been accomplished so far"
+
+describe("SessionPrompt.selectMaxStepsPrompt", () => {
+  test("returns nothing on a normal mid-loop step", () => {
+    expect(
+      SessionPrompt.selectMaxStepsPrompt({ step: 3, maxSteps: 10, headless: false }),
+    ).toBeUndefined()
+    expect(
+      SessionPrompt.selectMaxStepsPrompt({ step: 3, maxSteps: 10, headless: true }),
+    ).toBeUndefined()
+  })
+
+  test("interactive last step uses the original summarize-what-you-tried prompt", () => {
+    const out = SessionPrompt.selectMaxStepsPrompt({ step: 10, maxSteps: 10, headless: false })
+    expect(out).toBeDefined()
+    expect(out).toContain(INTERACTIVE_MARKER)
+    expect(out).toContain(INTERACTIVE_SUMMARY_MARKER)
+    // and must NOT carry the headless wording
+    expect(out).not.toContain(HEADLESS_MARKER)
+  })
+
+  test("headless last step asks for a best-guess answer, not a meta-summary", () => {
+    const out = SessionPrompt.selectMaxStepsPrompt({ step: 10, maxSteps: 10, headless: true })
+    expect(out).toBeDefined()
+    expect(out).toContain(HEADLESS_MARKER)
+    // Must explicitly tell the model to commit an answer rather than summarize.
+    expect(out).toMatch(/best guess/i)
+    expect(out).toMatch(/Do NOT summarize/i)
+    // And must NOT be the interactive summary text.
+    expect(out).not.toContain(INTERACTIVE_SUMMARY_MARKER)
+  })
+
+  test("headless pre-warning fires one step before the limit", () => {
+    const out = SessionPrompt.selectMaxStepsPrompt({ step: 9, maxSteps: 10, headless: true })
+    expect(out).toBeDefined()
+    expect(out).toContain(HEADLESS_PREWARN_MARKER)
+  })
+
+  test("interactive mode never fires a pre-warning", () => {
+    expect(
+      SessionPrompt.selectMaxStepsPrompt({ step: 9, maxSteps: 10, headless: false }),
+    ).toBeUndefined()
+  })
+
+  test("over-limit step still uses the final-step prompt", () => {
+    const interactive = SessionPrompt.selectMaxStepsPrompt({
+      step: 15,
+      maxSteps: 10,
+      headless: false,
+    })
+    const headless = SessionPrompt.selectMaxStepsPrompt({
+      step: 15,
+      maxSteps: 10,
+      headless: true,
+    })
+    expect(interactive).toContain(INTERACTIVE_MARKER)
+    expect(headless).toContain(HEADLESS_MARKER)
+  })
+
+  test("infinite step budget never fires either prompt", () => {
+    expect(
+      SessionPrompt.selectMaxStepsPrompt({ step: 9999, maxSteps: Infinity, headless: false }),
+    ).toBeUndefined()
+    expect(
+      SessionPrompt.selectMaxStepsPrompt({ step: 9999, maxSteps: Infinity, headless: true }),
+    ).toBeUndefined()
+  })
+})

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -210,3 +210,126 @@ describe("session.prompt agent variant", () => {
     }
   })
 })
+
+// altimate_change start - regression tests for headless flag propagation.
+// These guard against the silent drops the consensus review caught on PR #763.
+describe("session.prompt headless flag propagation", () => {
+  test("persists headless: true on the user message and survives a roundtrip", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        agent: {
+          build: {
+            model: "openai/gpt-5.2",
+          },
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const msg = await SessionPrompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          noReply: true,
+          headless: true,
+          parts: [{ type: "text", text: "headless run" }],
+        })
+        if (msg.info.role !== "user") throw new Error("expected user message")
+        expect(msg.info.headless).toBe(true)
+
+        const reloaded = await MessageV2.get({ sessionID: session.id, messageID: msg.info.id })
+        if (reloaded.info.role !== "user") throw new Error("expected user message after reload")
+        expect(reloaded.info.headless).toBe(true)
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("absence of headless leaves the field undefined (interactive default)", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        agent: {
+          build: {
+            model: "openai/gpt-5.2",
+          },
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const msg = await SessionPrompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          noReply: true,
+          parts: [{ type: "text", text: "interactive run" }],
+        })
+        if (msg.info.role !== "user") throw new Error("expected user message")
+        // explicit absence — !!undefined is false, which is the interactive branch.
+        expect(msg.info.headless).toBeUndefined()
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("CommandInput zod schema accepts the headless flag", () => {
+    // C1 regression: `run --command` was dropping headless because CommandInput
+    // didn't have the field. Verify the schema both accepts headless: true and
+    // tolerates its absence.
+    const withFlag = SessionPrompt.CommandInput.safeParse({
+      sessionID: "ses_" + "0".repeat(20),
+      arguments: "",
+      command: "doit",
+      headless: true,
+    })
+    expect(withFlag.success).toBe(true)
+    if (withFlag.success) expect(withFlag.data.headless).toBe(true)
+
+    const withoutFlag = SessionPrompt.CommandInput.safeParse({
+      sessionID: "ses_" + "0".repeat(20),
+      arguments: "",
+      command: "doit",
+    })
+    expect(withoutFlag.success).toBe(true)
+    if (withoutFlag.success) expect(withoutFlag.data.headless).toBeUndefined()
+  })
+
+  test("PromptInput zod schema accepts the headless flag", () => {
+    const parsed = SessionPrompt.PromptInput.safeParse({
+      sessionID: "ses_" + "0".repeat(20),
+      headless: true,
+      parts: [{ type: "text", text: "x" }],
+    })
+    expect(parsed.success).toBe(true)
+    if (parsed.success) expect(parsed.data.headless).toBe(true)
+  })
+})
+
+// C2 regression: synthetic user-message constructors must propagate the
+// headless flag from the prior `lastUser`. We can't easily run the full loop,
+// but we can assert that the User schema accepts headless and that the shape
+// the loop builds (a copy from `lastUser`) round-trips through MessageV2.
+describe("MessageV2.User headless flag", () => {
+  test("schema accepts headless on the user message", () => {
+    const parsed = MessageV2.User.safeParse({
+      id: "msg_" + "0".repeat(20),
+      sessionID: "ses_" + "0".repeat(20),
+      role: "user",
+      time: { created: Date.now() },
+      agent: "build",
+      model: { providerID: "openai", modelID: "gpt-5.2" },
+      headless: true,
+    })
+    expect(parsed.success).toBe(true)
+    if (parsed.success) expect(parsed.data.headless).toBe(true)
+  })
+})
+// altimate_change end

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -1841,6 +1841,7 @@ export class Session2 extends HeyApiClient {
       format?: OutputFormat
       system?: string
       variant?: string
+      headless?: boolean
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
@@ -1861,6 +1862,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "format" },
             { in: "body", key: "system" },
             { in: "body", key: "variant" },
+            { in: "body", key: "headless" },
             { in: "body", key: "parts" },
           ],
         },
@@ -1973,6 +1975,7 @@ export class Session2 extends HeyApiClient {
       format?: OutputFormat
       system?: string
       variant?: string
+      headless?: boolean
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
@@ -1993,6 +1996,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "format" },
             { in: "body", key: "system" },
             { in: "body", key: "variant" },
+            { in: "body", key: "headless" },
             { in: "body", key: "parts" },
           ],
         },

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2030,6 +2030,7 @@ export class Session2 extends HeyApiClient {
       arguments?: string
       command?: string
       variant?: string
+      headless?: boolean
       parts?: Array<{
         id?: string
         type: "file"
@@ -2055,6 +2056,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "arguments" },
             { in: "body", key: "command" },
             { in: "body", key: "variant" },
+            { in: "body", key: "headless" },
             { in: "body", key: "parts" },
           ],
         },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -138,6 +138,7 @@ export type UserMessage = {
     [key: string]: boolean
   }
   variant?: string
+  headless?: boolean
 }
 
 export type ProviderAuthError = {
@@ -3284,6 +3285,7 @@ export type SessionPromptData = {
     format?: OutputFormat
     system?: string
     variant?: string
+    headless?: boolean
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
   }
   path: {
@@ -3484,6 +3486,7 @@ export type SessionPromptAsyncData = {
     format?: OutputFormat
     system?: string
     variant?: string
+    headless?: boolean
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
   }
   path: {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3529,6 +3529,7 @@ export type SessionCommandData = {
     arguments: string
     command: string
     variant?: string
+    headless?: boolean
     parts?: Array<{
       id?: string
       type: "file"

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -3026,6 +3026,9 @@
                   "variant": {
                     "type": "string"
                   },
+                  "headless": {
+                    "type": "boolean"
+                  },
                   "parts": {
                     "type": "array",
                     "items": {
@@ -3510,6 +3513,9 @@
                   "variant": {
                     "type": "string"
                   },
+                  "headless": {
+                    "type": "boolean"
+                  },
                   "parts": {
                     "type": "array",
                     "items": {
@@ -3641,6 +3647,9 @@
                   },
                   "variant": {
                     "type": "string"
+                  },
+                  "headless": {
+                    "type": "boolean"
                   },
                   "parts": {
                     "type": "array",
@@ -7290,6 +7299,9 @@
           },
           "variant": {
             "type": "string"
+          },
+          "headless": {
+            "type": "boolean"
           }
         },
         "required": ["id", "sessionID", "role", "time", "agent", "model"]


### PR DESCRIPTION
Closes #759

## Motivation

In headless mode (`-p` / `--print`), when the agent hits `--max-turns`, the existing MAX_STEPS injection produces a multi-paragraph "I have reached the maximum number of steps" summary instead of a committed answer. In interactive mode this is fine — a human can react. In headless / scripted use, there is no human; the program's final stdout is unparseable meta-prose.

Common situations where this matters:
- CI pipelines: `claude -p "review this PR for security issues"` returns a status update instead of a partial review
- Eval harnesses (any non-interactive batch grader)
- Composable shell pipelines: `git diff | claude -p "summarize"` — works only if the agent always emits the requested shape
- Scheduled / cron jobs: produce parseable output regardless of run length

## What's changed

This PR keeps interactive behaviour completely unchanged and adds a separate prompt path for headless mode.

**New prompt files:**
- `prompt/max-steps-headless.txt` — final-step prompt explicitly instructing the model to emit the answer (not a summary). The wording makes the rationale explicit: an uncertain best-guess is more useful than meta-prose, because the caller cannot ask for retries.
- `prompt/max-steps-headless-prewarn.txt` — soft pre-warning that fires one step before the limit when headless and `Number.isFinite(maxSteps)`. The `isFinite` guard prevents misfiring when no max-turns is set.

**Wiring:**
- `session/prompt.ts`: exported `selectMaxStepsPrompt({ step, maxSteps, headless })` — pure selector returning the right prompt for the current state, plumbed into the existing prompt loop.
- `cli/cmd/run.ts`: passes `headless: true` from the `-p` / `--print` CLI entry into the session SDK call.
- `session/message-v2.ts`: extended the `User` zod schema with optional `headless: boolean`, persisted on the user message so resumed sessions retain the flag.
- SDK gen cascade (`sdk.gen.ts` + `types.gen.ts`): updated by the existing `@hey-api/openapi-ts` step.

## Tests

**7 new tests** in `test/session/max-steps-prompt.test.ts`:
1. Mid-loop returns interactive prompt
2. Interactive last step returns interactive prompt
3. Headless last step returns headless prompt
4. Headless one-step-before-last returns prewarning
5. Interactive one-step-before-last returns nothing
6. Over-limit returns headless prompt (continues to fire if invoked late)
7. Infinite-budget (no maxSteps) returns nothing — `Number.isFinite` guard

**Results:**
- This file: **7 pass / 0 fail**
- Full session test directory: **543 pass / 4 skip / 0 fail** across 24 files (~8.6s) — no regressions
- Full opencode suite when merged with #758 + #760: **7421 pass / 0 fail / 494 skip** (~88s)
- `bun run typecheck` (opencode + sdk/js): clean

## Backwards compatibility

- Interactive prompt text completely unchanged — only headless invocations see new behaviour.
- New `headless?: boolean` field is optional everywhere; older SDK consumers see no breaking change.
- A session run with `-p` and then resumed (e.g., session reload via the API) still applies headless behaviour, which matches the original intent — the flag persists on the user message.

## Notes

- The headless prompt's full text is in `max-steps-headless.txt`; it explicitly tells the model not to emit a meta-summary, with the reasoning (no human to ask follow-ups, an uncertain answer is more useful than no answer).
- The optional pre-warning is wired in and tested. It only fires in headless mode and only when `maxSteps` is finite; interactive mode never sees it.

## Files

- `packages/opencode/src/cli/cmd/run.ts`
- `packages/opencode/src/session/message-v2.ts`
- `packages/opencode/src/session/prompt.ts`
- `packages/opencode/src/session/prompt/max-steps-headless.txt` (new)
- `packages/opencode/src/session/prompt/max-steps-headless-prewarn.txt` (new)
- `packages/opencode/test/session/max-steps-prompt.test.ts` (new)
- `packages/sdk/js/src/v2/gen/types.gen.ts`
- `packages/sdk/js/src/v2/gen/sdk.gen.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Headless runs now commit a best-guess answer at `--max-turns` and actually disable tools on the final step. This makes CI/evals reliably parseable and fully addresses #759.

- **Bug Fixes**
  - Propagate `headless: true` through all non-interactive paths: `run --command`, GitHub, and GitLab commands.
  - Preserve `headless` on synthetic user messages (post-task summary, compaction replay/continue) so long runs don’t flip back to interactive.
  - Enforce tools-disabled on the headless final step (strip tools, set toolChoice to none; exempt `json_schema`).
  - Add `headless` to `User` and to `session.prompt`/`session.prompt_async`/`session.command` in `openapi.json` and the JS SDK types.
  - Make the prewarn copy consistent via `{TURNS_REMAINING}` substitution; add focused tests for selection, tool-disabling, schemas, and edge cases.

<sup>Written for commit 78acb0fc42f2264e525d359971d1992b68515373. Summary will update on new commits. <a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/763?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Headless mode for non-interactive runs now produces a final best-guess answer (rather than a meta-summary) and disables tool use on the final headless step.
  * CLI/CI executions default to headless behavior; API now accepts an optional headless flag.

* **Tests**
  * Added tests covering max-steps prompt selection, headless pre-warn/final behavior, and headless flag propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->