### PR TITLE
fix: two tests flaky under parallel CI load (S27 + trace snapshot)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,13 @@ jobs:
         # Cloud E2E tests (Snowflake, BigQuery, Databricks) auto-skip when
         # ALTIMATE_CODE_CONN_* env vars are not set. Docker E2E tests auto-skip
         # when Docker is not available. No exclusion needed — skipIf handles it.
-        # --timeout 30000: matches package.json "test" script; prevents 5s default
-        # from cutting off tests that run bun install or bootstrap git instances.
+        # --timeout 90000: the full suite (9500+ tests across 379 files) runs in
+        # one parallel bun process. Under CPU contention a handful of slower tests
+        # (real fs/spawn/git-bootstrap work) get starved and exceed a tight timeout
+        # NON-deterministically — different tests each run — failing CI with
+        # "timed out after Nms" (observed 32s/51s at the old 30s limit). 90s gives
+        # ~3x headroom over the worst observed, killing the resource-contention
+        # flakiness without masking genuinely-hung tests.
         #
         # Bun 1.3.x has a known segfault during process cleanup after all tests
         # pass (exit code 143/SIGTERM or 134/SIGABRT). We capture test output and
@@ -108,7 +113,7 @@ jobs:
         run: |
           # Redirect bun output to file, then cat it for CI visibility.
           # This avoids tee/pipe issues where SIGTERM kills tee before flush.
-          bun test --timeout 30000 > /tmp/test-output.txt 2>&1 || true
+          bun test --timeout 90000 > /tmp/test-output.txt 2>&1 || true
           cat /tmp/test-output.txt
 
           # Extract pass/fail counts from Bun test summary (e.g., " 5362 pass")

--- a/packages/opencode/test/altimate/tracing-adversarial-snapshot.test.ts
+++ b/packages/opencode/test/altimate/tracing-adversarial-snapshot.test.ts
@@ -37,6 +37,26 @@ const ZERO_STEP = {
   tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
 }
 
+// Poll the on-disk snapshot until it reaches `expected` status, instead of a
+// single fixed sleep. Snapshot writes are debounced/async, so a hardcoded delay
+// is too short under heavy parallel CI load (the snapshot hasn't flushed yet) →
+// flaky reads of a stale status. Polling is robust regardless of machine load.
+async function pollStatus(tracer: { getTracePath(): string | undefined }, expected: string, timeoutMs = 4000) {
+  const start = Date.now()
+  let last = "<none>"
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const snap = JSON.parse(await fs.readFile(tracer.getTracePath()!, "utf-8")) as TraceFile
+      last = snap.summary.status
+      if (last === expected) return snap
+    } catch {
+      /* file mid-write or not yet created — keep polling */
+    }
+    await new Promise((r) => setTimeout(r, 25))
+  }
+  throw new Error(`timed out after ${timeoutMs}ms waiting for status '${expected}' (last seen '${last}')`)
+}
+
 // ---------------------------------------------------------------------------
 // 1. buildTraceFile — snapshot isolation from mutations
 // ---------------------------------------------------------------------------
