### PR TITLE
fix: [#309] point install endpoint at altimate.sh/install (not altimate.ai/install)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm install -g altimate-code
 Or via curl (installs the `altimate` binary to `~/.altimate/bin`):
 
 ```bash
-curl -fsSL https://altimate.sh/install | bash
+curl -fsSL https://www.altimate.sh/install | bash
 ```
 
 The curl install drops a single self-contained binary named `altimate`. The npm install exposes both `altimate` and `altimate-code` on PATH; the curl install only exposes `altimate`. Alpine Linux (musl) and Windows on ARM64 are not currently supported by the standalone binary — use `apk add gcompat` on Alpine, or use WSL on Windows-on-ARM.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm install -g altimate-code
 Or via curl (installs the `altimate` binary to `~/.altimate/bin`):
 
 ```bash
-curl -fsSL https://altimate.ai/install | bash
+curl -fsSL https://altimate.sh/install | bash
 ```
 
 The curl install drops a single self-contained binary named `altimate`. The npm install exposes both `altimate` and `altimate-code` on PATH; the curl install only exposes `altimate`. Alpine Linux (musl) and Windows on ARM64 are not currently supported by the standalone binary — use `apk add gcompat` on Alpine, or use WSL on Windows-on-ARM.

--- a/docs/docs/reference/troubleshooting.md
+++ b/docs/docs/reference/troubleshooting.md
@@ -4,7 +4,7 @@
 
 ### Standalone binary not found after curl install
 
-**Symptoms:** `altimate-code: command not found` after running `curl -fsSL https://altimate.sh/install | bash`.
+**Symptoms:** `altimate-code: command not found` after running `curl -fsSL https://www.altimate.sh/install | bash`.
 
 As of v0.7.1 the curl-installed binary is named `altimate`, not `altimate-code`. The npm package continues to ship both names. If you scripted against the curl install:
 
@@ -25,7 +25,7 @@ Or stay on the `altimate-code` name by installing via npm: `npm install -g altim
 The v0.7.0 curl install shipped without the NAPI native module. Fixed in v0.7.1 — the native module is now embedded directly into the binary. Re-install with:
 
 ```bash
-curl -fsSL https://altimate.sh/install | bash
+curl -fsSL https://www.altimate.sh/install | bash
 ```
 
 ### Alpine Linux (musl) not supported
@@ -39,7 +39,7 @@ curl -fsSL https://altimate.sh/install | bash
 apk add gcompat
 
 # Then either:
-curl -fsSL https://altimate.sh/install | bash   # standalone binary
+curl -fsSL https://www.altimate.sh/install | bash   # standalone binary
 # or:
 apk add gcompat && npm install -g altimate-code  # npm install
 ```

--- a/docs/docs/reference/troubleshooting.md
+++ b/docs/docs/reference/troubleshooting.md
@@ -4,7 +4,7 @@
 
 ### Standalone binary not found after curl install
 
-**Symptoms:** `altimate-code: command not found` after running `curl -fsSL https://altimate.ai/install | bash`.
+**Symptoms:** `altimate-code: command not found` after running `curl -fsSL https://altimate.sh/install | bash`.
 
 As of v0.7.1 the curl-installed binary is named `altimate`, not `altimate-code`. The npm package continues to ship both names. If you scripted against the curl install:
 
@@ -25,7 +25,7 @@ Or stay on the `altimate-code` name by installing via npm: `npm install -g altim
 The v0.7.0 curl install shipped without the NAPI native module. Fixed in v0.7.1 — the native module is now embedded directly into the binary. Re-install with:
 
 ```bash
-curl -fsSL https://altimate.ai/install | bash
+curl -fsSL https://altimate.sh/install | bash
 ```
 
 ### Alpine Linux (musl) not supported
@@ -39,7 +39,7 @@ curl -fsSL https://altimate.ai/install | bash
 apk add gcompat
 
 # Then either:
-curl -fsSL https://altimate.ai/install | bash   # standalone binary
+curl -fsSL https://altimate.sh/install | bash   # standalone binary
 # or:
 apk add gcompat && npm install -g altimate-code  # npm install
 ```

--- a/install
+++ b/install
@@ -20,8 +20,8 @@ Options:
         --no-modify-path    Don't modify shell config files (.zshrc, .bashrc, etc.)
 
 Examples:
-    curl -fsSL https://altimate.ai/install | bash
-    curl -fsSL https://altimate.ai/install | bash -s -- --version 1.0.180
+    curl -fsSL https://altimate.sh/install | bash
+    curl -fsSL https://altimate.sh/install | bash -s -- --version 1.0.180
     ./install --binary /path/to/altimate
 EOF
 }

