### PR TITLE
fix: correct reviewer APPROVE→COMMENT docs + enforce no-formal-approve at compile time

### DIFF
--- a/packages/opencode/src/altimate/review/post-github.ts
+++ b/packages/opencode/src/altimate/review/post-github.ts
@@ -6,8 +6,10 @@ import { renderSummary, inlineComments, REVIEW_MARKER, verdictHeadline } from ".
 /**
  * Post a verdict envelope to a GitHub pull request: an upserted summary comment
  * (deduped by the review marker, so re-reviews update in place) plus a single
- * batched review with inline comments. In `comment` mode the review event is
- * always COMMENT; in `gate` mode it maps the verdict to APPROVE/REQUEST_CHANGES.
+ * batched review with inline comments. The review event is never a formal
+ * GitHub APPROVE (a bot approval could satisfy branch protection): an APPROVE
+ * verdict posts COMMENT. In `comment` mode REQUEST_CHANGES is also softened to
+ * COMMENT; in `gate` mode REQUEST_CHANGES maps through as a blocking review.
  *
  * Self-contained (uses GITHUB_TOKEN) so it works from CI without the GitHub App
  * flow. Defensive: inline comments outside the diff fall back to an event-only
@@ -78,8 +80,10 @@ export async function postGitHubReview(env: VerdictEnvelope, target: GitHubTarge
     result.summaryCommentId = r.data.id
   }
 
-  // 2. Post a review. In comment mode the engine already softened the verdict
-  //    to COMMENT; gate mode keeps APPROVE / REQUEST_CHANGES.
+  // 2. Post a review. `env.verdict` arrives already mode-gated from
+  //    buildEnvelope (comment mode softened REQUEST_CHANGES → COMMENT upstream);
+  //    this map only translates verdict → GitHub event. APPROVE always maps to a
+  //    COMMENT event — the bot must never submit a formal GitHub approval.
   const event = VCS_EVENT[env.verdict]
   const comments = inlineComments(env)
   const reviewBody = verdictHeadline(env)

--- a/packages/opencode/src/altimate/review/verdict.ts
+++ b/packages/opencode/src/altimate/review/verdict.ts
@@ -29,8 +29,13 @@ export type ReviewMode = z.infer<typeof ReviewMode>
  * sign-off (matching CodeRabbit/Greptile/etc., which comment but never approve).
  * The "approved — no findings" outcome is conveyed in the comment body instead.
  * `REQUEST_CHANGES` still maps through (in `gate` mode it blocks; `comment` mode
- * softens it to COMMENT via {@link applyMode}). */
-export const VCS_EVENT: Record<Verdict, "APPROVE" | "COMMENT" | "REQUEST_CHANGES"> = {
+ * softens it to COMMENT via {@link applyMode}).
+ *
+ * The value type deliberately EXCLUDES `"APPROVE"`: the no-formal-approval
+ * invariant is enforced at compile time, so no future edit can map a verdict
+ * back to a GitHub APPROVE without breaking the build. (The narrower union is
+ * still assignable to Octokit's `createReview` event param.) */
+export const VCS_EVENT: Record<Verdict, "COMMENT" | "REQUEST_CHANGES"> = {
   APPROVE: "COMMENT",
   COMMENT: "COMMENT",
   REQUEST_CHANGES: "REQUEST_CHANGES",
@@ -65,6 +70,8 @@ export function computeIdealVerdict(findings: Finding[], rubric: Rubric = DEFAUL
 /** Apply mode-gating: in `comment` mode, REQUEST_CHANGES is softened to COMMENT. */
 export function applyMode(verdict: Verdict, mode: ReviewMode): Verdict {
   if (mode === "comment" && verdict === "REQUEST_CHANGES") return "COMMENT"
+  // APPROVE and COMMENT pass through unchanged in both modes — the no-formal-
+  // approval guarantee for APPROVE lives solely in the VCS_EVENT map, not here.
   return verdict
 }
 

--- a/packages/opencode/test/altimate/review.test.ts
+++ b/packages/opencode/test/altimate/review.test.ts
@@ -211,6 +211,45 @@ describe("verdict", () => {
     expect(applyMode("REQUEST_CHANGES", "gate")).toBe("REQUEST_CHANGES")
   })
 
+  test("composition: computeIdealVerdict → applyMode → VCS_EVENT maps to the right event in both modes", () => {
+    // Adversarial composition test. The static-map test guards the table in
+    // isolation; this asserts the POSITIVE expected GitHub event for every
+    // verdict-producing finding-set across both modes, so a regression at any
+    // layer (computeIdealVerdict, applyMode, or the map) is caught — not just a
+    // resurrected APPROVE path. Each case lists [findings, gate event, comment event].
+    type Event = "COMMENT" | "REQUEST_CHANGES"
+    const cases: Array<{ findings: Finding[]; gate: Event; comment: Event }> = [
+      { findings: [], gate: "COMMENT", comment: "COMMENT" }, // ideal APPROVE → never a formal APPROVE
+      { findings: [mk("suggestion")], gate: "COMMENT", comment: "COMMENT" }, // ideal COMMENT
+      { findings: [mk("critical", "lineage_breakage")], gate: "REQUEST_CHANGES", comment: "COMMENT" }, // blocking critical
+      { findings: [mk("warning"), mk("warning"), mk("warning")], gate: "REQUEST_CHANGES", comment: "COMMENT" }, // risk pattern
+    ]
+    for (const { findings, gate, comment } of cases) {
+      const gateEnv = buildEnvelope({ findings, tier: "full", mode: "gate" })
+      const commentEnv = buildEnvelope({ findings, tier: "full", mode: "comment" })
+      expect(VCS_EVENT[gateEnv.verdict]).toBe(gate)
+      expect(VCS_EVENT[commentEnv.verdict]).toBe(comment)
+      // No mode/finding combination may ever emit a formal APPROVE.
+      expect(VCS_EVENT[gateEnv.verdict]).not.toBe("APPROVE")
+      expect(VCS_EVENT[commentEnv.verdict]).not.toBe("APPROVE")
+    }
+
+    // Separation of semantic verdict vs VCS event: with no findings in gate mode
+    // the internal verdict is still APPROVE (audit signal preserved), but the
+    // posted event is COMMENT — the bot never formally approves.
+    const approve = buildEnvelope({ findings: [], tier: "full", mode: "gate" })
+    expect(approve.verdict).toBe("APPROVE")
+    expect(approve.idealVerdict).toBe("APPROVE")
+    expect(VCS_EVENT[approve.verdict]).toBe("COMMENT")
+
+    // Comment mode preserves the would-have-blocked audit trail: idealVerdict is
+    // REQUEST_CHANGES while the gated verdict (and event) soften to COMMENT.
+    const softened = buildEnvelope({ findings: [mk("critical", "lineage_breakage")], tier: "full", mode: "comment" })
+    expect(softened.idealVerdict).toBe("REQUEST_CHANGES")
+    expect(softened.verdict).toBe("COMMENT")
+    expect(VCS_EVENT[softened.verdict]).toBe("COMMENT")
+  })
+
   test("envelope signs and verifies; tamper is detected", () => {
     const env = buildEnvelope({
       findings: [mk("critical", "pii_exposure")],


### PR DESCRIPTION
### What does this PR do?

Follow-up to #870. That PR mapped an `APPROVE` verdict to a GitHub **COMMENT** review event (so the bot never submits a formal approval that could satisfy branch protection), but left two loose ends this PR closes:

1. **Stale doc comments** in `packages/opencode/src/altimate/review/post-github.ts` still claimed *"in `gate` mode it maps the verdict to APPROVE/REQUEST_CHANGES"* and *"gate mode keeps APPROVE / REQUEST_CHANGES"* — contradicting the shipped behavior on a security-relevant path. Corrected to describe the actual contract (APPROVE → COMMENT always; comment mode also softens REQUEST_CHANGES → COMMENT; gate mode keeps REQUEST_CHANGES; `env.verdict` arrives pre-softened from `buildEnvelope`).

2. **The no-formal-approval invariant was only enforced at runtime.** `VCS_EVENT`'s value type still included `"APPROVE"`. Narrowed it to `"COMMENT" | "REQUEST_CHANGES"` so the invariant is now a **compile-time** guarantee — no future edit can resurrect a formal GitHub approval without breaking the build. The narrower union is still assignable to Octokit's `createReview` event param.

Also documents `applyMode`'s APPROVE/COMMENT passthrough, and adds a composition test asserting the positive expected GitHub event for every verdict-producing finding-set across both modes, plus the semantic-verdict-vs-VCS-event separation (gate + no findings → `verdict === "APPROVE"` but event `"COMMENT"`; comment-mode blocking critical → `idealVerdict === "REQUEST_CHANGES"`, `verdict === "COMMENT"`).

The type narrowing and test strengthening were findings from a multi-model consensus review (GPT 5.4, Gemini 3.1 Pro, GLM-5) incorporated during convergence.

- `packages/opencode/src/altimate/review/verdict.ts` — narrowed `VCS_EVENT` value type to exclude `"APPROVE"`; documented `applyMode` passthrough.
- `packages/opencode/src/altimate/review/post-github.ts` — corrected the two stale doc comments.
- `packages/opencode/test/altimate/review.test.ts` — added the composition / verdict-vs-event-separation test.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #871

### How did you verify your code works?

- `bun run typecheck` (tsgo `--noEmit`) — clean. The narrowed `VCS_EVENT` type compiles against `post-github.ts`'s `createReview({ event })` call.
- `bun test test/altimate/review.test.ts` — 66 pass, 0 fail (includes the new composition test).
- `bun test test/altimate/review.test.ts review-ci.test.ts review-dbt-patterns.test.ts review-rule-catalog.test.ts` — 118 pass, 0 fail.
- Marker guard (`script/upstream/analyze.ts --markers --base origin/main --strict`) — no upstream-shared files modified.
- `prettier --check` on all three changed files — clean (only the added test block; no unrelated reformatting).

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a compile-time guarantee that the reviewer never submits a formal GitHub approval and updates docs to reflect the APPROVE → COMMENT behavior. Adds tests to verify verdict-to-event mapping across modes.

- **Bug Fixes**
  - Updated docs in `packages/opencode/src/altimate/review/post-github.ts` to state: APPROVE always posts COMMENT; `comment` mode softens REQUEST_CHANGES → COMMENT; `gate` mode keeps REQUEST_CHANGES; `env.verdict` is pre-softened.
  - Narrowed `VCS_EVENT` in `packages/opencode/src/altimate/review/verdict.ts` to `"COMMENT" | "REQUEST_CHANGES"` to enforce no-formal-approve at compile time; documented `applyMode` passthrough.
  - Added a composition test in `packages/opencode/test/altimate/review.test.ts` that checks correct GitHub events across modes, preserves ideal verdicts for audit, and ensures no path emits `"APPROVE"`.

<sup>Written for commit 2dd495a5126238e308eec0c2507ec504ee193302. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified GitHub review posting semantics and verdict mode mappings.

* **Bug Fixes**
  * Enforced at compile-time that APPROVE verdicts never map to formal VCS approval events; they consistently map to COMMENT events instead.

* **Tests**
  * Added comprehensive tests verifying end-to-end verdict-to-event mapping across different review modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->