@@ -110,8 +130,6 @@ describe("buildTraceFile — snapshot isolation", () => {
   test("buildTraceFile shows 'running' status during active generation", async () => {
     const tracer = Recap.withExporters([new FileExporter(tmpDir)])
     tracer.startTrace("s-running", { prompt: "test" })
-    // Wait for initial snapshot to complete
-    await new Promise((r) => setTimeout(r, 50))
 
     tracer.logStepStart({ id: "1" })
     tracer.logToolCall({
@@ -120,15 +138,13 @@ describe("buildTraceFile — snapshot isolation", () => {
       state: { status: "completed", input: {}, output: "ok", time: { start: 1, end: 2 } },
     })
 
-    // Wait for snapshot — should show "running" since generation is in progress
-    await new Promise((r) => setTimeout(r, 50))
-    const snap = JSON.parse(await fs.readFile(tracer.getTracePath()!, "utf-8")) as TraceFile
+    // Snapshot should show "running" since generation is in progress.
+    const snap = await pollStatus(tracer, "running")
     expect(snap.summary.status).toBe("running")
 
-    // After finishing generation, should show "completed"
+    // After finishing generation, should show "completed".
     tracer.logStepFinish(ZERO_STEP)
-    await new Promise((r) => setTimeout(r, 50))
-    const snap2 = JSON.parse(await fs.readFile(tracer.getTracePath()!, "utf-8")) as TraceFile
+    const snap2 = await pollStatus(tracer, "completed")
     expect(snap2.summary.status).toBe("completed")
 
     await tracer.endTrace()

--- a/packages/opencode/test/session/real-tool-simulation.test.ts
+++ b/packages/opencode/test/session/real-tool-simulation.test.ts
@@ -12,6 +12,11 @@
 import { describe, expect, test, beforeEach, mock } from "bun:test"
 import { Dispatcher } from "../../src/altimate/native"
 import { Log } from "../../src/util/log"
+// Static import so resetShownSuggestions() targets the SAME module instance that
+// the tools (sql-analyze, schema-inspect) use. A dynamic `await import` here can
+// resolve to a different instance under parallel CI, leaving the real dedup Set
+// un-reset → flaky cross-test pollution of the progressive-suggestion state.
+import { PostConnectSuggestions } from "../../src/altimate/tools/post-connect-suggestions"
 
 Log.init({ print: false })
 
@@ -37,7 +42,6 @@ function makeCtx(agent = "builder") {
 // ---------------------------------------------------------------------------
 beforeEach(async () => {
   Dispatcher.reset()
-  const { PostConnectSuggestions } = await import("../../src/altimate/tools/post-connect-suggestions")
   PostConnectSuggestions.resetShownSuggestions()
 })
 
@@ -291,6 +295,7 @@ describe("REAL EXEC: sql_analyze tool", () => {
 
   test("S27: sql_analyze with parse error — no suggestion", async () => {
     Dispatcher.reset()
+    PostConnectSuggestions.resetShownSuggestions()
     Dispatcher.register("sql.analyze", async () => ({
       success: true, issues: [], issue_count: 0, confidence: "none",
       confidence_factors: [], error: "Parse error at line 1",


### PR DESCRIPTION
### What does this PR do?

Fixes two tests that pass locally but **fail consistently in CI's parallel run** (9474 tests / 378 files) — the repo's "no flaky tests under resource contention" case. They fail identically on three unrelated PRs (#854, #858, #863), blocking all of them; neither is caused by any feature change.

- **`real-tool-simulation` S27 (sql_analyze parse error):** the progressive-suggestion dedup state is a module-global `Set`. The `beforeEach` reset used a dynamic `await import`, which under parallel CI can resolve to a *different module instance* than the tool's static import — so the real Set is never reset and accumulates `sql_analyze` from S25/S26, leaving S27 with no suggestion. **Fix:** import `PostConnectSuggestions` statically (same instance the tools use); reset in S27 too.
- **`tracing-adversarial-snapshot` (shows 'running' status):** waited a fixed `50ms` for a *debounced async snapshot write* — too short under CI load → reads a stale snapshot. **Fix:** poll the on-disk status until expected (4s timeout) instead of a fixed sleep.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #879

### How did you verify your code works?

- Both affected files pass locally (61 tests); `tsgo` typecheck clean; marker check clean (test-only, no upstream-shared files).
- The real proof is CI on this branch going green (the failures only reproduce under CI's parallel load).

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two parallel-CI flaky tests by resetting `PostConnectSuggestions` via static import (and in S27) and by polling trace snapshot status (4s timeout) instead of a 50ms sleep. Also raises Bun test timeout from 30s to 90s to prevent load-induced timeouts. Closes #879.

<sup>Written for commit 79df91a34c221c5c3ae1301f96f17cd189148238. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability by replacing fixed delays with intelligent polling for snapshot verification
  * Enhanced test isolation to prevent cross-test flakiness and ensure consistent behavior across scenarios
* **Chores**
  * Increased test runner timeout in CI to reduce spurious test failures due to longer test execution
<!-- end of auto-generated comment: release notes by coderabbit.ai -->