### PR TITLE
fix: [#832] build agent 0% completion — legacy name leaking into telemetry

### DIFF
--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -951,7 +951,7 @@ export const GithubRunCommand = cmd({
             providerID,
             modelID,
           },
-          // agent is omitted - server will use default_agent from config or fall back to "build"
+          // agent is omitted - server will use default_agent from config or fall back to "builder"
           parts: [
             {
               id: PartID.ascending(),

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -224,7 +224,13 @@ export function Session() {
     if (part.id === lastSwitch) return
 
     if (part.tool === "plan_exit") {
-      local.agent.set("build")
+      // altimate_change start — canonical "builder" agent name (renamed from "build")
+      // Previously wrote "build" here which then flowed into the next session.prompt
+      // request as `agent: "build"`, leaking the legacy name into telemetry. Even
+      // though prompt.ts now normalizes at the emit boundary, write the canonical
+      // value at the source so debugging dumps / inspection see consistent state.
+      local.agent.set("builder")
+      // altimate_change end
       lastSwitch = part.id
     } else if (part.tool === "plan_enter") {
       local.agent.set("plan")

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1139,9 +1139,11 @@ export namespace Config {
       default_agent: z
         .string()
         .optional()
+        // altimate_change start — fallback name reflects the renamed "builder" agent
         .describe(
-          "Default agent to use when none is specified. Must be a primary agent. Falls back to 'build' if not set or if the specified agent is invalid.",
+          "Default agent to use when none is specified. Must be a primary agent. Falls back to 'builder' if not set or if the specified agent is invalid.",
         ),
+      // altimate_change end
       username: z
         .string()
         .optional()

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -73,6 +73,22 @@ const STRUCTURED_OUTPUT_SYSTEM_PROMPT = `IMPORTANT: The user has requested struc
 export namespace SessionPrompt {
   const log = Log.create({ service: "session.prompt" })
 
+  // altimate_change start — single source of truth for legacy agent-name normalization
+  //
+  // The "build" agent was renamed to "builder" but some persisted sessions and
+  // the plan-exit synthetic message historically wrote `agent: "build"`. Agent.get()
+  // applies an alias so execution still works, but every telemetry event with an
+  // `agent` field needs to project to the canonical name or dashboards see a
+  // phantom "build" bucket alongside "builder". This helper is the single place
+  // that normalization lives — used by both session_start and agent_outcome
+  // emits below so they can never drift. Future telemetry events with an `agent`
+  // field should route through this helper too.
+  function normalizeAgentName(name: string | undefined): string {
+    if (!name || name === "build") return "builder"
+    return name
+  }
+  // altimate_change end
+
   const state = Instance.state(
     () => {
       const data: Record<
@@ -830,13 +846,17 @@ export namespace SessionPrompt {
           messageID: lastUser.id,
         })
         // altimate_change start — session start telemetry
+        // Agent name routed through normalizeAgentName so session_start and the
+        // downstream agent_outcome event always agree on the canonical bucket
+        // (funnel analysis from start → outcome would otherwise drop legacy
+        // "build" sessions). See the helper at the top of this namespace.
         Telemetry.track({
           type: "session_start",
           timestamp: Date.now(),
           session_id: sessionID,
           model_id: model.id,
           provider_id: model.providerID,
-          agent: lastUser.agent,
+          agent: normalizeAgentName(lastUser.agent),
           project_id: Instance.project?.id ?? "",
           os: process.platform,
           arch: process.arch,
@@ -1150,14 +1170,10 @@ export namespace SessionPrompt {
       type: "agent_outcome",
       timestamp: Date.now(),
       session_id: sessionID,
-      // altimate_change start — normalize legacy agent name for telemetry parity
-      // The "build" agent was renamed to "builder" but some persisted sessions
-      // and the plan-exit handler historically wrote `agent: "build"`. Agent.get()
-      // applies an alias so execution still works, but the telemetry event used
-      // to record the literal "build" value — splitting metrics into a phantom
-      // 0%-completion bucket. Normalize at the emit boundary so dashboards see
-      // a single coherent agent name regardless of how the session got created.
-      agent: sessionAgentName === "build" ? "builder" : sessionAgentName,
+      // altimate_change start — route through normalizeAgentName (shared with
+      // session_start above) so the two events always agree on the bucket name.
+      // See the helper at the top of this namespace for the legacy-name policy.
+      agent: normalizeAgentName(sessionAgentName),
       // altimate_change end
       tool_calls: toolCallCount,
       generations: step,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -84,7 +84,11 @@ export namespace SessionPrompt {
   // emits below so they can never drift. Future telemetry events with an `agent`
   // field should route through this helper too.
   function normalizeAgentName(name: string | undefined): string {
-    if (!name || name === "build") return "builder"
+    // Case-insensitive guard: a future config, custom prompt, or hand-edited
+    // persisted session could surface "Build" or "BUILD" and the phantom
+    // bucket would come back. One toLowerCase() costs nothing and pins the
+    // contract regardless of caller hygiene.
+    if (!name || name.toLowerCase() === "build") return "builder"
     return name
   }
   // altimate_change end

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1150,7 +1150,15 @@ export namespace SessionPrompt {
       type: "agent_outcome",
       timestamp: Date.now(),
       session_id: sessionID,
-      agent: sessionAgentName,
+      // altimate_change start — normalize legacy agent name for telemetry parity
+      // The "build" agent was renamed to "builder" but some persisted sessions
+      // and the plan-exit handler historically wrote `agent: "build"`. Agent.get()
+      // applies an alias so execution still works, but the telemetry event used
+      // to record the literal "build" value — splitting metrics into a phantom
+      // 0%-completion bucket. Normalize at the emit boundary so dashboards see
+      // a single coherent agent name regardless of how the session got created.
+      agent: sessionAgentName === "build" ? "builder" : sessionAgentName,
+      // altimate_change end
       tool_calls: toolCallCount,
       generations: step,
       duration_ms: Date.now() - sessionStartTime,

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -53,7 +53,17 @@ export const PlanExitTool = Tool.define("plan_exit", {
       time: {
         created: Date.now(),
       },
-      agent: "build",
+      // altimate_change start — use canonical "builder" name (renamed from "build")
+      // The Agent.get() alias in agent.ts:408 maps the legacy "build" to "builder"
+      // so the session still executes correctly, but the telemetry agent_outcome
+      // event in prompt.ts records the literal `lastUser.agent` value. Hardcoding
+      // "build" here meant every plan-exit invocation showed up as a separate
+      // (and confusingly-named) `agent: "build"` row in agent_outcome telemetry —
+      // 133 invocations in 14 days, 0% completion in the dashboard, distinct
+      // from builder's actual numbers. Using the canonical name folds these
+      // back into the right bucket.
+      agent: "builder",
+      // altimate_change end
       model,
     }
     await Session.updateMessage(userMsg)
@@ -67,8 +77,8 @@ export const PlanExitTool = Tool.define("plan_exit", {
     } satisfies MessageV2.TextPart)
 
     return {
-      title: "Switching to build agent",
-      output: "User approved switching to build agent. Wait for further instructions.",
+      title: "Switching to builder agent",
+      output: "User approved switching to builder agent. Wait for further instructions.",
       metadata: {},
     }
   },

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -24,17 +24,19 @@ export const PlanExitTool = Tool.define("plan_exit", {
     const plan = path.relative(Instance.worktree, Session.plan(session))
     const answers = await Question.ask({
       sessionID: ctx.sessionID,
+      // altimate_change start — UI copy reflects canonical agent name (renamed from "build")
       questions: [
         {
-          question: `Plan at ${plan} is complete. Would you like to switch to the build agent and start implementing?`,
-          header: "Build Agent",
+          question: `Plan at ${plan} is complete. Would you like to switch to the builder agent and start implementing?`,
+          header: "Builder Agent",
           custom: false,
           options: [
-            { label: "Yes", description: "Switch to build agent and start implementing the plan" },
+            { label: "Yes", description: "Switch to builder agent and start implementing the plan" },
             { label: "No", description: "Stay with plan agent to continue refining the plan" },
           ],
         },
       ],
+      // altimate_change end
       tool: ctx.callID ? { messageID: ctx.messageID, callID: ctx.callID } : undefined,
     })
 
@@ -76,11 +78,13 @@ export const PlanExitTool = Tool.define("plan_exit", {
       synthetic: true,
     } satisfies MessageV2.TextPart)
 
+    // altimate_change start — title/output text reflects canonical "builder" name (renamed from "build")
     return {
       title: "Switching to builder agent",
       output: "User approved switching to builder agent. Wait for further instructions.",
       metadata: {},
     }
+    // altimate_change end
   },
 })
 

--- a/packages/opencode/test/session/plan-layer-e2e.test.ts
+++ b/packages/opencode/test/session/plan-layer-e2e.test.ts
@@ -315,6 +315,24 @@ describe("sessionAgentName fix safety", () => {
     const declarations = promptTs.match(/function\s+normalizeAgentName\s*\(/g) ?? []
     expect(declarations.length).toBe(1)
   })
+
+  test("normalizeAgentName comparison is case-insensitive", async () => {
+    // A future config, custom prompt, or hand-edited persisted session
+    // could surface "Build" or "BUILD". Without case-folding, the phantom
+    // bucket comes back. Pin that the helper does the toLowerCase() guard
+    // so a refactor can't silently drop it.
+    const promptTs = await fs.readFile(
+      path.join(__dirname, "../../src/session/prompt.ts"),
+      "utf-8",
+    )
+    const declIdx = promptTs.indexOf("function normalizeAgentName")
+    expect(declIdx).toBeGreaterThan(-1)
+    const body = promptTs.slice(declIdx, declIdx + 400)
+    // The body should case-fold before comparing — either toLowerCase() or
+    // toUpperCase() before the equality check. Anchored so a refactor to a
+    // raw string compare fails this test.
+    expect(body).toMatch(/name\.toLowerCase\(\)\s*===\s*"build"/)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/opencode/test/session/plan-layer-e2e.test.ts
+++ b/packages/opencode/test/session/plan-layer-e2e.test.ts
@@ -281,16 +281,39 @@ describe("sessionAgentName fix safety", () => {
       "utf-8",
     )
 
-    // Find agent_outcome emission
+    // Find agent_outcome emission and assert it routes through the shared
+    // `normalizeAgentName` helper. Anchored regex (not a token-presence check
+    // inside a wide window) so this fails if anyone replaces the helper call
+    // with a literal or accidentally bypasses normalization.
     const outcomeIdx = promptTs.indexOf('type: "agent_outcome"')
     expect(outcomeIdx).toBeGreaterThan(-1)
-    // The agent name is normalized at the emit boundary: legacy "build" sessions
-    // (from before the agent was renamed to "builder") fold into "builder" so
-    // dashboards see one coherent bucket instead of a phantom 0%-completion row.
-    // Allow both the original `agent: sessionAgentName` and the normalized form.
-    const block = promptTs.slice(outcomeIdx, outcomeIdx + 1200)
-    expect(block).toContain("sessionAgentName")
-    expect(block).toContain('"builder"')
+    const block = promptTs.slice(outcomeIdx, outcomeIdx + 600)
+    expect(block).toMatch(/agent:\s*normalizeAgentName\(sessionAgentName\)/)
+  })
+
+  test("session_start telemetry normalizes the agent name (parity with agent_outcome)", async () => {
+    // Funnel analysis from session_start → agent_outcome must see the same
+    // bucket name; otherwise sessions appear to "vanish" when the legacy
+    // "build" value at start gets normalized to "builder" at end.
+    const promptTs = await fs.readFile(
+      path.join(__dirname, "../../src/session/prompt.ts"),
+      "utf-8",
+    )
+    const startIdx = promptTs.indexOf('type: "session_start"')
+    expect(startIdx).toBeGreaterThan(-1)
+    const block = promptTs.slice(startIdx, startIdx + 600)
+    expect(block).toMatch(/agent:\s*normalizeAgentName\(lastUser\.agent\)/)
+  })
+
+  test("normalizeAgentName helper is declared exactly once (single source of truth)", async () => {
+    // If a second normalizer is ever introduced the two will inevitably drift.
+    // Pin a single implementation.
+    const promptTs = await fs.readFile(
+      path.join(__dirname, "../../src/session/prompt.ts"),
+      "utf-8",
+    )
+    const declarations = promptTs.match(/function\s+normalizeAgentName\s*\(/g) ?? []
+    expect(declarations.length).toBe(1)
   })
 })
 

--- a/packages/opencode/test/session/plan-layer-e2e.test.ts
+++ b/packages/opencode/test/session/plan-layer-e2e.test.ts
@@ -284,8 +284,13 @@ describe("sessionAgentName fix safety", () => {
     // Find agent_outcome emission
     const outcomeIdx = promptTs.indexOf('type: "agent_outcome"')
     expect(outcomeIdx).toBeGreaterThan(-1)
-    const block = promptTs.slice(outcomeIdx, outcomeIdx + 400)
-    expect(block).toContain("agent: sessionAgentName")
+    // The agent name is normalized at the emit boundary: legacy "build" sessions
+    // (from before the agent was renamed to "builder") fold into "builder" so
+    // dashboards see one coherent bucket instead of a phantom 0%-completion row.
+    // Allow both the original `agent: sessionAgentName` and the normalized form.
+    const block = promptTs.slice(outcomeIdx, outcomeIdx + 1200)
+    expect(block).toContain("sessionAgentName")
+    expect(block).toContain('"builder"')
   })
 })
 


### PR DESCRIPTION
### What does this PR do?

Fixes the phantom `agent: "build"` 0%-completion bucket flagged in the May 21 telemetry triage (133 invocations, 0/133 completed).

It's not a routing bug. The `build` agent was renamed to `builder` and `Agent.get("build")` aliases through to it, so execution works. But two places still write the literal `"build"` to user messages, which then flows verbatim into the `agent_outcome` telemetry event — creating a phantom dashboard row with no completions to its name. Real `builder` work is recorded correctly under the `builder` bucket.

The dominant source is `plan_exit`: every time a user approves a plan and exits plan mode, the synthetic user message hardcodes `agent: "build"`. 133 plan-exits in 14 days, all funnelled into the wrong bucket.

Three fixes:
1. `tool/plan.ts:56` writes `agent: "builder"` instead of `"build"`
2. `session/prompt.ts:1153` normalizes at the telemetry-emit boundary — `agent === "build" ? "builder" : agent` — belt-and-suspenders for persisted sessions still carrying the legacy value
3. `cli/cmd/github.ts:954` updates a stale comment

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #832

### How did you verify your code works?

- `tsgo --noEmit`: pass
- `bun test test/session/plan-layer-e2e.test.ts test/telemetry/plan-skill-telemetry.test.ts test/altimate/plan-refinement.test.ts`: **95 pass / 0 fail**
- `bun test test/altimate/ test/agent/ test/tool/`: **3,242 pass / 0 fail** (1 unrelated flake — registry.test.ts timeout under parallel load; passes in isolation)
- Updated `test/session/plan-layer-e2e.test.ts` to allow both the normalized and original forms in the agent_outcome block, and pinned that `"builder"` appears so the normalization isn't accidentally removed
- Marker check: pass — `altimate_change` markers added on every changed line in upstream-shared files

### Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Marker check passes
- [x] Linked to issue #832

---

**Files changed (4):**
- `packages/opencode/src/tool/plan.ts` — write canonical "builder" + title/output text update
- `packages/opencode/src/session/prompt.ts` — normalize agent at emit boundary
- `packages/opencode/src/cli/cmd/github.ts` — fix stale "build" comment
- `packages/opencode/test/session/plan-layer-e2e.test.ts` — update assertion to allow normalized form

**Expected telemetry impact:** the phantom `agent: "build"` 0%-completion row disappears. Plan-exit invocations fold back into `builder`'s real completion rate.

**Related P0 series:**
- Issue #827 / PR #828: finops_* 100% failure rate
- Issue #830 / PR #831: project_scan 32% errors (437 users)
- Issue #832 / this PR: build agent 0% completion measurement artifact

P0-3 in the May 21 triage (`classifier 100% empty`) was investigated and determined to be a telemetry-analysis schema mismatch (the analyst queried `task_type`/`complexity` fields that don't exist in the schema; the actual `intent`/`confidence` fields are populated correctly). No code change needed.

P0-5 (PII masker shredding error messages to `?`) was addressed structurally by #831 — fixing the root cause (project_scan crashing) eliminated the dominant case where the masker was hiding diagnostic info. A broader masker change would risk leaking actual PII; leaving as-is.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Canonicalizes the agent name to `builder` and normalizes it (case-insensitive) at telemetry emit time to remove the phantom 0% `build` bucket. Closes #832.

- **Bug Fixes**
  - `tool/plan.ts`: write `agent: "builder"` and update dialog/title/output to say “builder”.
  - `session/prompt.ts`: add `normalizeAgentName()` (case-insensitive) and use it in `session_start` and `agent_outcome`.
  - `cli/cmd/tui/routes/session/index.tsx`: set `local.agent` to `"builder"` on `plan_exit`.
  - `config/config.ts`: update `default_agent` fallback description to `builder`.
  - Tests: anchored checks for the shared normalizer, `session_start` parity, single-normalizer invariant, and case-folding.

<sup>Written for commit f0bff6ea5b67809a5d1eb3234ae0fd7c80673174. Summary will update on new commits. <a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/833?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified agent naming from "build" to "builder" in UI text and messaging to ensure consistent messaging and telemetry
  * Updated plan-exit messaging to reference "builder agent"

* **Tests**
  * Expanded end-to-end tests to validate normalized agent reporting and telemetry routing

* **Chores**
  * Added normalization for legacy agent names and updated schema description to reflect the new default agent name

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AltimateAI/altimate-code/pull/833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->