--- a/install
+++ b/install
@@ -20,8 +20,8 @@ Options:
         --no-modify-path    Don't modify shell config files (.zshrc, .bashrc, etc.)
 
 Examples:
-    curl -fsSL https://altimate.sh/install | bash
-    curl -fsSL https://altimate.sh/install | bash -s -- --version 1.0.180
+    curl -fsSL https://www.altimate.sh/install | bash
+    curl -fsSL https://www.altimate.sh/install | bash -s -- --version 1.0.180
     ./install --binary /path/to/altimate
 EOF
 }

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -34,11 +34,14 @@ export namespace Installation {
   }
 
   async function upgradeCurl(target: string) {
-    // altimate_change start — curl-upgrade endpoint URL
+    // altimate_change start — curl-upgrade endpoint URL + bounded fetch timeout
     // Upstream uses opencode.ai/install. We fetch the altimate install script
     // from www.altimate.sh/install (the apex altimate.sh isn't routed to the
     // Amplify Next.js app — tracked separately; revisit when apex DNS is fixed).
-    const body = await fetch("https://www.altimate.sh/install").then((res) => {
+    // 15s timeout so a stalled CDN/origin can't hang `altimate upgrade` forever.
+    const body = await fetch("https://www.altimate.sh/install", {
+      signal: AbortSignal.timeout(15_000),
+    }).then((res) => {
       if (!res.ok) throw new Error(res.statusText)
       return res.text()
     })

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -34,7 +34,7 @@ export namespace Installation {
   }
 
   async function upgradeCurl(target: string) {
-    const body = await fetch("https://altimate.ai/install").then((res) => {
+    const body = await fetch("https://altimate.sh/install").then((res) => {
       if (!res.ok) throw new Error(res.statusText)
       return res.text()
     })

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -34,10 +34,15 @@ export namespace Installation {
   }
 
   async function upgradeCurl(target: string) {
-    const body = await fetch("https://altimate.sh/install").then((res) => {
+    // altimate_change start — curl-upgrade endpoint URL
+    // Upstream uses opencode.ai/install. We fetch the altimate install script
+    // from www.altimate.sh/install (the apex altimate.sh isn't routed to the
+    // Amplify Next.js app — tracked separately; revisit when apex DNS is fixed).
+    const body = await fetch("https://www.altimate.sh/install").then((res) => {
       if (!res.ok) throw new Error(res.statusText)
       return res.text()
     })
+    // altimate_change end
     const proc = Process.spawn(["bash"], {
       stdin: "pipe",
       stdout: "pipe",

--- a/packages/opencode/test/branding/branding.test.ts
+++ b/packages/opencode/test/branding/branding.test.ts
@@ -121,8 +121,12 @@ describe("Installation Script", () => {
     expect(installContent).not.toContain("anomalyco")
   })
 
-  test("references altimate.ai domain for user-facing URLs", () => {
-    expect(installContent).toContain("altimate.ai")
+  test("references altimate-owned domain for user-facing URLs", () => {
+    // The install URL moved from altimate.ai → altimate.sh in v0.7.1 because
+    // altimate.ai/install was an unreachable route on the marketing SPA
+    // (issue #309). altimate.sh is the canonical altimate-code site.
+    expect(installContent).toContain("altimate.sh/install")
+    expect(installContent).not.toContain("altimate.ai/install")
   })
 })
 

--- a/packages/opencode/test/install/upgrade-method.test.ts
+++ b/packages/opencode/test/install/upgrade-method.test.ts
@@ -97,6 +97,13 @@ describe("upgrade execution", () => {
     expect(INSTALLATION_SRC).not.toContain("https://altimate.ai/install")
   })
 
+  test("curl upgrade fetch has a bounded timeout", () => {
+    // Without a timeout the install-script fetch can stall indefinitely on a
+    // hung CDN/origin, blocking `altimate upgrade` forever. Use AbortSignal.timeout
+    // so the request fails fast with a clear error instead.
+    expect(INSTALLATION_SRC).toMatch(/AbortSignal\.timeout\(\s*15_000\s*\)/)
+  })
+
   test("VERSION normalization strips v prefix", () => {
     expect(INSTALLATION_SRC).toContain('OPENCODE_VERSION.trim().replace(/^v/, "")')
   })

--- a/packages/opencode/test/install/upgrade-method.test.ts
+++ b/packages/opencode/test/install/upgrade-method.test.ts
@@ -86,7 +86,11 @@ describe("upgrade execution", () => {
   })
 
   test("curl upgrade uses altimate.sh/install endpoint", () => {
-    expect(INSTALLATION_SRC).toContain("https://altimate.sh/install")
+    // Accept either apex (altimate.sh) or www. host. Apex routes to a non-
+    // Amplify origin today, so the source uses www.altimate.sh; once the
+    // apex is fixed (separate infra change), the source can drop www. and
+    // this assertion still passes.
+    expect(INSTALLATION_SRC).toMatch(/https:\/\/(www\.)?altimate\.sh\/install/)
     // altimate.ai/install was the legacy URL (broken since 2026-05; tracked in
     // #309). Keep the assertion so any future regression that reintroduces it
     // fires immediately.

--- a/packages/opencode/test/install/upgrade-method.test.ts
+++ b/packages/opencode/test/install/upgrade-method.test.ts
@@ -85,8 +85,12 @@ describe("upgrade execution", () => {
     expect(INSTALLATION_SRC).toContain("HOMEBREW_NO_AUTO_UPDATE")
   })
 
-  test("curl upgrade uses altimate.ai/install endpoint", () => {
-    expect(INSTALLATION_SRC).toContain("https://altimate.ai/install")
+  test("curl upgrade uses altimate.sh/install endpoint", () => {
+    expect(INSTALLATION_SRC).toContain("https://altimate.sh/install")
+    // altimate.ai/install was the legacy URL (broken since 2026-05; tracked in
+    // #309). Keep the assertion so any future regression that reintroduces it
+    // fires immediately.
+    expect(INSTALLATION_SRC).not.toContain("https://altimate.ai/install")
   })
 
   test("VERSION normalization strips v prefix", () => {

--- a/packages/opencode/test/skill/release-v0.7.1-binary-adversarial.test.ts
+++ b/packages/opencode/test/skill/release-v0.7.1-binary-adversarial.test.ts
@@ -281,7 +281,9 @@ describe("v0.7.1 PR #820 — docs surface coverage", () => {
   })
   test("README documents the curl install option with the correct binary name", () => {
     const readme = readFileSync(path.join(REPO_ROOT, "README.md"), "utf8")
-    expect(readme).toContain("curl -fsSL https://altimate.sh/install | bash")
+    // Accept either apex (altimate.sh) or www. host so a future apex-DNS fix
+    // that swaps www.altimate.sh → altimate.sh doesn't need another test update.
+    expect(readme).toMatch(/curl -fsSL https:\/\/(www\.)?altimate\.sh\/install \| bash/)
     expect(readme).toContain("~/.altimate/bin")
     expect(readme).toMatch(/single self-contained binary named `altimate`/)
   })

--- a/packages/opencode/test/skill/release-v0.7.1-binary-adversarial.test.ts
+++ b/packages/opencode/test/skill/release-v0.7.1-binary-adversarial.test.ts
@@ -281,7 +281,7 @@ describe("v0.7.1 PR #820 — docs surface coverage", () => {
   })
   test("README documents the curl install option with the correct binary name", () => {
     const readme = readFileSync(path.join(REPO_ROOT, "README.md"), "utf8")
-    expect(readme).toContain("curl -fsSL https://altimate.ai/install | bash")
+    expect(readme).toContain("curl -fsSL https://altimate.sh/install | bash")
     expect(readme).toContain("~/.altimate/bin")
     expect(readme).toMatch(/single self-contained binary named `altimate`/)
   })


### PR DESCRIPTION
### What does this PR do?

Swaps the install endpoint from `altimate.ai/install` (unreachable — HTML 404 on the marketing-site SPA) to `altimate.sh/install` (the canonical altimate-code site, where a Next.js route handler now serves the curl install script — see AltimateAI/altimate-code-website#22).

The mismatch broke v0.7.1's standalone install path end-to-end. Two failures, one URL:

1. `curl -fsSL https://altimate.ai/install | bash` fetched HTML and tried to bash-execute it (would error out, but with a confusing symptom — not a clear "endpoint missing" message).
2. `altimate upgrade` for curl-installed users fetches the install URL via `Installation.upgradeCurl()` in `packages/opencode/src/installation/index.ts:37` to re-run the install script. With the broken URL, every curl-installed user's in-place upgrade silently failed.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other: doc + test sweep to keep references in sync

### Issue for this PR

Closes #309

### How did you verify your code works?

- [x] `bun turbo typecheck --filter=@altimateai/altimate-code` — clean
- [x] `bun test --timeout 30000 test/install/ test/installation/ test/branding/ test/skill/release-v0.7.1-*` — 420/420 pass
- [x] `bun run script/upstream/analyze.ts --markers --base main --strict` — `ok` no upstream-shared files modified
- [x] Updated `packages/opencode/test/install/upgrade-method.test.ts:88-93` so the assertion now **requires** `altimate.sh/install` AND **rejects** `altimate.ai/install` (negative assertion catches future regression that reintroduces the broken URL)
- [x] Updated `packages/opencode/test/branding/branding.test.ts:124-130` "references altimate-owned domain" check the same way
- [x] Updated `packages/opencode/test/skill/release-v0.7.1-binary-adversarial.test.ts:284` README curl-install assertion that was pinning the old URL
- [ ] After companion website PR ships + this PR merges + next release: `altimate upgrade` from a curl-installed binary upgrades in place (manual verification)
- [ ] After companion website PR ships: `curl -fsSL https://altimate.sh/install | bash` end-to-end smoke (manual verification)

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (the negative-assertion comments explain why both directions of the test matter)
- [x] I have made corresponding changes to the documentation (`docs/docs/reference/troubleshooting.md`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective (negative assertions on `altimate.ai/install` in two test files)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published: **pending** — the companion website PR (AltimateAI/altimate-code-website#22) ships the route handler at `altimate.sh/install`. **Merge order: website first, then this.**

### Files touched

| File | Change |
|------|--------|
| `install` | 2× `altimate.ai/install` → `altimate.sh/install` (--help examples) |
| `README.md` | install instruction |
| `packages/opencode/src/installation/index.ts` | `fetch("https://altimate.sh/install")` in `upgradeCurl()` |
| `docs/docs/reference/troubleshooting.md` | 3× references in install-path troubleshooting section |
| `packages/opencode/test/install/upgrade-method.test.ts` | assertion updated + negative assertion against legacy URL |
| `packages/opencode/test/branding/branding.test.ts` | brand-domain assertion updated + negative assertion |
| `packages/opencode/test/skill/release-v0.7.1-binary-adversarial.test.ts` | README curl-install assertion updated |

### Out of scope

- `docs/mkdocs.yml:51` references `altimate.ai/discord` — that's the Discord invite on the marketing site, not the install path. Left unchanged.

### Pairs with

- **AltimateAI/altimate-code-website#22** — adds the `app/install/route.ts` handler that serves the curl script at `altimate.sh/install` with proper `Content-Type` and GA4 download tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the install endpoint to https://www.altimate.sh/install and add a 15s timeout in `upgradeCurl()` to prevent hung upgrades. Fixes curl installs and restores `altimate upgrade` for curl users (issue #309).

- **Bug Fixes**
  - `upgradeCurl()` now fetches from `https://www.altimate.sh/install` (inside an `altimate_change` block).
  - Bound the fetch with `AbortSignal.timeout(15_000)` to fail fast on stalls.
  - Updated examples in `install`, `README.md`, and troubleshooting docs to use the `www` host.
  - Strengthened tests to accept `https://(www\.)?altimate.sh/install`, reject `altimate.ai/install`, and verify the timeout is present.

<sup>Written for commit a511019b26eb9dec90b56f355feae6c530e96fbb. Summary will update on new commits. <a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/825?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README and troubleshooting docs to point users to the new standalone installer URL and clarified reinstall/workaround steps for missing native modules and Alpine (musl).

* **Chores**
  * Aligned installer help text and all install/upgrade references in tests and docs to the new curl installer endpoint.

* **Bug Fixes**
  * Installer upgrade now enforces a bounded download timeout to avoid long hangs during fetch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AltimateAI/altimate-code/pull/825?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->