### PR TITLE
fix: [#788] surface OpenAI nested error.message instead of `Bad Request: {?:?}`

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -61,11 +61,21 @@ export namespace ProviderError {
 
       try {
         const body = JSON.parse(e.responseBody)
-        // try to extract common error message fields
-        const errMsg = body.message || body.error || body.error?.message
-        if (errMsg && typeof errMsg === "string") {
-          return `${msg}: ${errMsg}`
-        }
+        // altimate_change start — upstream_fix: OpenAI errors use {error: {message}} shape;
+        // the original `body.message || body.error || body.error?.message` short-circuits on
+        // the parent object, fails the typeof string guard, and dumps the raw body. Use an
+        // explicit-typeof ternary so a truthy non-string at any level can't block a valid
+        // string further down the chain (matches parseStreamError's pattern below).
+        const errMsg =
+          typeof body.error?.message === "string"
+            ? body.error.message
+            : typeof body.message === "string"
+              ? body.message
+              : typeof body.error === "string"
+                ? body.error
+                : undefined
+        if (errMsg) return `${msg}: ${errMsg}`
+        // altimate_change end
       } catch {}
 
       // If responseBody is HTML (e.g. from a gateway or proxy error page),

--- a/packages/opencode/test/provider/error.test.ts
+++ b/packages/opencode/test/provider/error.test.ts
@@ -259,4 +259,125 @@ describe("ProviderError.parseAPICallError: error message extraction", () => {
       expect(result.message).toContain("invalid JSON in request body")
     }
   })
+
+  test("extracts nested error.message from OpenAI-shaped JSON body", () => {
+    // OpenAI returns 4xx errors with {error: {message, type, code}}. The extractor
+    // must reach body.error.message — not stop at body.error (which is the object).
+    const result = ProviderError.parseAPICallError({
+      providerID: "openai" as any,
+      error: makeAPICallError({
+        message: "Bad Request",
+        statusCode: 400,
+        responseBody: JSON.stringify({
+          error: {
+            message: "The model `gpt-5-codex` does not exist or you do not have access to it.",
+            type: "invalid_request_error",
+            code: "model_not_found",
+          },
+        }),
+      }),
+    })
+    expect(result.type).toBe("api_error")
+    if (result.type === "api_error") {
+      expect(result.message).toContain("Bad Request")
+      expect(result.message).toContain("gpt-5-codex")
+      expect(result.message).toContain("does not exist")
+      // The raw structured body must not be dumped when a clean message extracted.
+      // Detect a leak by looking for JSON delimiters from the parsed body.
+      expect(result.message).not.toContain('"error":')
+      expect(result.message).not.toContain("{")
+    }
+  })
+
+  test("extracts top-level message field when present", () => {
+    const result = ProviderError.parseAPICallError({
+      providerID: "anthropic" as any,
+      error: makeAPICallError({
+        message: "Bad Request",
+        statusCode: 400,
+        responseBody: JSON.stringify({ message: "Field 'foo' is required" }),
+      }),
+    })
+    expect(result.type).toBe("api_error")
+    if (result.type === "api_error") {
+      expect(result.message).toContain("Field 'foo' is required")
+    }
+  })
+
+  test("falls back to body.error string when it is a plain string", () => {
+    // Some providers return {error: "string"} rather than {error: {message: ...}}.
+    const result = ProviderError.parseAPICallError({
+      providerID: "anthropic" as any,
+      error: makeAPICallError({
+        message: "Bad Request",
+        statusCode: 400,
+        responseBody: JSON.stringify({ error: "Something went wrong" }),
+      }),
+    })
+    expect(result.type).toBe("api_error")
+    if (result.type === "api_error") {
+      expect(result.message).toContain("Something went wrong")
+    }
+  })
+
+  test("falls back through the chain when body.error has no message but body.message does", () => {
+    // body.error is an object without a `message` key — the extractor must skip it
+    // and reach the top-level body.message.
+    const result = ProviderError.parseAPICallError({
+      providerID: "openai" as any,
+      error: makeAPICallError({
+        message: "Bad Request",
+        statusCode: 400,
+        responseBody: JSON.stringify({
+          error: { code: "rate_limited", type: "throttle" },
+          message: "Slow down",
+        }),
+      }),
+    })
+    expect(result.type).toBe("api_error")
+    if (result.type === "api_error") {
+      expect(result.message).toContain("Slow down")
+    }
+  })
+
+  test("non-string body.error.message does not block a valid body.message", () => {
+    // Same class as the bug we just fixed: a truthy non-string at any level of the
+    // chain must not short-circuit a valid string further down.
+    const result = ProviderError.parseAPICallError({
+      providerID: "openai" as any,
+      error: makeAPICallError({
+        message: "Bad Request",
+        statusCode: 400,
+        responseBody: JSON.stringify({
+          error: { message: ["array", "of", "strings"] },
+          message: "Real human-readable error",
+        }),
+      }),
+    })
+    expect(result.type).toBe("api_error")
+    if (result.type === "api_error") {
+      expect(result.message).toContain("Real human-readable error")
+      expect(result.message).not.toContain("array")
+    }
+  })
+
+  test("dumps raw body when no string-typed message field exists anywhere", () => {
+    // body.error has only non-message fields and no top-level message — the parser
+    // falls through to the raw responseBody dump (last-resort behavior preserved).
+    const responseBody = JSON.stringify({ error: { code: "x", type: "y" } })
+    const result = ProviderError.parseAPICallError({
+      providerID: "openai" as any,
+      error: makeAPICallError({
+        message: "Bad Request",
+        statusCode: 400,
+        responseBody,
+      }),
+    })
+    expect(result.type).toBe("api_error")
+    if (result.type === "api_error") {
+      // Falls through to `${msg}: ${responseBody}` — preserves existing behavior.
+      expect(result.message).toContain("Bad Request")
+      expect(result.message).toContain(responseBody)
+    }
+  })
 })


