### PR TITLE
fix: port 3 upstream DeepSeek transform fixes

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -151,6 +151,28 @@ export namespace ProviderTransform {
       return result
     }
 
+    // altimate_change start — upstream_fix: ensure deepseek assistant messages always have a reasoning part
+    // Ported from upstream-opencode commit 86715fecc4 (#24180). DeepSeek's OpenAI-compatible
+    // protocol requires every assistant message to carry a `reasoning` part — without it the API
+    // returns 400 on multi-turn sessions. Drop this marker if upstream merges the same shape.
+    if (model.api.id.includes("deepseek")) {
+      msgs = msgs.map((msg) => {
+        if (msg.role !== "assistant") return msg
+        if (Array.isArray(msg.content)) {
+          if (msg.content.some((part: any) => part.type === "reasoning")) return msg
+          return { ...msg, content: [...msg.content, { type: "reasoning", text: "" } as any] }
+        }
+        return {
+          ...msg,
+          content: [
+            ...(msg.content ? [{ type: "text" as const, text: msg.content as unknown as string }] : []),
+            { type: "reasoning" as const, text: "" } as any,
+          ] as any,
+        }
+      })
+    }
+    // altimate_change end
+
     if (typeof model.capabilities.interleaved === "object" && model.capabilities.interleaved.field) {
       const field = model.capabilities.interleaved.field
       return msgs.map((msg) => {
@@ -161,25 +183,23 @@ export namespace ProviderTransform {
           // Filter out reasoning parts from content
           const filteredContent = msg.content.filter((part: any) => part.type !== "reasoning")
 
-          // Include reasoning_content | reasoning_details directly on the message for all assistant messages
-          if (reasoningText) {
-            return {
-              ...msg,
-              content: filteredContent,
-              providerOptions: {
-                ...msg.providerOptions,
-                openaiCompatible: {
-                  ...(msg.providerOptions as any)?.openaiCompatible,
-                  [field]: reasoningText,
-                },
-              },
-            }
-          }
-
+          // altimate_change start — upstream_fix: always set the interleaved reasoning field
+          // even when empty. Ported from upstream-opencode commit 923af96d26 (#24146). DeepSeek
+          // V4 thinking mode may emit empty reasoning_content; the field must still be present
+          // on subsequent requests or the API rejects the message. Drop this marker if upstream
+          // ships the same shape.
           return {
             ...msg,
             content: filteredContent,
+            providerOptions: {
+              ...msg.providerOptions,
+              openaiCompatible: {
+                ...(msg.providerOptions as any)?.openaiCompatible,
+                [field]: reasoningText,
+              },
+            },
           }
+          // altimate_change end
         }
 
         return msg
@@ -283,8 +303,10 @@ export namespace ProviderTransform {
     msgs = normalizeMessages(msgs, model, options)
     if (
       (model.providerID === "anthropic" ||
+        // altimate_change start — altimate-specific Anthropic provider IDs
         model.providerID === "google-vertex-anthropic" ||
         model.providerID === "altimate-backend" ||
+        // altimate_change end
         model.api.id.includes("anthropic") ||
         model.api.id.includes("claude") ||
         model.id.includes("anthropic") ||
@@ -503,7 +525,17 @@ export namespace ProviderTransform {
       case "venice-ai-sdk-provider":
       // https://docs.venice.ai/overview/guides/reasoning-models#reasoning-effort
       case "@ai-sdk/openai-compatible":
-        return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
+        // altimate_change start — upstream_fix: add "max" reasoning effort for deepseek-v4
+        // Ported from upstream-opencode commit f8e939d96f (#24163). DeepSeek-v4 advertises a
+        // `max` reasoning effort that the default WIDELY_SUPPORTED_EFFORTS list omits. Drop
+        // this marker if upstream lifts the cap or ships the same shape.
+        return Object.fromEntries(
+          [
+            ...WIDELY_SUPPORTED_EFFORTS,
+            ...(model.api.id.includes("deepseek-v4") ? ["max"] : []),
+          ].map((effort) => [effort, { reasoningEffort: effort }]),
+        )
+        // altimate_change end
 
       case "@ai-sdk/azure":
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/azure


### PR DESCRIPTION
### What does this PR do?

Cherry-picks (manual port — no merge base with upstream-opencode) 3 DeepSeek-specific `transform.ts` fixes that landed in upstream-opencode but never made it into altimate-code's `main`:

1. **DeepSeek assistant messages always carry a reasoning part** — upstream `86715fecc4` / `#24180`. DeepSeek's OpenAI-compatible protocol rejects multi-turn assistant messages that lack a `reasoning` part; the fix inserts an empty one before the interleaved-field normalization.

2. **Always emit the interleaved reasoning field, even when empty** — upstream `923af96d26` / `#24146`. DeepSeek V4 thinking mode may emit empty `reasoning_content`; the field must still be present in subsequent requests or the API rejects the message. Removes the `if (reasoningText)` guard around the `providerOptions` set so the field is always written.

3. **DeepSeek-v4 supports `max` reasoning effort** — upstream `f8e939d96f` / `#24163`. Adds `"max"` to the `@ai-sdk/openai-compatible` variant cascade when the model id contains `deepseek-v4`.

A fourth upstream fix (`9d6718131e` — remove `deepseek-chat`/`deepseek-reasoner` from a variants include list) is **not** ported because our equivalent block already excludes all `deepseek` model ids from variant calculation via the broader `id.includes("deepseek")` check at `transform.ts:380`.

Also wraps the altimate-specific `altimate-backend` / `google-vertex-anthropic` providerID entries in `altimate_change` markers (pre-existing oversight from PR #850 that the marker guard now flags).

All three ported changes are marked with the `upstream_fix:` tag so they can be dropped when upstream finally ships the same shape via a normal merge.

### Type of change

`fix:` (provider compat with DeepSeek V4 / Reasoner endpoints).

### Issue for this PR

No tracking issue — these are upstream fixes that fell off the bridge during our diverged history. Investigated as a follow-up to #849 review.

### How did you verify your code works?

- `bun test test/provider/` — 387 pass / 0 fail, exercises the variant cascade and `normalizeMessages`
- `bun run typecheck` — clean
- `bun run script/upstream/analyze.ts --markers --base main --strict` — clean (new code wrapped in `altimate_change` blocks)
- Spot-checked against a DGX DeepSeek-V4 benchmark trace at `~/ade-bench-openrouter/experiments/duckdb_deepseek_v4pro_run1__none/` to confirm the model id pattern matches (`alibaba-cn/deepseek-v4-pro` and `azure-deepseek/deepseek-v4-flash` both contain `deepseek-v4`).

### Checklist

- [x] Tests pass locally
- [x] No new lint errors
- [x] Marker guard clean
- [x] Self-reviewed the diff
- [x] All ported changes carry `upstream_fix:` so they auto-surface during the next upstream merge audit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports three upstream DeepSeek transform fixes to restore API compatibility and prevent 400 errors in multi-turn chats. Ensures reasoning fields are always present and enables `max` reasoning effort for `deepseek-v4`.

- Bug Fixes
  - Always add an empty `reasoning` part to DeepSeek assistant messages.
  - Always set the interleaved reasoning field on assistant messages, even when empty.
  - Add `"max"` to reasoning effort variants for `deepseek-v4` under `@ai-sdk/openai-compatible`.

- Refactors
  - Wrap `altimate-backend` and `google-vertex-anthropic` provider IDs in `altimate_change` guards.

<sup>Written for commit dc995c586b6de33c68267855ddc28d4bdb8e89d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced support for AI reasoning capabilities across models
  * Expanded compatibility with additional AI provider backends
  * Added maximum reasoning effort level option for DeepSeek models
  * Improved message transformation consistency for multi-provider support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AltimateAI/altimate-code/pull/852?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->