### PR TITLE
fix: [#830] project_scan 32% failure rate — defensive spawn + degraded tracking

### DIFF
--- a/packages/opencode/src/altimate/tools/project-scan.ts
+++ b/packages/opencode/src/altimate/tools/project-scan.ts
@@ -47,28 +47,45 @@ export interface ConfigFileInfo {
 
 // --- Detection functions (exported for testing) ---
 
+/**
+ * Run a subprocess that may or may not exist on the host.
+ *
+ * `Bun.spawnSync` throws when the binary is missing from $PATH (e.g.
+ * `Executable not found in $PATH: "git"`) — not just when it exits non-zero.
+ * Telemetry shows this fingerprint hitting ~437 distinct users on
+ * `project_scan` (the binary name `"git"` was masked to `?` downstream,
+ * which made it look like a generic shell error). Wrap every spawn so a
+ * missing binary degrades gracefully instead of crashing the whole tool.
+ */
+function safeSpawnSync(args: string[]): { exitCode: number; stdout: string } | null {
+  try {
+    const result = Bun.spawnSync(args, { stdout: "pipe", stderr: "pipe" })
+    return {
+      exitCode: result.exitCode ?? 1,
+      stdout: result.stdout?.toString() ?? "",
+    }
+  } catch {
+    // Binary missing from PATH, permission denied, etc. — treat as
+    // "command failed" so the caller sees a deterministic result instead
+    // of an exception bubbling up.
+    return null
+  }
+}
+
 export async function detectGit(): Promise<GitInfo> {
-  const isRepoResult = Bun.spawnSync(["git", "rev-parse", "--is-inside-work-tree"], {
-    stdout: "pipe",
-    stderr: "pipe",
-  })
-  if (isRepoResult.exitCode !== 0) {
+  const isRepoResult = safeSpawnSync(["git", "rev-parse", "--is-inside-work-tree"])
+  if (!isRepoResult || isRepoResult.exitCode !== 0) {
     return { isRepo: false }
   }
 
-  const branchResult = Bun.spawnSync(["git", "branch", "--show-current"], {
-    stdout: "pipe",
-    stderr: "pipe",
-  })
-  const branch = branchResult.exitCode === 0 ? branchResult.stdout.toString().trim() || undefined : undefined
+  const branchResult = safeSpawnSync(["git", "branch", "--show-current"])
+  const branch =
+    branchResult && branchResult.exitCode === 0 ? branchResult.stdout.trim() || undefined : undefined
 
   let remoteUrl: string | undefined
-  const remoteResult = Bun.spawnSync(["git", "remote", "get-url", "origin"], {
-    stdout: "pipe",
-    stderr: "pipe",
-  })
-  if (remoteResult.exitCode === 0) {
-    remoteUrl = remoteResult.stdout.toString().trim()
+  const remoteResult = safeSpawnSync(["git", "remote", "get-url", "origin"])
+  if (remoteResult && remoteResult.exitCode === 0) {
+    remoteUrl = remoteResult.stdout.trim()
   }
 
   return { isRepo: true, branch, remoteUrl }
@@ -454,40 +471,82 @@ export const ProjectScanTool = Tool.define("project_scan", {
   async execute(args, ctx) {
     const cwd = process.cwd()
 
-    // Run local detections in parallel
+    // Track which sub-detections failed so the LLM can see partial results
+    // instead of getting a single opaque "Executable not found in $PATH: ?"
+    // failure (the previous behavior — see safeSpawnSync above).
+    const degraded: string[] = []
+
+    // Run local detections in parallel. Every detection function is now
+    // expected to fail-safe (return a "not found" or empty result) rather
+    // than throw — see detectGit + detectDataTools.
     const [git, dbtProject, envVars, dataTools, configFiles] = await Promise.all([
-      detectGit(),
-      detectDbtProject(cwd),
-      detectEnvVars(),
-      detectDataTools(!!args.skip_tools),
-      detectConfigFiles(cwd),
+      detectGit().catch(() => {
+        degraded.push("git")
+        return { isRepo: false } as GitInfo
+      }),
+      detectDbtProject(cwd).catch(() => {
+        degraded.push("dbt-project")
+        return { found: false } as DbtProjectInfo
+      }),
+      detectEnvVars().catch(() => {
+        degraded.push("env-vars")
+        return [] as EnvVarConnection[]
+      }),
+      detectDataTools(!!args.skip_tools).catch(() => {
+        degraded.push("data-tools")
+        return [] as DataToolInfo[]
+      }),
+      detectConfigFiles(cwd).catch(() => {
+        degraded.push("config-files")
+        return { altimateConfig: false, sqlfluff: false, preCommit: false } as ConfigFileInfo
+      }),
     ])
 
-    // Run bridge-dependent detections with individual error handling
+    // Run bridge-dependent detections with individual error handling. A
+    // dispatcher failure on any one of these is expected (Python engine may
+    // not be running locally) — degrade silently and report in metadata.
     const engineHealth = await Dispatcher.call("ping", {} as any)
       .then((r) => ({ healthy: true, status: r.status }))
-      .catch(() => ({ healthy: false, status: undefined as string | undefined }))
+      .catch(() => {
+        degraded.push("python-engine")
+        return { healthy: false, status: undefined as string | undefined }
+      })
 
     const existingConnections = await Dispatcher.call("warehouse.list", {})
       .then((r) => r.warehouses)
-      .catch(() => [] as Array<{ name: string; type: string; database?: string }>)
+      .catch(() => {
+        degraded.push("warehouse.list")
+        return [] as Array<{ name: string; type: string; database?: string }>
+      })
 
     const dbtProfiles = await Dispatcher.call("dbt.profiles", {
       projectDir: dbtProject.found ? dbtProject.path : undefined,
     })
       .then((r) => r.connections ?? [])
-      .catch(() => [] as Array<{ name: string; type: string; config: Record<string, unknown> }>)
+      .catch(() => {
+        degraded.push("dbt.profiles")
+        return [] as Array<{ name: string; type: string; config: Record<string, unknown> }>
+      })
 
     const dockerContainers = args.skip_docker
       ? []
       : await Dispatcher.call("warehouse.discover", {} as any)
           .then((r) => r.containers ?? [])
-          .catch(() => [] as Array<{ name: string; db_type: string; host: string; port: number; database?: string }>)
+          .catch(() => {
+            degraded.push("warehouse.discover")
+            return [] as Array<{ name: string; db_type: string; host: string; port: number; database?: string }>
+          })
 
-    const schemaCache = await Dispatcher.call("schema.cache_status", {}).catch(() => null)
+    const schemaCache = await Dispatcher.call("schema.cache_status", {}).catch(() => {
+      degraded.push("schema.cache_status")
+      return null
+    })
 
     const dbtManifest = dbtProject.manifestPath
-      ? await Dispatcher.call("dbt.manifest", { path: dbtProject.manifestPath }).catch(() => null)
+      ? await Dispatcher.call("dbt.manifest", { path: dbtProject.manifestPath }).catch(() => {
+          degraded.push("dbt.manifest")
+          return null
+        })
       : null
 
     // Deduplicate connections
@@ -655,7 +714,12 @@ export const ProjectScanTool = Tool.define("project_scan", {
     if (connections.newFromDocker.length > 0) connectionSources.push("docker")
     if (connections.newFromEnv.length > 0) connectionSources.push("env-var")
 
-    const mcpConfig = (await Config.get()).mcp ?? {}
+    const mcpConfig = await Config.get()
+      .then((c) => c.mcp ?? {})
+      .catch(() => {
+        degraded.push("config")
+        return {}
+      })
     const mcpServerCount = Object.keys(mcpConfig).length
 
     const enabledFlags: string[] = []
@@ -702,11 +766,26 @@ export const ProjectScanTool = Tool.define("project_scan", {
       feature_flags: enabledFlags,
     })
 
+    // Surface degraded detections in the output so the LLM can recommend
+    // installing the missing pieces without thinking the tool itself failed.
+    if (degraded.length > 0) {
+      lines.push("")
+      lines.push("## Degraded Detections")
+      lines.push(
+        `The following sub-detections failed and were skipped (the rest of the scan is still valid):`,
+      )
+      for (const d of degraded) {
+        lines.push(`- ${d}`)
+      }
+    }
+
     // Build metadata
     const toolsFound = dataTools.filter((t) => t.installed).map((t) => t.name)
 
     return {
-      title: `Scan: ${totalConnections} connection(s), ${dbtProject.found ? "dbt found" : "no dbt"}`,
+      title: `Scan: ${totalConnections} connection(s), ${dbtProject.found ? "dbt found" : "no dbt"}${
+        degraded.length > 0 ? ` (${degraded.length} degraded)` : ""
+      }`,
       metadata: {
         engine_healthy: engineHealth.healthy,
         git: { isRepo: git.isRepo, branch: git.branch },
@@ -729,6 +808,7 @@ export const ProjectScanTool = Tool.define("project_scan", {
             }
           : { warehouses: 0, tables: 0, columns: 0 },
         tools_found: toolsFound,
+        degraded: degraded.length > 0 ? degraded : undefined,
       },
       output: lines.join("\n"),
     }

--- a/packages/opencode/src/altimate/tools/project-scan.ts
+++ b/packages/opencode/src/altimate/tools/project-scan.ts
@@ -14,6 +14,15 @@ export interface GitInfo {
   isRepo: boolean
   branch?: string
   remoteUrl?: string
+  /**
+   * True if `git` was reachable on the host (regardless of whether the cwd
+   * is a git repo). False ONLY when `safeSpawnSync(["git", ...])` failed
+   * to spawn — most commonly because git is not installed / not in PATH.
+   * Distinct from `isRepo` so callers record the "missing git" signal
+   * separately from "this directory is not a git repo".
+   * Undefined for callers that don't care.
+   */
+  gitAvailable?: boolean
 }
 
 export interface DbtProjectInfo {
@@ -93,8 +102,17 @@ export function safeSpawnSync(
 
 export async function detectGit(): Promise<GitInfo> {
   const isRepoResult = safeSpawnSync(["git", "rev-parse", "--is-inside-work-tree"])
-  if (!isRepoResult || isRepoResult.exitCode !== 0) {
-    return { isRepo: false }
+  // Distinguish "git binary missing" from "valid git, not a repo" — both
+  // produce isRepo=false but the caller wants to record "git" in the
+  // degraded list only for the first case. Collapsing both into a bare
+  // `{ isRepo: false }` would re-introduce the same opacity that was the
+  // original 437-user telemetry symptom — "Executable not found in
+  // $PATH: ?" masked to look like a generic shell error.
+  if (!isRepoResult) {
+    return { isRepo: false, gitAvailable: false }
+  }
+  if (isRepoResult.exitCode !== 0) {
+    return { isRepo: false, gitAvailable: true }
   }
 
   const branchResult = safeSpawnSync(["git", "branch", "--show-current"])
@@ -107,7 +125,7 @@ export async function detectGit(): Promise<GitInfo> {
     remoteUrl = remoteResult.stdout.trim()
   }
 
-  return { isRepo: true, branch, remoteUrl }
+  return { isRepo: true, gitAvailable: true, branch, remoteUrl }
 }
 
 export async function detectDbtProject(startDir: string): Promise<DbtProjectInfo> {
@@ -491,30 +509,36 @@ export const ProjectScanTool = Tool.define("project_scan", {
     // Track which sub-detections failed so the LLM can see partial results
     // instead of getting a single opaque "Executable not found in $PATH: ?"
     // failure (the previous behavior — see safeSpawnSync above).
-    const degraded: string[] = []
+    //
+    // Set rather than [] so adjacent `.catch` blocks (or any future
+    // refactor that wraps Dispatcher calls at two layers) can't record the
+    // same key twice. `.add()` is idempotent. Serialized as a sorted array
+    // for `metadata.degraded` at the end so dashboard queries see a stable
+    // shape.
+    const degraded = new Set<string>()
 
     // Run local detections in parallel. Every detection function is now
     // expected to fail-safe (return a "not found" or empty result) rather
     // than throw — see detectGit + detectDataTools.
     const [git, dbtProject, envVars, dataTools, configFiles] = await Promise.all([
       detectGit().catch(() => {
-        degraded.push("git")
+        degraded.add("git")
         return { isRepo: false } as GitInfo
       }),
       detectDbtProject(cwd).catch(() => {
-        degraded.push("dbt-project")
+        degraded.add("dbt-project")
         return { found: false } as DbtProjectInfo
       }),
       detectEnvVars().catch(() => {
-        degraded.push("env-vars")
+        degraded.add("env-vars")
         return [] as EnvVarConnection[]
       }),
       detectDataTools(!!args.skip_tools).catch(() => {
-        degraded.push("data-tools")
+        degraded.add("data-tools")
         return [] as DataToolInfo[]
       }),
       detectConfigFiles(cwd).catch(() => {
-        degraded.push("config-files")
+        degraded.add("config-files")
         return { altimateConfig: false, sqlfluff: false, preCommit: false } as ConfigFileInfo
       }),
     ])
@@ -525,14 +549,14 @@ export const ProjectScanTool = Tool.define("project_scan", {
     const engineHealth = await Dispatcher.call("ping", {} as any)
       .then((r) => ({ healthy: true, status: r.status }))
       .catch(() => {
-        degraded.push("python-engine")
+        degraded.add("python-engine")
         return { healthy: false, status: undefined as string | undefined }
       })
 
     const existingConnections = await Dispatcher.call("warehouse.list", {})
       .then((r) => r.warehouses)
       .catch(() => {
-        degraded.push("warehouse.list")
+        degraded.add("warehouse.list")
         return [] as Array<{ name: string; type: string; database?: string }>
       })
 
@@ -541,7 +565,7 @@ export const ProjectScanTool = Tool.define("project_scan", {
     })
       .then((r) => r.connections ?? [])
       .catch(() => {
-        degraded.push("dbt.profiles")
+        degraded.add("dbt.profiles")
         return [] as Array<{ name: string; type: string; config: Record<string, unknown> }>
       })
 
@@ -550,18 +574,18 @@ export const ProjectScanTool = Tool.define("project_scan", {
       : await Dispatcher.call("warehouse.discover", {} as any)
           .then((r) => r.containers ?? [])
           .catch(() => {
-            degraded.push("warehouse.discover")
+            degraded.add("warehouse.discover")
             return [] as Array<{ name: string; db_type: string; host: string; port: number; database?: string }>
           })
 
     const schemaCache = await Dispatcher.call("schema.cache_status", {}).catch(() => {
-      degraded.push("schema.cache_status")
+      degraded.add("schema.cache_status")
       return null
     })
 
     const dbtManifest = dbtProject.manifestPath
       ? await Dispatcher.call("dbt.manifest", { path: dbtProject.manifestPath }).catch(() => {
-          degraded.push("dbt.manifest")
+          degraded.add("dbt.manifest")
           return null
         })
       : null
@@ -588,6 +612,14 @@ export const ProjectScanTool = Tool.define("project_scan", {
     if (git.isRepo) {
       const remote = git.remoteUrl ? ` (origin: ${git.remoteUrl})` : ""
       lines.push(`✓ Git repo on branch \`${git.branch ?? "unknown"}\`${remote}`)
+    } else if (git.gitAvailable === false) {
+      // Distinguish "git not installed" from "not a repo" so the LLM /
+      // user can act differently (suggest installing git vs initialising a
+      // repo). Also record in degraded so dashboards spot the pattern —
+      // detectGit no longer throws, so the .catch() above never fires for
+      // this case and only this explicit add() records it.
+      lines.push("✗ git binary not found in PATH (install git or add it to PATH)")
+      degraded.add("git")
     } else {
       lines.push("✗ Not a git repository")
     }
@@ -628,7 +660,7 @@ export const ProjectScanTool = Tool.define("project_scan", {
         // Telemetry must never break scan output, but record it in the
         // degraded list so we can see post-deploy whether the dynamic
         // import is silently failing for some users.
-        degraded.push("post-connect-suggestions")
+        degraded.add("post-connect-suggestions")
       }
       // altimate_change end
     } else {
@@ -737,7 +769,7 @@ export const ProjectScanTool = Tool.define("project_scan", {
     const mcpConfig = await Config.get()
       .then((c) => c.mcp ?? {})
       .catch(() => {
-        degraded.push("config")
+        degraded.add("config")
         return {}
       })
     const mcpServerCount = Object.keys(mcpConfig).length
@@ -754,7 +786,7 @@ export const ProjectScanTool = Tool.define("project_scan", {
     const skillCount = await Skill.all()
       .then((s) => s.length)
       .catch(() => {
-        degraded.push("skills")
+        degraded.add("skills")
         return 0
       })
 
@@ -791,13 +823,17 @@ export const ProjectScanTool = Tool.define("project_scan", {
 
     // Surface degraded detections in the output so the LLM can recommend
     // installing the missing pieces without thinking the tool itself failed.
-    if (degraded.length > 0) {
+    // Sort the keys so the output is stable across runs (Set iteration
+    // order is insertion order, which depends on which detection failed
+    // first — not useful to the human reader).
+    const degradedList = [...degraded].sort()
+    if (degradedList.length > 0) {
       lines.push("")
-      lines.push("## Degraded Detections")
+      lines.push(`## Degraded Detections (${degradedList.length})`)
       lines.push(
         `The following sub-detections failed and were skipped (the rest of the scan is still valid):`,
       )
-      for (const d of degraded) {
+      for (const d of degradedList) {
         lines.push(`- ${d}`)
       }
     }
@@ -805,13 +841,13 @@ export const ProjectScanTool = Tool.define("project_scan", {
     // Build metadata
     const toolsFound = dataTools.filter((t) => t.installed).map((t) => t.name)
 
+    const degradedSuffix = degradedList.length > 0 ? ` (${degradedList.length} degraded)` : ""
+
     return {
-      title: `Scan: ${totalConnections} connection(s), ${dbtProject.found ? "dbt found" : "no dbt"}${
-        degraded.length > 0 ? ` (${degraded.length} degraded)` : ""
-      }`,
+      title: `Scan: ${totalConnections} connection(s), ${dbtProject.found ? "dbt found" : "no dbt"}${degradedSuffix}`,
       metadata: {
         engine_healthy: engineHealth.healthy,
-        git: { isRepo: git.isRepo, branch: git.branch },
+        git: { isRepo: git.isRepo, branch: git.branch, gitAvailable: git.gitAvailable },
         dbt: {
           found: dbtProject.found,
           name: dbtProject.name,
@@ -831,7 +867,10 @@ export const ProjectScanTool = Tool.define("project_scan", {
             }
           : { warehouses: 0, tables: 0, columns: 0 },
         tools_found: toolsFound,
-        degraded: degraded.length > 0 ? degraded : undefined,
+        // Always emit as an array (sorted, deduplicated) — never `undefined` —
+        // so dashboard queries don't need null coalescing. Empty array means
+        // "no degradation" cleanly.
+        degraded: degradedList,
       },
       output: lines.join("\n"),
     }

--- a/packages/opencode/src/altimate/tools/project-scan.ts
+++ b/packages/opencode/src/altimate/tools/project-scan.ts
@@ -23,6 +23,16 @@ export interface GitInfo {
    * Undefined for callers that don't care.
    */
   gitAvailable?: boolean
+  /**
+   * Captures the case where git ran but produced a non-standard error
+   * (corrupted .git, permission denied, etc. — anything that isn't a
+   * clean "not a repo" exit-128). Lets callers distinguish:
+   *   isRepo=false, gitAvailable=true, gitError=undefined → clean non-repo
+   *   isRepo=false, gitAvailable=true, gitError=<exit>   → degraded git
+   *   isRepo=false, gitAvailable=false                    → git missing
+   * Undefined when irrelevant.
+   */
+  gitError?: { exitCode: number; stderr?: string }
 }
 
 export interface DbtProjectInfo {
@@ -81,7 +91,7 @@ export interface ConfigFileInfo {
 export function safeSpawnSync(
   args: string[],
   opts?: { timeout?: number },
-): { exitCode: number; stdout: string } | null {
+): { exitCode: number; stdout: string; stderr: string } | null {
   try {
     const result = Bun.spawnSync(args, {
       stdout: "pipe",
@@ -91,6 +101,7 @@ export function safeSpawnSync(
     return {
       exitCode: result.exitCode ?? 1,
       stdout: result.stdout?.toString() ?? "",
+      stderr: result.stderr?.toString() ?? "",
     }
   } catch {
     // Binary missing from PATH, permission denied, etc. — treat as
@@ -102,17 +113,30 @@ export function safeSpawnSync(
 
 export async function detectGit(): Promise<GitInfo> {
   const isRepoResult = safeSpawnSync(["git", "rev-parse", "--is-inside-work-tree"])
-  // Distinguish "git binary missing" from "valid git, not a repo" — both
-  // produce isRepo=false but the caller wants to record "git" in the
-  // degraded list only for the first case. Collapsing both into a bare
-  // `{ isRepo: false }` would re-introduce the same opacity that was the
-  // original 437-user telemetry symptom — "Executable not found in
+  // Distinguish three cases that all produce isRepo=false:
+  //   1. Git binary missing (null result) — record "git" in degraded.
+  //   2. Git ran with exit 128 — clean "not a repo" signal.
+  //   3. Git ran with non-zero, non-128 — degraded git (corrupted .git,
+  //      permission denied, etc.); still record "git" in degraded so the
+  //      caller doesn't silently bucket a real failure as "not a repo".
+  // Collapsing all three into a bare `{ isRepo: false }` would re-introduce
+  // the original 437-user telemetry opacity — "Executable not found in
   // $PATH: ?" masked to look like a generic shell error.
   if (!isRepoResult) {
     return { isRepo: false, gitAvailable: false }
   }
   if (isRepoResult.exitCode !== 0) {
-    return { isRepo: false, gitAvailable: true }
+    // Exit 128 is git's standard "fatal" for not-in-a-repo. Anything else
+    // is unusual — surface it via gitError so the caller can decide
+    // whether to record it in degraded.
+    if (isRepoResult.exitCode === 128) {
+      return { isRepo: false, gitAvailable: true }
+    }
+    return {
+      isRepo: false,
+      gitAvailable: true,
+      gitError: { exitCode: isRepoResult.exitCode, stderr: isRepoResult.stderr?.trim() || undefined },
+    }
   }
 
   const branchResult = safeSpawnSync(["git", "branch", "--show-current"])
@@ -620,6 +644,14 @@ export const ProjectScanTool = Tool.define("project_scan", {
       // this case and only this explicit add() records it.
       lines.push("✗ git binary not found in PATH (install git or add it to PATH)")
       degraded.add("git")
+    } else if (git.gitError) {
+      // Git ran but produced a non-128 error — corrupted .git, permission
+      // denied, etc. Surface the exit code + stderr (truncated) so the user
+      // can self-diagnose. Record in degraded so this case doesn't silently
+      // bucket as a clean "not a repo".
+      const stderrSuffix = git.gitError.stderr ? `: ${git.gitError.stderr.slice(0, 120)}` : ""
+      lines.push(`✗ git error (exit ${git.gitError.exitCode})${stderrSuffix}`)
+      degraded.add("git")
     } else {
       lines.push("✗ Not a git repository")
     }
@@ -847,7 +879,12 @@ export const ProjectScanTool = Tool.define("project_scan", {
       title: `Scan: ${totalConnections} connection(s), ${dbtProject.found ? "dbt found" : "no dbt"}${degradedSuffix}`,
       metadata: {
         engine_healthy: engineHealth.healthy,
-        git: { isRepo: git.isRepo, branch: git.branch, gitAvailable: git.gitAvailable },
+        git: {
+          isRepo: git.isRepo,
+          branch: git.branch,
+          gitAvailable: git.gitAvailable,
+          gitError: git.gitError,
+        },
         dbt: {
           found: dbtProject.found,
           name: dbtProject.name,

--- a/packages/opencode/src/altimate/tools/project-scan.ts
+++ b/packages/opencode/src/altimate/tools/project-scan.ts
@@ -56,10 +56,29 @@ export interface ConfigFileInfo {
  * `project_scan` (the binary name `"git"` was masked to `?` downstream,
  * which made it look like a generic shell error). Wrap every spawn so a
  * missing binary degrades gracefully instead of crashing the whole tool.
+ *
+ * Return value semantics:
+ *   - `null`         → could not spawn (binary missing, permission denied,
+ *                      Bun internal failure). Distinct from "ran and failed".
+ *   - `{exitCode: 0, stdout}`         → ran successfully.
+ *   - `{exitCode: N>0, stdout}`       → ran and exited non-zero.
+ *   - `{exitCode: 1, stdout: ""}`     → also returned when `Bun.spawnSync`
+ *                                       gives back `exitCode: null` (signaled
+ *                                       child). Coalesced to `1` because no
+ *                                       current caller distinguishes "killed
+ *                                       by signal" from "exited with status 1";
+ *                                       expand this contract if that changes.
  */
-function safeSpawnSync(args: string[]): { exitCode: number; stdout: string } | null {
+export function safeSpawnSync(
+  args: string[],
+  opts?: { timeout?: number },
+): { exitCode: number; stdout: string } | null {
   try {
-    const result = Bun.spawnSync(args, { stdout: "pipe", stderr: "pipe" })
+    const result = Bun.spawnSync(args, {
+      stdout: "pipe",
+      stderr: "pipe",
+      ...(opts?.timeout !== undefined && { timeout: opts.timeout }),
+    })
     return {
       exitCode: result.exitCode ?? 1,
       stdout: result.stdout?.toString() ?? "",
@@ -352,25 +371,23 @@ export function parseToolVersion(output: string): string | undefined {
 export async function detectDataTools(skip: boolean): Promise<DataToolInfo[]> {
   if (skip) return []
 
+  // Route through safeSpawnSync for consistency with detectGit. The previous
+  // implementation used a bare try/catch around Bun.spawnSync — same outcome
+  // for the caller, but the two functions solved the same problem two
+  // different ways. Using one helper keeps the contract uniform: `null`
+  // means "could not spawn" (binary missing), distinct from "ran and exited
+  // non-zero" (binary present but the version check failed).
   const results = await Promise.all(
     DATA_TOOL_NAMES.map(async (tool): Promise<DataToolInfo> => {
-      try {
-        const result = Bun.spawnSync([tool, "--version"], {
-          stdout: "pipe",
-          stderr: "pipe",
-          timeout: 5000,
-        })
-        if (result.exitCode === 0) {
-          return {
-            name: tool,
-            installed: true,
-            version: parseToolVersion(result.stdout.toString()),
-          }
+      const result = safeSpawnSync([tool, "--version"], { timeout: 5000 })
+      if (result && result.exitCode === 0) {
+        return {
+          name: tool,
+          installed: true,
+          version: parseToolVersion(result.stdout),
         }
-        return { name: tool, installed: false }
-      } catch {
-        return { name: tool, installed: false }
       }
+      return { name: tool, installed: false }
     }),
   )
 
@@ -608,7 +625,10 @@ export const ProjectScanTool = Tool.define("project_scan", {
           suggestionsShown: ["dbt-develop", "dbt-troubleshoot", "dbt-analyze"],
         })
       } catch {
-        // Telemetry must never break scan output
+        // Telemetry must never break scan output, but record it in the
+        // degraded list so we can see post-deploy whether the dynamic
+        // import is silently failing for some users.
+        degraded.push("post-connect-suggestions")
       }
       // altimate_change end
     } else {
@@ -733,7 +753,10 @@ export const ProjectScanTool = Tool.define("project_scan", {
 
     const skillCount = await Skill.all()
       .then((s) => s.length)
-      .catch(() => 0)
+      .catch(() => {
+        degraded.push("skills")
+        return 0
+      })
 
     Telemetry.track({
       type: "environment_census",

--- a/packages/opencode/test/tool/project-scan.test.ts
+++ b/packages/opencode/test/tool/project-scan.test.ts
@@ -141,6 +141,26 @@ describe("detectGit", () => {
     expect(currentRepoResult.isRepo).toBe(true)
   })
 
+  test("detectGit on a clean non-repo dir has no gitError", async () => {
+    // Reviewer (coderabbit) flagged: any non-zero rev-parse exit was being
+    // bucketed as "not a repo", potentially masking corrupted-.git failures.
+    // Pin the contract that a clean non-repo (exit 128) leaves gitError
+    // undefined so callers can distinguish "clean non-repo" from "degraded
+    // git" by checking gitError presence.
+    const dir = nextTmpDir()
+    await fsp.mkdir(dir, { recursive: true })
+    const originalCwd = process.cwd()
+    process.chdir(dir)
+    try {
+      const result = await detectGit()
+      expect(result.isRepo).toBe(false)
+      expect(result.gitAvailable).toBe(true)
+      expect(result.gitError).toBeUndefined()
+    } finally {
+      process.chdir(originalCwd)
+    }
+  })
+
   afterAll(async () => {
     await fsp.rm(tmpRoot, { recursive: true, force: true }).catch(() => {})
   })

--- a/packages/opencode/test/tool/project-scan.test.ts
+++ b/packages/opencode/test/tool/project-scan.test.ts
@@ -11,6 +11,7 @@ import {
   detectDataTools,
   detectConfigFiles,
   parseToolVersion,
+  safeSpawnSync,
   DATA_TOOL_NAMES,
   type GitInfo,
   type DbtProjectInfo,
@@ -928,5 +929,43 @@ describe("return type contracts", () => {
     expect(typeof result.altimateConfig).toBe("boolean")
     expect(typeof result.sqlfluff).toBe("boolean")
     expect(typeof result.preCommit).toBe("boolean")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// safeSpawnSync — the new primitive both detectGit and detectDataTools route through
+// ---------------------------------------------------------------------------
+
+describe("safeSpawnSync", () => {
+  test("returns null when the binary is missing from PATH", () => {
+    const result = safeSpawnSync(["this-binary-does-not-exist-anywhere-on-the-system-xyz123"])
+    expect(result).toBeNull()
+  })
+
+  test("returns { exitCode, stdout } when the binary runs successfully", () => {
+    // Use `node --version` — present on any system that can run this test.
+    const result = safeSpawnSync(["node", "--version"])
+    expect(result).not.toBeNull()
+    if (result) {
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toMatch(/^v?\d+\.\d+/)
+    }
+  })
+
+  test("returns { exitCode: nonzero } when the binary exits non-zero", () => {
+    // `node -e 'process.exit(7)'` runs but exits 7.
+    const result = safeSpawnSync(["node", "-e", "process.exit(7)"])
+    expect(result).not.toBeNull()
+    if (result) {
+      expect(result.exitCode).toBe(7)
+    }
+  })
+
+  test("forwards the timeout option to Bun.spawnSync", () => {
+    // Just verify the helper doesn't crash when given timeout — actually
+    // exercising the timeout path requires a long-running command, which
+    // is flaky in CI. Smoke-check the wiring instead.
+    const result = safeSpawnSync(["node", "--version"], { timeout: 5000 })
+    expect(result).not.toBeNull()
   })
 })

--- a/packages/opencode/test/tool/project-scan.test.ts
+++ b/packages/opencode/test/tool/project-scan.test.ts
@@ -119,6 +119,34 @@ describe("detectGit", () => {
     }
   })
 
+  test("does not throw when git binary is missing from PATH", async () => {
+    // Telemetry-2026-05-21 showed `project_scan` failing 32% of the time with
+    // `Executable not found in $PATH: ?` — the binary was masked to `?` by the
+    // PII filter, but the underlying cause was Bun.spawnSync throwing on a
+    // missing git executable. This test pins the fix: detectGit must return a
+    // sentinel result rather than throw, so the rest of project_scan still
+    // runs.
+    const dir = nextTmpDir()
+    await fsp.mkdir(dir, { recursive: true })
+
+    const originalPath = process.env.PATH
+    const originalCwd = process.cwd()
+    // Point PATH at an empty directory so the shell can't find git (or any
+    // other binary). Bun.spawnSync will throw "Executable not found in $PATH"
+    // — which the safeSpawnSync wrapper should catch.
+    process.env.PATH = dir
+    process.chdir(dir)
+    try {
+      const result = await detectGit()
+      expect(result.isRepo).toBe(false)
+      expect(result.branch).toBeUndefined()
+      expect(result.remoteUrl).toBeUndefined()
+    } finally {
+      process.chdir(originalCwd)
+      process.env.PATH = originalPath
+    }
+  })
+
   afterAll(async () => {
     await fsp.rm(tmpRoot, { recursive: true, force: true }).catch(() => {})
   })

--- a/packages/opencode/test/tool/project-scan.test.ts
+++ b/packages/opencode/test/tool/project-scan.test.ts
@@ -120,32 +120,25 @@ describe("detectGit", () => {
     }
   })
 
-  test("does not throw when git binary is missing from PATH", async () => {
+  test("safeSpawnSync returns null on missing binary (no process.env.PATH mutation needed)", () => {
     // Telemetry-2026-05-21 showed `project_scan` failing 32% of the time with
     // `Executable not found in $PATH: ?` — the binary was masked to `?` by the
     // PII filter, but the underlying cause was Bun.spawnSync throwing on a
-    // missing git executable. This test pins the fix: detectGit must return a
-    // sentinel result rather than throw, so the rest of project_scan still
-    // runs.
-    const dir = nextTmpDir()
-    await fsp.mkdir(dir, { recursive: true })
+    // missing git executable. Previously this test mutated process.env.PATH
+    // + process.chdir() to force the throw, which is risky under any future
+    // intra-file concurrency (and required handling the PATH=undefined
+    // restore case carefully). Use safeSpawnSync directly with an unknown
+    // binary instead — same code path, no global state mutation.
+    expect(safeSpawnSync(["this-binary-does-not-exist-xyz123"])).toBeNull()
+  })
 
-    const originalPath = process.env.PATH
-    const originalCwd = process.cwd()
-    // Point PATH at an empty directory so the shell can't find git (or any
-    // other binary). Bun.spawnSync will throw "Executable not found in $PATH"
-    // — which the safeSpawnSync wrapper should catch.
-    process.env.PATH = dir
-    process.chdir(dir)
-    try {
-      const result = await detectGit()
-      expect(result.isRepo).toBe(false)
-      expect(result.branch).toBeUndefined()
-      expect(result.remoteUrl).toBeUndefined()
-    } finally {
-      process.chdir(originalCwd)
-      process.env.PATH = originalPath
-    }
+  test("detectGit distinguishes 'git missing' from 'not a repo'", () => {
+    // The gitAvailable field separates the two cases. We can't easily force
+    // git-missing in a unit test (would require mutating PATH globally),
+    // but we can verify the contract: the field exists and is true when
+    // git ran successfully (which it does in this repo).
+    expect(currentRepoResult.gitAvailable).toBe(true)
+    expect(currentRepoResult.isRepo).toBe(true)
   })
 
   afterAll(async () => {


### PR DESCRIPTION
### What does this PR do?

Fixes `project_scan` failing 32% of the time across 1,171 distinct users (telemetry-2026-05-21, 2,503 machines, 14 days). It's the first-interaction tool, so 32% failure at boot is a major conversion killer for new installs.

Two root causes (both addressed):

1. **`detectGit()` had no try/catch around `Bun.spawnSync(["git", ...])`.** Bun's spawnSync THROWS when the binary is missing from PATH, not just when it exits non-zero. Any environment without git installed (minimal Docker images, fresh Windows installs without Git for Windows, some CI runners) crashed the entire tool — even though the other sub-detections didn't depend on git.

2. **The PII masker shredded the diagnostic.** Bun's error `Executable not found in $PATH: "git"` became `Executable not found in $PATH: ?` in telemetry (quoted strings → `?`), making the bug look like a generic shell failure and hiding it for two months.

Fix:
- New `safeSpawnSync` helper that catches the throw and returns `null` so callers see a deterministic "command failed" instead of an exception. Applied to every `Bun.spawnSync` call in `detectGit()`.
- Every detection in `ProjectScanTool.execute()` now wraps with `.catch()` recording the failure to a `degraded: string[]` field and continuing with a sentinel result.
- New "Degraded Detections" section in the formatted output + `degraded` field in metadata lets the LLM see exactly what was unavailable.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #830

### How did you verify your code works?

- `tsgo --noEmit`: pass, zero errors
- `bun test test/tool/project-scan.test.ts`: **78 pass / 0 fail** (1 new test)
- New test "does not throw when git binary is missing from PATH" pins the regression — sets PATH to an empty directory, calls `detectGit()`, asserts it returns `{ isRepo: false }` without throwing
- Marker check: pass — no upstream-shared files touched

### Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Marker check passes
- [x] Linked to issue #830

---

**Files changed (2):**
- `packages/opencode/src/altimate/tools/project-scan.ts` — `safeSpawnSync` helper, `degraded` tracking on every detection, Config.get() guarded, output surfaces degraded list
- `packages/opencode/test/tool/project-scan.test.ts` — +1 test for the missing-git path

**Expected telemetry impact:** `project_scan` error rate drops from 32% to near-zero. Users without git get a successful scan with `degraded: ["git"]` instead of an opaque tool failure. Same defensive pattern protects against future Dispatcher/Config/Skill regressions that previously could crash the whole tool.

**Related:** Issue #827 / PR #828 fixed the finops_* 100% failure rate. This PR fixes the next P0 from the same triage doc (`docs/internal/2026-05-21-p0-triage.md`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `project_scan` fail-safe by degrading partial detections instead of crashing, and now clearly distinguishes missing `git`, clean non-repo, and degraded `git` errors. Fixes #830 and should drop the 32% error rate to near-zero.

- **Bug Fixes**
  - Added and exported `safeSpawnSync`; routed all `git` and tool-version checks through it with `timeout` support.
  - `detectGit()` now returns `gitAvailable` and optional `gitError`; output shows "git not found" or "git error (exit N)" vs "Not a git repository"; `metadata.git` includes both.
  - Wrapped all sub-detections and `Dispatcher` calls with `.catch()`; track degraded as a `Set`, sort it, always emit `metadata.degraded`, and append `(<n> degraded)` to the title; added a "Degraded Detections (n)" section in output.
  - Guarded `Config.get()`; mark `"skills"`, `"post-connect-suggestions"`, `"python-engine"`, `"warehouse.list"`, `"dbt.profiles"`, `"warehouse.discover"`, `"schema.cache_status"`, and `"dbt.manifest"` on failure.
  - Tests: added `safeSpawnSync` cases (missing binary, success, non-zero, timeout) and `detectGit` contracts (`gitAvailable` true in normal runs; clean non-repo leaves `gitError` undefined); removed PATH-mutation approach.

<sup>Written for commit c760f9c5bca915db0fdeec9e990164eb2b6b8bc2. Summary will update on new commits. <a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/831?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scan tolerates partial failures across sub-detections and records degraded items instead of aborting.

* **New Features**
  * Adds a "Degraded Detections" section, appends a degraded-count suffix to the title, and includes degraded details in scan metadata.

* **Improvements**
  * More clearly reports VCS availability vs. "not a repository" and treats failed tool checks as not-installed.

* **Tests**
  * Added tests for missing system binaries, non-zero exits, timeouts, and degraded-scan scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AltimateAI/altimate-code/pull/831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->