### PR DESCRIPTION
### What does this PR do?

Fixes `provider/error.ts` so OpenAI 4xx errors with the standard `{error: {message, type, code}}` shape surface their inner `message` to the user, instead of the previous fallthrough behavior that produced `APIError: Bad Request: {?:?}` (the `{?:?}` is the App Insights pipeline scrubbing string values from the raw structured body).

The original OR-chain `body.message || body.error || body.error?.message` short-circuited on `body.error` (an object), failed the `typeof === "string"` guard, and dumped the raw `responseBody`. Replaced with an explicit-typeof ternary that handles the three known shapes cleanly and matches `parseStreamError`'s defensive pattern at line 153.

Wrapped in `// altimate_change start — upstream_fix:` markers per project policy. Upstream has the same bug; a parallel upstream PR is being filed so we can drop our marker if upstream takes the fix.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #788

### How did you verify your code works?

- `bun test packages/opencode/test/provider/error.test.ts` — **24/24 pass** (18 existing + 6 new)
- `bun test packages/opencode/test/provider/` — **386/386 pass** (full provider suite)
- `bunx tsgo --noEmit` — clean (exit 0)
- `bun run script/upstream/analyze.ts --markers --base main --strict` — passes (changes wrapped in markers)
- Reviewed by GPT 5.4, Gemini 3.1 Pro, Kimi K2.5 via `/consensus:code-review` — all approved with the test coverage and ternary improvements applied before commit

### Tests added

- OpenAI nested shape extracts the inner message and does not leak the structured body (regression test for the bug)
- Top-level `body.message` still works (non-regression)
- Plain-string `body.error` still works (non-regression)
- Object `body.error` without `message` key falls through to top-level `body.message`
- Non-string `body.error.message` (array/object) does not block a valid `body.message` (defensive guard for the same class of bug)
- All-non-string-fields body falls through to raw `responseBody` (existing last-resort behavior preserved)

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (n/a — internal error parser)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes error message extraction for OpenAI 4xx responses by reading nested `error.message` instead of dumping the raw body. Users now see actionable errors (e.g., model not found) instead of "Bad Request: {?:?}", meeting Linear #788.

- **Bug Fixes**
  - Extract error via `body.error.message` → `body.message` → string `body.error`, avoiding object short-circuits and matching stream parser behavior.
  - Avoids leaking raw `responseBody` when a valid message exists; covered by new tests.

<sup>Written for commit 3a7ec72b32e724782bf7eeb8648a7bf2d8754aa1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error message extraction from API responses, ensuring clearer and more accurate error details are displayed to users even when APIs return complex error structures.

* **Tests**
  * Added comprehensive test coverage for error message extraction across multiple response formats to ensure consistent error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->