### PR TITLE
fix: [#881] dbt_pr_review needs no altimate API key — correct stale tool descriptions

### DIFF
--- a/docs/docs/usage/dbt-pr-review.md
+++ b/docs/docs/usage/dbt-pr-review.md
@@ -110,6 +110,24 @@ Options:
 > clearly labeled, never mistaken for a full verdict. Run `dbt compile` first for
 > the full verdict.
 
+!!! question "Stuck in lint-only mode? It is **not** an API-key problem."
+    The deterministic engine (lineage, equivalence, PII, grade) runs fully
+    offline via the bundled native binary — **no altimate API key or account is
+    required** for any part of the verdict. A key is only ever needed for the
+    *optional* advisory LLM lane (see [below](#model--credentials-for-the-advisory-lane)),
+    and that lane can never block a verdict.
+
+    Lint-only means the **manifest didn't resolve**, not that auth failed. Check:
+
+    - **Path.** The default is `target/manifest.json` *relative to the project
+      root you run from*. If your manifest lives elsewhere, pass it explicitly:
+      `dbt_pr_review({ manifest_path: "target/manifest.json" })` (or `--manifest`
+      on the CLI), or set `manifestPath:` in `.altimate/review.yml`.
+    - **Freshness.** A stale manifest that predates the changed models can't
+      resolve them. Run `dbt compile` (or `dbt build`) to regenerate it before reviewing.
+    - **Working directory.** Run the review from the dbt project root so the
+      relative manifest path resolves.
+
 !!! note "Current limitations"
     - **BigQuery equivalence** on some compiled SQL (3-part backtick relations)
       is currently *undecidable* — the reviewer reports a warning ("could not

--- a/packages/opencode/src/altimate/tools/altimate-core-column-lineage.ts
+++ b/packages/opencode/src/altimate/tools/altimate-core-column-lineage.ts
@@ -5,7 +5,7 @@ import { isRecord, normalizeError } from "./response-normalization"
 
 export const AltimateCoreColumnLineageTool = Tool.define("altimate_core_column_lineage", {
   description:
-    "Trace schema-aware column lineage. Maps how columns flow through a query from source tables to output. Requires altimate_core.init() with API key. Provide schema_context or schema_path for accurate table/column resolution.",
+    "Trace schema-aware column lineage. Maps how columns flow through a query from source tables to output. Runs fully offline via the native engine — no API key or account required. Provide schema_context or schema_path for accurate table/column resolution.",
   parameters: z.object({
     sql: z.string().describe("SQL query to trace lineage for"),
     dialect: z.string().optional().describe("SQL dialect (e.g. snowflake, bigquery)"),

--- a/packages/opencode/src/altimate/tools/altimate-core-track-lineage.ts
+++ b/packages/opencode/src/altimate/tools/altimate-core-track-lineage.ts
@@ -4,7 +4,7 @@ import { Dispatcher } from "../native"
 
 export const AltimateCoreTrackLineageTool = Tool.define("altimate_core_track_lineage", {
   description:
-    "Track lineage across multiple SQL queries. Builds a combined lineage graph from a sequence of queries. Requires altimate_core.init() with API key. Provide schema_context or schema_path for accurate table/column resolution.",
+    "Track lineage across multiple SQL queries. Builds a combined lineage graph from a sequence of queries. Runs fully offline via the native engine — no API key or account required. Provide schema_context or schema_path for accurate table/column resolution.",
   parameters: z.object({
     queries: z.array(z.string()).describe("List of SQL queries to track lineage across"),
     schema_path: z.string().optional().describe("Path to YAML/JSON schema file"),

--- a/packages/opencode/test/altimate/altimate-core-tool-descriptions.test.ts
+++ b/packages/opencode/test/altimate/altimate-core-tool-descriptions.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Regression guard for issue #881.
+ *
+ * The native altimate-core engine (column lineage, track lineage, equivalence,
+ * grade, PII, …) runs fully offline via the bundled `@altimateai/altimate-core`
+ * napi binary — there is no `altimate_core.init` and no API-key gate in that
+ * path. Two tool descriptions used to falsely claim "Requires altimate_core.init()
+ * with API key", a stale leftover from the old Python bridge. The reviewer agent
+ * read those descriptions, concluded it needed an altimate API key, and degraded
+ * `dbt_pr_review` to lint-only mode.
+ *
+ * This test pins the descriptions so the false claim can never silently return.
+ */
+import { describe, test, expect } from "bun:test"
+import { AltimateCoreColumnLineageTool } from "../../src/altimate/tools/altimate-core-column-lineage"
+import { AltimateCoreTrackLineageTool } from "../../src/altimate/tools/altimate-core-track-lineage"
+
+describe("altimate-core tool descriptions (issue #881)", () => {
+  const tools = [
+    { name: "altimate_core_column_lineage", tool: AltimateCoreColumnLineageTool },
+    { name: "altimate_core_track_lineage", tool: AltimateCoreTrackLineageTool },
+  ]
+
+  for (const { name, tool } of tools) {
+    test(`${name} must not claim it requires an API key / altimate_core.init()`, async () => {
+      const { description } = await tool.init()
+      expect(description).toBeTruthy()
+      const lower = description.toLowerCase()
+      // These deterministic engine tools run offline — no auth in their call path.
+      // Guard the *false claim* (that a key/init is required), not the word
+      // "api key" itself: the corrected copy legitimately says "no API key required".
+      expect(lower).not.toContain("altimate_core.init")
+      expect(lower).not.toMatch(/requires?\b[^.]{0,40}\bapi key\b/)
+      // And it should positively state the offline / no-key reality.
+      expect(lower).toContain("no api key")
+    })
+  }
+})


### PR DESCRIPTION
### What does this PR do?

Fixes the confusing "needs an altimate AI API key" symptom reported in #881 when running the `dbt_pr_review` skill.

**Root cause:** The native altimate-core engine that backs `dbt_pr_review` (column lineage, track lineage, equivalence, PII, grade) runs **fully offline** via the bundled `@altimateai/altimate-core` napi binary — there is no `altimate_core.init` and no API-key gate anywhere in that path (verified in `native/altimate-core.ts` + `native/dispatcher.ts`). But two tool descriptions still carried a stale Python-bridge-era claim that they "Requires `altimate_core.init()` with API key". When the reviewer agent hits a **lint-only** run, it reads those descriptions and wrongly concludes it needs an API key — mis-diagnosing a *manifest-resolution* problem as an *auth* one.

**Changes:**
- `altimate-core-column-lineage.ts` / `altimate-core-track-lineage.ts`: drop the false API-key requirement; state the tools run offline via the native engine (no key/account).
- `docs/usage/dbt-pr-review.md`: add a troubleshooting note — lint-only means the dbt `manifest.json` did not resolve (wrong path, stale manifest, or wrong working directory), **never** an auth failure. The deterministic verdict needs no altimate key; only the optional advisory LLM lane does.
- `test/altimate/altimate-core-tool-descriptions.test.ts`: regression guard pinning both descriptions so the false claim can't silently return.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Issue for this PR

Closes #881

### How did you verify your code works?

- `bun run typecheck` — clean.
- New regression test `bun test test/altimate/altimate-core-tool-descriptions.test.ts` — 2 pass (also confirmed it would catch the old text via the `altimate_core.init` assertion).
- Verified the "no API key" claim against source: both handlers (`native/altimate-core.ts:426`/`:437`) call `core.columnLineage`/`core.trackLineage` directly; the dispatcher has no auth layer; schema resolution is local-only (`Schema.fromJson`).
- `prettier --check` clean on changed files; marker check reports no upstream-shared files touched.
- Multi-model review (Claude + GPT 5.4 + Gemini 3.1 Pro): unanimous APPROVE; the regression test was added per their shared suggestion.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the misleading “needs Altimate API key” message in `dbt_pr_review` by correcting tool descriptions and clarifying docs. Prevents false auth errors and explains that lint-only mode is a manifest resolution issue, not auth.

- Bug Fixes
  - Updated `altimate_core_column_lineage` and `altimate_core_track_lineage` descriptions to state they run fully offline via `@altimateai/altimate-core` (no API key/account required).
  - Added a troubleshooting note to `dbt_pr_review` docs: lint-only means the dbt `manifest.json` didn’t resolve; check path, freshness, and working directory.
  - Added `altimate-core-tool-descriptions.test.ts` to guard against reintroducing the false API-key/`altimate_core.init` claim.

<sup>Written for commit a1acf15c6e504bb40543d8c4f72cc94fbfe8c79d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified lint-only mode behavior and API key requirements in dbt PR review guide with expanded troubleshooting steps.
  * Updated tool descriptions for column lineage and track lineage tools to reflect offline-only operation.

* **Tests**
  * Added regression test for tool description accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->