### PR TITLE
test: [#883] harden #881 guard — loosen regex + sweep all altimate-core tool descriptions

### DIFF
--- a/packages/opencode/test/altimate/altimate-core-tool-descriptions.test.ts
+++ b/packages/opencode/test/altimate/altimate-core-tool-descriptions.test.ts
@@ -9,9 +9,13 @@
  * read those descriptions, concluded it needed an altimate API key, and degraded
  * `dbt_pr_review` to lint-only mode.
  *
- * This test pins the descriptions so the false claim can never silently return.
+ * This test pins the two corrected descriptions so the false claim can never
+ * silently return, and sweeps EVERY `altimate-core-*` tool source so the stale
+ * `altimate_core.init()` marker can't reappear in a newly added tool either.
  */
 import { describe, test, expect } from "bun:test"
+import { readdirSync, readFileSync } from "node:fs"
+import { join } from "node:path"
 import { AltimateCoreColumnLineageTool } from "../../src/altimate/tools/altimate-core-column-lineage"
 import { AltimateCoreTrackLineageTool } from "../../src/altimate/tools/altimate-core-track-lineage"
 
@@ -30,9 +34,34 @@ describe("altimate-core tool descriptions (issue #881)", () => {
       // Guard the *false claim* (that a key/init is required), not the word
       // "api key" itself: the corrected copy legitimately says "no API key required".
       expect(lower).not.toContain("altimate_core.init")
-      expect(lower).not.toMatch(/requires?\b[^.]{0,40}\bapi key\b/)
+      // Lazy `.*?` (no length cap) catches long-gap variants like
+      // "requires an API key for authentication" that a bounded pattern misses.
+      expect(lower).not.toMatch(/requires?\b.*?\bapi key\b/)
       // And it should positively state the offline / no-key reality.
       expect(lower).toContain("no api key")
+    })
+  }
+})
+
+/**
+ * Forward guard: no `altimate-core-*` tool may reintroduce the stale
+ * `altimate_core.init()` marker — the unambiguous fingerprint of the
+ * Python-bridge-era "needs an API key" claim. No native engine tool calls a
+ * dispatcher method by that name, so any occurrence is a regression. Scanning
+ * the source (not just the two known tools) auto-covers tools added later.
+ */
+describe("altimate-core tool sources must not reference altimate_core.init() (issue #881)", () => {
+  const toolsDir = join(import.meta.dir, "../../src/altimate/tools")
+  const files = readdirSync(toolsDir).filter((f) => f.startsWith("altimate-core-") && f.endsWith(".ts"))
+
+  test("there is at least one altimate-core tool to scan", () => {
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  for (const file of files) {
+    test(`${file} must not contain the stale altimate_core.init() marker`, () => {
+      const src = readFileSync(join(toolsDir, file), "utf8")
+      expect(src).not.toContain("altimate_core.init")
     })
   }
 })


### PR DESCRIPTION
### What does this PR do?

Hardens the #881 regression guard added in #882 (test-only — no runtime change).

1. **Loosens the false-claim regex** from `/requires?\b[^.]{0,40}\bapi key\b/` to `/requires?\b.*?\bapi key\b/`, so a long-gap variant like "requires an API key for authentication" can't slip through the 40-char cap. It still does **not** false-positive on the legitimate "no API key required" copy (there "required" follows "api key", so the require→api-key order never matches).
2. **Adds a source sweep** over every `altimate-core-*.ts` tool, asserting none contains the unambiguous `altimate_core.init` marker — the fingerprint of the old Python-bridge "needs an API key" claim. No native engine tool calls a dispatcher method by that name, so any occurrence is a regression. Scanning the source (rather than two hard-coded tools) auto-covers tools added later.

Raised by the multi-model review of #882 (DeepSeek V3.2 + Gemini 3.1 Pro).

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other: test hardening

### Issue for this PR

Closes #883

### How did you verify your code works?

- `bun test test/altimate/altimate-core-tool-descriptions.test.ts` → 30 pass / 0 fail (2 focused + 27-file sweep + 1 non-empty guard).
- Confirmed the sweep is false-positive-free: `grep -rn "altimate_core.init" packages/opencode/src/altimate/tools/altimate-core-*.ts` → 0 matches across all 27 files.
- Confirmed the loosened regex still passes against the shipped "no API key required" copy (positive `toContain("no api key")` assertion guards the corrected wording).
- `bun run typecheck` clean; `prettier --check` clean; marker check reports no upstream-shared files touched.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the #881 regression guard in tests by loosening the false-claim regex and adding a sweep across all `altimate-core-*` tools to block the old “needs an API key” marker. Test-only; no runtime changes. Addresses #883.

- **Bug Fixes**
  - Updated regex from `/requires?\b[^.]{0,40}\bapi key\b/` to `/requires?\b.*?\bapi key\b/` to catch long-gap variants; still ignores valid “no API key required”.
  - Added a source sweep over `altimate-core-*.ts` to assert no `altimate_core.init` occurrences, covering future tools automatically.

<sup>Written for commit 2f9236956bf6c3533c4b66e5d81c2e403ed91862. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced regression protection for altimate-core tool descriptions with improved validation of API key requirement documentation.
  * Added automated scanning to prevent stale documentation markers from being reintroduced in new tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->