### PR TITLE
fix: [#781] marker-guard non-strict on bridge-merge push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,8 +441,18 @@ jobs:
               echo "Initial push (zero-SHA) — skipping marker check"
               exit 0
             fi
-            echo "Push to main — running marker check against pre-push state"
-            bun run script/upstream/analyze.ts --markers --base "${{ github.event.before }}" --strict
+            # Squash-merging an `upstream/merge-*` PR lands as a single commit
+            # on main, so the second-parent / branch-name signal is gone here.
+            # Detect bridge/merge-upstream commits in the pushed range by subject
+            # and downgrade to non-strict — the PR-side review already gated this.
+            if git log --format=%s "${{ github.event.before }}..${{ github.sha }}" \
+                 | grep -qiE '(bridge|merge) upstream'; then
+              echo "Bridge/upstream-merge commit detected in push range — running marker check in non-strict mode"
+              bun run script/upstream/analyze.ts --markers --base "${{ github.event.before }}"
+            else
+              echo "Push to main — running marker check against pre-push state"
+              bun run script/upstream/analyze.ts --markers --base "${{ github.event.before }}" --strict
+            fi
           elif [[ "${{ github.head_ref }}" == merge-upstream-* ]] || [[ "${{ github.head_ref }}" == upstream/merge-* ]]; then
             echo "Upstream merge PR detected — running marker check in non-strict mode"
             bun run script/upstream/analyze.ts --markers --base ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
### What does this PR do?

Fixes the `Marker Guard` job failing on push-to-`main` immediately after a bridge / upstream-merge PR is squash-merged.

The PR-side path of the workflow already runs `analyze.ts --markers` in non-strict mode for `upstream/merge-*` head_refs. But once such a PR is squash-merged, the push event onto `main` has no head_ref / second-parent / branch-name signal, so the workflow falls back to:

```
bun run script/upstream/analyze.ts --markers --base "${{ github.event.before }}" --strict
```

For a bridge merge that overlays hundreds of upstream files, the diff legitimately contains piles of upstream code without `altimate_change` blocks, and strict mode fails. That's exactly what happened on the v1.4.0 bridge merge:
- Run: https://github.com/AltimateAI/altimate-code/actions/runs/25264283463
- Output: `⚠ Found 98 file(s) with unmarked custom code` → `--strict mode — failing CI`

This patch detects bridge / upstream-merge commits in the pushed range by commit subject (`grep -qiE '(bridge|merge) upstream'`) and downgrades strict→non-strict for those pushes. Warnings are still printed in the job output; the PR-side review already gated marker integrity for the change before it landed.

The `Branding leak audit` and `Require-markers regression backstop` steps remain unconditional — the only thing being relaxed is the strict diff-based marker check on push, and only when the push contains a bridge/upstream-merge commit.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Issue for this PR

Closes #781

### How did you verify your code works?

Re-ran the marker tooling locally against the exact range from the failing run (`941c8cae21..3cc3d4cb68` on `origin/main`):

- **Detection regex** — `git log --format=%s 941c8cae21..3cc3d4cb68 origin/main | grep -qiE '(bridge|merge) upstream'` → matches the squash-merge subject `feat: bridge upstream v1.4.0 across history rewrite + 3 backports + adversarial test suite (#757)`. Without `--strict`, the workflow takes the new bridge-merge path.
- **Non-strict marker run** — `bun run script/upstream/analyze.ts --markers --base 941c8cae21f124f509da6cc0ca0313a06473e50c` prints 97 warnings and **exits 0** (vs strict mode exiting 1).
- **Other guard steps still pass on current `main` HEAD**:
  - `bun run script/upstream/analyze.ts --branding` → exit 0, "All blocks properly closed".
  - `bun run script/upstream/analyze.ts --require-markers --strict` → exit 0, "All behavior-patched files have markers" (38/38).
- **Marker parser tests** — `cd script/upstream && bun test` → 22 pass, 0 fail.
- **YAML validity** — `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → OK.
- **No false-positive risk for normal pushes** — the regex only matches the literal subject patterns `bridge upstream` / `merge upstream`. Dependabot, release, and ordinary feature commits do not contain these phrases, so non-bridge pushes still take the strict path.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `Marker Guard` job run in non-strict mode on pushes to `main` that include a bridge/upstream-merge commit, preventing false failures after squash merges. Normal pushes remain strict.

- **Bug Fixes**
  - Detect bridge/upstream-merge commits in the pushed range by subject and run `analyze.ts --markers --base <before>` without `--strict`.
  - Keep `--branding` and `--require-markers --strict` unchanged; warnings still surface in job output.

<sup>Written for commit 94e7a6508c2160e710b30e05f60946572eb3d50a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to improve marker validation handling. The system now intelligently differentiates between standard repository pushes and upstream-related commits, applying appropriate validation modes for each scenario type. Initial push operations continue to bypass marker checks as expected, with no changes to existing branch logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->