### PR TITLE
fix: [#834] cap todowrite per session to break runaway loops

### DIFF
--- a/packages/opencode/src/tool/todo.ts
+++ b/packages/opencode/src/tool/todo.ts
@@ -119,13 +119,21 @@ export const TodoWriteTool = Tool.define("todowrite", {
     const decision = recordTodoWriteCall(ctx.sessionID)
 
     if (decision.action === "refuse") {
-      Telemetry.track({
-        type: "doom_loop_detected",
-        timestamp: Date.now(),
-        session_id: ctx.sessionID,
-        tool_name: "todowrite",
-        repeat_count: decision.count,
-      })
+      // Fire telemetry ONLY on the transition into refusal (first call at
+      // the threshold), not on every subsequent refused call. Without this
+      // gate, a runaway agent that keeps hammering todowrite after refusal
+      // produces ~9,000+ doom_loop_detected events per session — pure
+      // telemetry noise. The transition fires once; subsequent refusals
+      // remain silent. Mirrors the `===` symmetry of the warn branch.
+      if (decision.count === TODOWRITE_REFUSE_THRESHOLD) {
+        Telemetry.track({
+          type: "doom_loop_detected",
+          timestamp: Date.now(),
+          session_id: ctx.sessionID,
+          tool_name: "todowrite",
+          repeat_count: decision.count,
+        })
+      }
       return {
         title: `todowrite blocked: ${decision.count} calls this session`,
         output:

--- a/packages/opencode/src/tool/todo.ts
+++ b/packages/opencode/src/tool/todo.ts
@@ -2,6 +2,56 @@ import z from "zod"
 import { Tool } from "./tool"
 import DESCRIPTION_WRITE from "./todowrite.txt"
 import { Todo } from "../session/todo"
+// altimate_change start — telemetry hook for session-level todowrite runaway detection
+import { Telemetry } from "@/altimate/telemetry"
+// altimate_change end
+
+// altimate_change start — session-level todowrite call counters
+// The doom-loop detector in session/processor.ts is per-assistant-message
+// scope: its counter resets every time a new assistant message starts. Real
+// telemetry (telemetry-analysis-2026-05-21) shows machines with 9,139
+// todowrite calls across 28 sessions — ~325 per session, each turn under the
+// processor threshold but total runaway. This per-session counter catches the
+// slow-burn pattern by accumulating across all turns within a session.
+//
+// In-memory Map is fine because:
+// - Sessions don't survive process restart anyway (the loop would end naturally).
+// - Stale entries are harmless because the counter is keyed per sessionID; a
+//   new session simply starts at 0 regardless of any old entries.
+const todoWriteCallsBySession = new Map<string, number>()
+export const TODOWRITE_WARN_THRESHOLD = 25
+export const TODOWRITE_REFUSE_THRESHOLD = 50
+
+/**
+ * Record one todowrite call for the session and return a decision about how
+ * the tool should respond.
+ *
+ * Exported so unit tests can drive the same code path the tool uses, without
+ * needing the full Tool.define() initialization context.
+ */
+export function recordTodoWriteCall(sessionID: string): {
+  action: "ok" | "warn" | "refuse"
+  count: number
+} {
+  const prev = todoWriteCallsBySession.get(sessionID) ?? 0
+  const count = prev + 1
+  todoWriteCallsBySession.set(sessionID, count)
+
+  if (count >= TODOWRITE_REFUSE_THRESHOLD) return { action: "refuse", count }
+  if (count === TODOWRITE_WARN_THRESHOLD) return { action: "warn", count }
+  return { action: "ok", count }
+}
+
+/** Reset all per-session counters (testing only). */
+export function _resetTodoWriteCounters(): void {
+  todoWriteCallsBySession.clear()
+}
+
+/** Read the current count for a session (testing only). */
+export function _getTodoWriteCount(sessionID: string): number {
+  return todoWriteCallsBySession.get(sessionID) ?? 0
+}
+// altimate_change end
 
 export const TodoWriteTool = Tool.define("todowrite", {
   description: DESCRIPTION_WRITE,
@@ -16,15 +66,75 @@ export const TodoWriteTool = Tool.define("todowrite", {
       metadata: {},
     })
 
+    // altimate_change start — session-level runaway detection
+    const decision = recordTodoWriteCall(ctx.sessionID)
+
+    if (decision.action === "refuse") {
+      Telemetry.track({
+        type: "doom_loop_detected",
+        timestamp: Date.now(),
+        session_id: ctx.sessionID,
+        tool_name: "todowrite",
+        repeat_count: decision.count,
+      })
+      return {
+        title: `todowrite blocked: ${decision.count} calls this session`,
+        output:
+          `todowrite has been called ${decision.count} times this session, far beyond normal usage ` +
+          `(typically 5-15 calls). Refusing further updates to break the loop. ` +
+          `Continue with the work you were doing — the todo list is already tracked. ` +
+          `If you genuinely need to update the list, summarise the remaining tasks in your ` +
+          `next response instead of calling todowrite again.`,
+        metadata: {
+          todos: await Todo.get(ctx.sessionID),
+          refused: true,
+          call_count: decision.count,
+        },
+      }
+    }
+    // altimate_change end
+
     await Todo.update({
       sessionID: ctx.sessionID,
       todos: params.todos,
     })
+
+    const remainingTodos = params.todos.filter((x) => x.status !== "completed").length
+
+    // altimate_change start — gentle warning at the soft threshold
+    if (decision.action === "warn") {
+      Telemetry.track({
+        type: "doom_loop_detected",
+        timestamp: Date.now(),
+        session_id: ctx.sessionID,
+        tool_name: "todowrite",
+        repeat_count: decision.count,
+      })
+      return {
+        title: `${remainingTodos} todos (warning: ${decision.count} updates this session)`,
+        output:
+          `${JSON.stringify(params.todos, null, 2)}\n\n` +
+          `WARNING: todowrite has been called ${decision.count} times this session. ` +
+          `Typical usage is 5-15 calls. Consider whether you're updating the list ` +
+          `more often than needed — the list will be discarded if you exceed ` +
+          `${TODOWRITE_REFUSE_THRESHOLD} calls.`,
+        metadata: {
+          todos: params.todos,
+          warning_emitted: true,
+          call_count: decision.count,
+        },
+      }
+    }
+    // altimate_change end
+
     return {
-      title: `${params.todos.filter((x) => x.status !== "completed").length} todos`,
+      title: `${remainingTodos} todos`,
       output: JSON.stringify(params.todos, null, 2),
       metadata: {
         todos: params.todos,
+        // altimate_change start — expose count so observability sees the climb
+        call_count: decision.count,
+        // altimate_change end
       },
     }
   },

--- a/packages/opencode/src/tool/todo.ts
+++ b/packages/opencode/src/tool/todo.ts
@@ -37,22 +37,23 @@ export const TODOWRITE_REFUSE_THRESHOLD = 50
 // and `recordTodoWriteCall` has no awaits before the guard flips, so two
 // concurrent first-calls cannot both enter the subscribe block.
 //
-// Failure handling: if `Bus.subscribe` throws (Bus not yet initialized in
-// some test contexts), we still flip `_subscribed = true` to avoid retrying
-// every call. The counter remains correct for the in-memory case — only the
-// daemon-mode auto-cleanup is lost, and the explicit `clearTodoWriteCounter`
-// escape hatch remains available. This is a deliberate trade-off: silent
-// retry every call would noisily re-throw on every todowrite invocation.
+// Failure handling: `_subscribed` flips to true ONLY after a successful
+// `Bus.subscribe`. If subscribe throws (e.g. Bus not yet initialized in
+// a test context), `_subscribed` stays false so the next todowrite call
+// retries. Bus.subscribe is synchronous + the handler set is idempotent
+// per identity, so racy first-calls won't double-subscribe.
 let _subscribed = false
 function ensureSessionDeletedSubscription(): void {
   if (_subscribed) return
-  _subscribed = true
   try {
     Bus.subscribe(Session.Event.Deleted, (evt) => {
       todoWriteCallsBySession.delete(evt.properties.info.id)
     })
+    _subscribed = true
   } catch {
-    // See comment above — subscription is best-effort, no retry by design.
+    // Bus may not be initialized yet (some test contexts). Leave
+    // _subscribed=false so the next todowrite call retries the subscribe.
+    // The counter still works correctly for the in-memory case meanwhile.
   }
 }
 

--- a/packages/opencode/src/tool/todo.ts
+++ b/packages/opencode/src/tool/todo.ts
@@ -32,8 +32,17 @@ export const TODOWRITE_WARN_THRESHOLD = 25
 export const TODOWRITE_REFUSE_THRESHOLD = 50
 
 // Clear counters on session deletion so daemon-mode processes don't
-// accumulate entries indefinitely. Subscribing at module load is the
-// established pattern in `share/share-next.ts` and `session/projectors.ts`.
+// accumulate entries indefinitely. Subscribing lazily on first call avoids
+// requiring an init step in callers — safe because Node is single-threaded
+// and `recordTodoWriteCall` has no awaits before the guard flips, so two
+// concurrent first-calls cannot both enter the subscribe block.
+//
+// Failure handling: if `Bus.subscribe` throws (Bus not yet initialized in
+// some test contexts), we still flip `_subscribed = true` to avoid retrying
+// every call. The counter remains correct for the in-memory case — only the
+// daemon-mode auto-cleanup is lost, and the explicit `clearTodoWriteCounter`
+// escape hatch remains available. This is a deliberate trade-off: silent
+// retry every call would noisily re-throw on every todowrite invocation.
 let _subscribed = false
 function ensureSessionDeletedSubscription(): void {
   if (_subscribed) return
@@ -43,8 +52,7 @@ function ensureSessionDeletedSubscription(): void {
       todoWriteCallsBySession.delete(evt.properties.info.id)
     })
   } catch {
-    // Bus may not be initialized in some test contexts; the counter still
-    // works correctly for the in-memory case. Subscription is best-effort.
+    // See comment above — subscription is best-effort, no retry by design.
   }
 }
 
@@ -80,6 +88,10 @@ export function recordTodoWriteCall(sessionID: string): {
  * counter cleared without ending the session. The operator can call this
  * from a debug context. Sessions reset automatically on `session.deleted`,
  * so most users never need this.
+ *
+ * No auth check: the CLI runs as a single local user with no remote callers;
+ * the worst case is a user resetting their own session's counter. Same
+ * privilege boundary as any other in-process import.
  */
 export function clearTodoWriteCounter(sessionID: string): void {
   todoWriteCallsBySession.delete(sessionID)
@@ -175,8 +187,8 @@ export const TodoWriteTool = Tool.define("todowrite", {
           `${JSON.stringify(params.todos, null, 2)}\n\n` +
           `WARNING: todowrite has been called ${decision.count} times this session. ` +
           `Typical usage is 5-15 calls. Consider whether you're updating the list ` +
-          `more often than needed — the list will be discarded if you exceed ` +
-          `${TODOWRITE_REFUSE_THRESHOLD} calls.`,
+          `more often than needed — further updates will be refused if you exceed ` +
+          `${TODOWRITE_REFUSE_THRESHOLD} calls. (Your current list is preserved.)`,
         metadata: {
           todos: params.todos,
           warning_emitted: true,

--- a/packages/opencode/src/tool/todo.ts
+++ b/packages/opencode/src/tool/todo.ts
@@ -3,7 +3,9 @@ import { Tool } from "./tool"
 import DESCRIPTION_WRITE from "./todowrite.txt"
 import { Todo } from "../session/todo"
 // altimate_change start — telemetry hook for session-level todowrite runaway detection
-import { Telemetry } from "@/altimate/telemetry"
+import { Telemetry } from "../altimate/telemetry"
+import { Bus } from "../bus"
+import { Session } from "../session"
 // altimate_change end
 
 // altimate_change start — session-level todowrite call counters
@@ -14,13 +16,37 @@ import { Telemetry } from "@/altimate/telemetry"
 // processor threshold but total runaway. This per-session counter catches the
 // slow-burn pattern by accumulating across all turns within a session.
 //
-// In-memory Map is fine because:
-// - Sessions don't survive process restart anyway (the loop would end naturally).
-// - Stale entries are harmless because the counter is keyed per sessionID; a
-//   new session simply starts at 0 regardless of any old entries.
+// Lifecycle and override semantics:
+// - In-memory Map keyed by sessionID. Entries are cleared on `session.deleted`
+//   so daemon-mode (`altimate serve`) doesn't accumulate stale state.
+// - REFUSAL IS PER-SESSION, NOT PERMANENT. The agent can continue working
+//   without calling todowrite (the existing list stays readable via todoread).
+//   To explicitly reset the counter mid-session, an operator can call
+//   `clearTodoWriteCounter(sessionID)` — exposed for debugging/escape hatch.
+// - Counter increments on EVERY call, including refused ones. The published
+//   count therefore represents attempts, not accepted updates.
+// - Permission check (`ctx.ask`) runs before the counter increment, so a
+//   permission-denied call does not bump the counter.
 const todoWriteCallsBySession = new Map<string, number>()
 export const TODOWRITE_WARN_THRESHOLD = 25
 export const TODOWRITE_REFUSE_THRESHOLD = 50
+
+// Clear counters on session deletion so daemon-mode processes don't
+// accumulate entries indefinitely. Subscribing at module load is the
+// established pattern in `share/share-next.ts` and `session/projectors.ts`.
+let _subscribed = false
+function ensureSessionDeletedSubscription(): void {
+  if (_subscribed) return
+  _subscribed = true
+  try {
+    Bus.subscribe(Session.Event.Deleted, (evt) => {
+      todoWriteCallsBySession.delete(evt.properties.info.id)
+    })
+  } catch {
+    // Bus may not be initialized in some test contexts; the counter still
+    // works correctly for the in-memory case. Subscription is best-effort.
+  }
+}
 
 /**
  * Record one todowrite call for the session and return a decision about how
@@ -28,11 +54,15 @@ export const TODOWRITE_REFUSE_THRESHOLD = 50
  *
  * Exported so unit tests can drive the same code path the tool uses, without
  * needing the full Tool.define() initialization context.
+ *
+ * Note: the counter increments on EVERY call, including refused ones — the
+ * returned `count` is attempts, not accepted updates.
  */
 export function recordTodoWriteCall(sessionID: string): {
   action: "ok" | "warn" | "refuse"
   count: number
 } {
+  ensureSessionDeletedSubscription()
   const prev = todoWriteCallsBySession.get(sessionID) ?? 0
   const count = prev + 1
   todoWriteCallsBySession.set(sessionID, count)
@@ -42,12 +72,31 @@ export function recordTodoWriteCall(sessionID: string): {
   return { action: "ok", count }
 }
 
-/** Reset all per-session counters (testing only). */
+/**
+ * Explicit escape hatch: reset the counter for a single session.
+ *
+ * Use case: a long-running session that legitimately exceeded the refuse
+ * threshold (large multi-step refactor, parallel subagents) needs the
+ * counter cleared without ending the session. The operator can call this
+ * from a debug context. Sessions reset automatically on `session.deleted`,
+ * so most users never need this.
+ */
+export function clearTodoWriteCounter(sessionID: string): void {
+  todoWriteCallsBySession.delete(sessionID)
+}
+
+/**
+ * Reset all per-session counters.
+ * @internal — only used by tests; do not call from production code.
+ */
 export function _resetTodoWriteCounters(): void {
   todoWriteCallsBySession.clear()
 }
 
-/** Read the current count for a session (testing only). */
+/**
+ * Read the current count for a session.
+ * @internal — only used by tests; do not call from production code.
+ */
 export function _getTodoWriteCount(sessionID: string): number {
   return todoWriteCallsBySession.get(sessionID) ?? 0
 }
@@ -99,7 +148,9 @@ export const TodoWriteTool = Tool.define("todowrite", {
       todos: params.todos,
     })
 
+    // altimate_change start — extract for reuse across warn / normal branches
     const remainingTodos = params.todos.filter((x) => x.status !== "completed").length
+    // altimate_change end
 
     // altimate_change start — gentle warning at the soft threshold
     if (decision.action === "warn") {

--- a/packages/opencode/src/tool/todo.ts
+++ b/packages/opencode/src/tool/todo.ts
@@ -179,14 +179,14 @@ export const TodoWriteTool = Tool.define("todowrite", {
     // altimate_change end
 
     return {
+      // altimate_change start — reuse extracted remainingTodos + expose call_count for observability
       title: `${remainingTodos} todos`,
       output: JSON.stringify(params.todos, null, 2),
       metadata: {
         todos: params.todos,
-        // altimate_change start — expose count so observability sees the climb
         call_count: decision.count,
-        // altimate_change end
       },
+      // altimate_change end
     }
   },
 })

--- a/packages/opencode/test/tool/todowrite-loop.test.ts
+++ b/packages/opencode/test/tool/todowrite-loop.test.ts
@@ -38,7 +38,9 @@ describe("recordTodoWriteCall: counter mechanics", () => {
     expect(_getTodoWriteCount("session-b")).toBe(1)
   })
 
-  test("counter survives reset and starts fresh", () => {
+  test("counter is cleared by _resetTodoWriteCounters and starts fresh", () => {
+    // Renamed from "counter survives reset" which was misleading — the
+    // reset clears the counter, it doesn't survive.
     recordTodoWriteCall("session-a")
     recordTodoWriteCall("session-a")
     expect(_getTodoWriteCount("session-a")).toBe(2)

--- a/packages/opencode/test/tool/todowrite-loop.test.ts
+++ b/packages/opencode/test/tool/todowrite-loop.test.ts
@@ -1,0 +1,104 @@
+import { describe, test, expect, beforeEach } from "bun:test"
+import {
+  recordTodoWriteCall,
+  _resetTodoWriteCounters,
+  _getTodoWriteCount,
+  TODOWRITE_WARN_THRESHOLD,
+  TODOWRITE_REFUSE_THRESHOLD,
+} from "../../src/tool/todo"
+
+/**
+ * Per-session todowrite runaway detection.
+ *
+ * Background: telemetry-analysis-2026-05-21 showed machines with 9,139
+ * todowrite calls across 28 sessions (top-3 machines = 63% of all 29,562
+ * todowrite calls in a 14-day window). The doom-loop detector in
+ * session/processor.ts is per-assistant-message scope and was missing the
+ * slow-burn pattern. These tests pin the per-session counter that catches it.
+ */
+
+beforeEach(() => {
+  _resetTodoWriteCounters()
+})
+
+describe("recordTodoWriteCall: counter mechanics", () => {
+  test("counts each call within a single session", () => {
+    expect(_getTodoWriteCount("session-a")).toBe(0)
+    expect(recordTodoWriteCall("session-a").count).toBe(1)
+    expect(recordTodoWriteCall("session-a").count).toBe(2)
+    expect(_getTodoWriteCount("session-a")).toBe(2)
+  })
+
+  test("counters are independent across sessions", () => {
+    recordTodoWriteCall("session-a")
+    recordTodoWriteCall("session-a")
+    recordTodoWriteCall("session-b")
+    expect(_getTodoWriteCount("session-a")).toBe(2)
+    expect(_getTodoWriteCount("session-b")).toBe(1)
+  })
+
+  test("counter survives reset and starts fresh", () => {
+    recordTodoWriteCall("session-a")
+    recordTodoWriteCall("session-a")
+    expect(_getTodoWriteCount("session-a")).toBe(2)
+    _resetTodoWriteCounters()
+    expect(_getTodoWriteCount("session-a")).toBe(0)
+    expect(recordTodoWriteCall("session-a").count).toBe(1)
+  })
+})
+
+describe("recordTodoWriteCall: decision boundaries", () => {
+  test("returns action=ok for calls below the warn threshold", () => {
+    for (let i = 1; i < TODOWRITE_WARN_THRESHOLD; i++) {
+      const d = recordTodoWriteCall("session-x")
+      expect(d.action).toBe("ok")
+      expect(d.count).toBe(i)
+    }
+  })
+
+  test("returns action=warn exactly at the warn threshold", () => {
+    for (let i = 1; i < TODOWRITE_WARN_THRESHOLD; i++) {
+      recordTodoWriteCall("session-x")
+    }
+    const d = recordTodoWriteCall("session-x")
+    expect(d.action).toBe("warn")
+    expect(d.count).toBe(TODOWRITE_WARN_THRESHOLD)
+  })
+
+  test("returns action=ok between warn and refuse thresholds", () => {
+    for (let i = 1; i <= TODOWRITE_WARN_THRESHOLD; i++) {
+      recordTodoWriteCall("session-x")
+    }
+    // Next call: count = warn + 1
+    const d = recordTodoWriteCall("session-x")
+    expect(d.action).toBe("ok")
+    expect(d.count).toBe(TODOWRITE_WARN_THRESHOLD + 1)
+  })
+
+  test("returns action=refuse at the hard threshold", () => {
+    for (let i = 1; i < TODOWRITE_REFUSE_THRESHOLD; i++) {
+      recordTodoWriteCall("session-x")
+    }
+    const d = recordTodoWriteCall("session-x")
+    expect(d.action).toBe("refuse")
+    expect(d.count).toBe(TODOWRITE_REFUSE_THRESHOLD)
+  })
+
+  test("returns action=refuse for every call past the hard threshold", () => {
+    for (let i = 1; i < TODOWRITE_REFUSE_THRESHOLD; i++) {
+      recordTodoWriteCall("session-x")
+    }
+    // Trip and then push 10 more.
+    expect(recordTodoWriteCall("session-x").action).toBe("refuse")
+    for (let i = 0; i < 10; i++) {
+      expect(recordTodoWriteCall("session-x").action).toBe("refuse")
+    }
+    expect(_getTodoWriteCount("session-x")).toBe(TODOWRITE_REFUSE_THRESHOLD + 10)
+  })
+
+  test("threshold constants are sane and ordered", () => {
+    expect(TODOWRITE_WARN_THRESHOLD).toBeGreaterThan(15)
+    expect(TODOWRITE_WARN_THRESHOLD).toBeLessThan(TODOWRITE_REFUSE_THRESHOLD)
+    expect(TODOWRITE_REFUSE_THRESHOLD).toBeLessThanOrEqual(100)
+  })
+})

--- a/packages/opencode/test/tool/todowrite-loop.test.ts
+++ b/packages/opencode/test/tool/todowrite-loop.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach } from "bun:test"
 import {
   recordTodoWriteCall,
+  clearTodoWriteCounter,
   _resetTodoWriteCounters,
   _getTodoWriteCount,
   TODOWRITE_WARN_THRESHOLD,
@@ -100,5 +101,40 @@ describe("recordTodoWriteCall: decision boundaries", () => {
     expect(TODOWRITE_WARN_THRESHOLD).toBeGreaterThan(15)
     expect(TODOWRITE_WARN_THRESHOLD).toBeLessThan(TODOWRITE_REFUSE_THRESHOLD)
     expect(TODOWRITE_REFUSE_THRESHOLD).toBeLessThanOrEqual(100)
+  })
+})
+
+describe("clearTodoWriteCounter: explicit escape hatch", () => {
+  test("clearTodoWriteCounter resets a single session without affecting others", () => {
+    for (let i = 0; i < 10; i++) recordTodoWriteCall("session-x")
+    for (let i = 0; i < 5; i++) recordTodoWriteCall("session-y")
+    expect(_getTodoWriteCount("session-x")).toBe(10)
+    expect(_getTodoWriteCount("session-y")).toBe(5)
+
+    clearTodoWriteCounter("session-x")
+
+    expect(_getTodoWriteCount("session-x")).toBe(0)
+    expect(_getTodoWriteCount("session-y")).toBe(5)
+  })
+
+  test("clearTodoWriteCounter unblocks a refused session", () => {
+    // Climb to refusal.
+    for (let i = 0; i < TODOWRITE_REFUSE_THRESHOLD; i++) {
+      recordTodoWriteCall("stuck-session")
+    }
+    expect(recordTodoWriteCall("stuck-session").action).toBe("refuse")
+
+    // Operator clears.
+    clearTodoWriteCounter("stuck-session")
+
+    // Next call is ok again.
+    expect(recordTodoWriteCall("stuck-session").action).toBe("ok")
+    expect(_getTodoWriteCount("stuck-session")).toBe(1)
+  })
+
+  test("clearTodoWriteCounter on an unknown session is a no-op", () => {
+    expect(_getTodoWriteCount("never-touched")).toBe(0)
+    clearTodoWriteCounter("never-touched")
+    expect(_getTodoWriteCount("never-touched")).toBe(0)
   })
 })


### PR DESCRIPTION
### What does this PR do?

Caps `todowrite` at 50 calls per session with a warning at 25. Telemetry-2026-05-21 showed 29,562 total todowrite calls in 14 days with one machine hitting **9,139 calls across 28 sessions** (~325 per session). The existing doom-loop detector in `session/processor.ts` catches per-message bursts but not the slow-burn pattern of 10-15 calls per turn across many turns.

Implementation: tool-level per-session counter inside `TodoWriteTool`. Two thresholds:
- **25 calls → warn**: emit telemetry + insert a warning into the tool output that the LLM will read. Todos still persist.
- **50 calls → refuse**: emit telemetry + refuse the update with a structured message telling the agent to stop. Existing todos preserved.

Extracted into a testable helper `recordTodoWriteCall(sessionID)` returning `{ action, count }`.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #834

### How did you verify your code works?

- `tsgo --noEmit`: pass
- `bun test test/tool/todowrite-loop.test.ts test/session/todo.test.ts`: **15 pass / 0 fail** (12 new + 3 existing)
- 12 new tests pin every boundary: counter mechanics, action=ok below warn, action=warn exactly at threshold, action=ok between warn and refuse, action=refuse at and beyond, refusal repeats, threshold constants sane
- Marker check: pass — `altimate_change` markers applied to all changed lines in upstream-shared files

### Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Marker check passes
- [x] Linked to issue #834

---

**Files changed (2):**
- `packages/opencode/src/tool/todo.ts` — per-session counter + `recordTodoWriteCall` helper + warn/refuse branches in `TodoWriteTool.execute`
- `packages/opencode/test/tool/todowrite-loop.test.ts` — 12 tests covering every boundary

**Expected telemetry impact:**
- todowrite call volume per session capped at ~50 (down from 9,000+ peaks)
- `doom_loop_detected` events fire on every session that crosses threshold (previously invisible to the per-message detector)
- Reduced token/context burn from runaway todo updates

**P0 series progress (from telemetry-analysis-2026-05-21):**
- #827 / #828: finops_* 100% failure
- #830 / #831: project_scan 32% errors
- #832 / #833: build agent 0% completion
- #834 / this PR: todowrite runaway

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps `todowrite` per session (warn at 25, block at 50) to stop slow-burn loops and cut token/context waste. Addresses #834 by tracking repeat tool use across turns, and clarifies that the warning means future calls will be refused while the current list is preserved.

- **Bug Fixes**
  - Add per-session counter via `recordTodoWriteCall(sessionID)`; emit `doom_loop_detected` on warn and once on the first refusal to avoid telemetry spam.
  - At 25 calls: show an in-output warning that future updates will be refused and todos are preserved; at 50+: refuse with clear guidance; include `call_count` in metadata.
  - Clear counters on `Session.Event.Deleted` (lazy, best-effort); lazy subscription now retries if `Bus.subscribe` fails; add `clearTodoWriteCounter(sessionID)` to unblock legitimate long sessions; tests cover thresholds, isolation, transition-only telemetry, and the escape hatch.

<sup>Written for commit d3fb8c8e706536fee9861a924dde8e339c2f4788. Summary will update on new commits. <a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/835?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-session runaway detection for todo writes with warning and refusal thresholds; warnings surface a notice but still complete the write, refusals block further writes and include call-count metadata.

* **Tests**
  * Added comprehensive tests covering per-session counting, threshold behavior, counter reset/unblock behavior, and isolation across sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AltimateAI/altimate-code/pull/835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->