### PR TITLE
fix: dbt PR reviewer posts COMMENT, never a formal APPROVE review

### DIFF
--- a/packages/opencode/src/altimate/review/verdict.ts
+++ b/packages/opencode/src/altimate/review/verdict.ts
@@ -21,9 +21,17 @@ export const ReviewMode = z.enum([
 ])
 export type ReviewMode = z.infer<typeof ReviewMode>
 
-/** Maps a Verdict to a VCS review event. */
+/** Maps a Verdict to a VCS review event.
+ *
+ * An `APPROVE` verdict posts a **COMMENT** review event, NOT a GitHub "APPROVE".
+ * The reviewer is a bot: it must never submit a formal approval that could
+ * satisfy branch protection / required reviews and let a PR merge without human
+ * sign-off (matching CodeRabbit/Greptile/etc., which comment but never approve).
+ * The "approved — no findings" outcome is conveyed in the comment body instead.
+ * `REQUEST_CHANGES` still maps through (in `gate` mode it blocks; `comment` mode
+ * softens it to COMMENT via {@link applyMode}). */
 export const VCS_EVENT: Record<Verdict, "APPROVE" | "COMMENT" | "REQUEST_CHANGES"> = {
-  APPROVE: "APPROVE",
+  APPROVE: "COMMENT",
   COMMENT: "COMMENT",
   REQUEST_CHANGES: "REQUEST_CHANGES",
 }

--- a/packages/opencode/test/altimate/review.test.ts
+++ b/packages/opencode/test/altimate/review.test.ts
@@ -12,6 +12,7 @@ import {
   clampSeverity,
   computeIdealVerdict,
   applyMode,
+  VCS_EVENT,
   buildEnvelope,
   signEnvelope,
   verifyEnvelope,
@@ -196,6 +197,13 @@ describe("verdict", () => {
 
   test("single suggestion → COMMENT", () => {
     expect(computeIdealVerdict([mk("suggestion")], DEFAULT_RUBRIC)).toBe("COMMENT")
+  })
+
+  test("the bot NEVER emits a formal APPROVE review event", () => {
+    // A bot approval could satisfy branch protection and merge a PR without human
+    // sign-off. An APPROVE verdict must post a COMMENT review event instead.
+    expect(VCS_EVENT.APPROVE).toBe("COMMENT")
+    expect(Object.values(VCS_EVENT)).not.toContain("APPROVE")
   })
 
   test("comment mode softens REQUEST_CHANGES → COMMENT", () => {


### PR DESCRIPTION
### What does this PR do?

The dbt PR reviewer mapped an `APPROVE` verdict to a GitHub **APPROVE** review event, so the bot was formally approving PRs. Observed live on `AltimateAI/altimate-ingestion` #682, where the `github-actions` bot review state is `APPROVED`. Under branch protection / required reviews, a bot approval can satisfy the requirement and let a PR merge without human sign-off.

This maps `APPROVE` → a **COMMENT** review event in `VCS_EVENT` (`verdict.ts`). The "approved — no findings" outcome is conveyed in the comment body instead. `REQUEST_CHANGES` still maps through (`gate` mode blocks; `comment` mode softens to COMMENT via `applyMode`). This matches how CodeRabbit / Greptile / cubic behave — they comment but never grant a formal approval.

- `packages/opencode/src/altimate/review/verdict.ts` — `VCS_EVENT.APPROVE` is now `"COMMENT"`, with a doc comment explaining the bot-must-not-approve invariant.
- `packages/opencode/test/altimate/review.test.ts` — regression test asserting no verdict emits a formal `APPROVE` event.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #869

### How did you verify your code works?

- `bun turbo typecheck` — clean.
- `bun test test/altimate/review.test.ts` — 65 pass, 0 fail (includes the new regression test asserting `VCS_EVENT.APPROVE === "COMMENT"` and that `Object.values(VCS_EVENT)` never contains `"APPROVE"`).
- Marker guard (`--base origin/main --strict`) — no upstream-shared files modified.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the dbt PR reviewer from submitting formal GitHub approvals; an `APPROVE` verdict now posts a comment so branch protection and required reviews always need human sign-off. Closes #869.

- **Bug Fixes**
  - Mapped `APPROVE` → `COMMENT` in `VCS_EVENT` (`packages/opencode/src/altimate/review/verdict.ts`); the “approved — no findings” outcome is conveyed in the comment body.
  - Added a regression test to ensure no verdict emits a formal `APPROVE` review event (`packages/opencode/test/altimate/review.test.ts`).

<sup>Written for commit c1099d5a3de25d830433526ebc697f6fce7d9605. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Modified approval verdict submissions to emit as comments instead of formal approvals, ensuring they cannot satisfy required review requirements.

* **Tests**
  * Added test verifying approval verdicts never emit as formal approvals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->