### PR TITLE
fix: remove broken GitHub App install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ into CI pipelines and orchestration DAGs. Precision data tooling for any LLM.
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 [![Slack](https://img.shields.io/badge/Slack-Join%20Community-4A154B?logo=slack)](https://altimate.studio/join-agentic-data-engineering-slack)
 [![Docs](https://img.shields.io/badge/docs-docs.altimate.sh-blue)](https://docs.altimate.sh)
-[![Install GitHub App](https://img.shields.io/badge/GitHub-Install%20App-24292f?logo=github)](https://github.com/apps/altimate-code-agent/installations/new)
 [![Live dbt review](https://img.shields.io/badge/dbt-Live%20PR%20Demo-ff694b?logo=dbt)](https://github.com/AltimateAI/dbt-pr-review-demo/pulls)
 
 </div>
@@ -38,9 +37,7 @@ curl -fsSL https://www.altimate.sh/install | bash
 
 The curl install drops a single self-contained binary named `altimate`. The npm install exposes both `altimate` and `altimate-code` on PATH; the curl install only exposes `altimate`. Alpine Linux (musl) and Windows on ARM64 are not currently supported by the standalone binary — use `apk add gcompat` on Alpine, or use WSL on Windows-on-ARM.
 
-For GitHub, [install the Altimate Code App](https://github.com/apps/altimate-code-agent/installations/new)
-to select repositories for interactive agent tasks. Automatic dbt pull-request
-reviews use the deterministic GitHub Action documented below; see the
+Automatic dbt pull-request reviews use the deterministic GitHub Action documented below; see the
 [public demo PRs](https://github.com/AltimateAI/dbt-pr-review-demo/pulls) before
 installing it in your own repository.
 

--- a/docs/docs/usage/dbt-pr-review.md
+++ b/docs/docs/usage/dbt-pr-review.md
@@ -1,13 +1,11 @@
 # dbt PR Review
 
 [**See live review PRs**](https://github.com/AltimateAI/dbt-pr-review-demo/pulls)
-·
-[**Install the GitHub App**](https://github.com/apps/altimate-code-agent/installations/new)
 
 The public demo is a zero-secret DuckDB project with open PRs for broken joins,
 removed tests, PII exposure, `SELECT *`, unsafe incremental models, and a safe
-refactor. The GitHub App handles interactive repository tasks; the automatic
-review on every pull request is installed with the Action below.
+refactor. The automatic review on every pull request is installed with the
+Action below.
 
 AI code review specialized for dbt/SQL. `dbt-pr-review` produces a single,
 **signed** verdict on a pull request — `APPROVE`, `COMMENT`, or `REQUEST_CHANGES`

--- a/github/README.md
+++ b/github/README.md
@@ -56,12 +56,11 @@ Run the following command in the terminal from your GitHub repo:
 altimate-code github install
 ```
 
-This will walk you through installing the GitHub app, creating the workflow, and setting up secrets.
+This will walk you through installing the GitHub app, creating the workflow, and setting up secrets. The GitHub App install URL is deployment-specific; set `ALTIMATE_CODE_GITHUB_APP_INSTALL_URL` before running this command.
 
 ### Manual Setup
 
-1. [Install the GitHub app](https://github.com/apps/altimate-code-agent/installations/new) and select the target repository.
-2. Add the following workflow file to `.github/workflows/altimate-code.yml` in your repo. Set the appropriate `model` and required API keys in `env`.
+1. Add the following workflow file to `.github/workflows/altimate-code.yml` in your repo. Set the appropriate `model` and required API keys in `env`.
 
    ```yml
    name: altimate-code
@@ -97,7 +96,7 @@ This will walk you through installing the GitHub app, creating the workflow, and
              use_github_token: true
    ```
 
-3. Store the API keys in secrets. In your organization or project **settings**, expand **Secrets and variables** on the left and select **Actions**. Add the required API keys.
+2. Store the API keys in secrets. In your organization or project **settings**, expand **Secrets and variables** on the left and select **Actions**. Add the required API keys.
 
 ## Support
 

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -141,7 +141,7 @@ type IssueQueryResponse = {
 const AGENT_USERNAME = "altimate-code-agent[bot]"
 const AGENT_REACTION = "eyes"
 const WORKFLOW_FILE = ".github/workflows/altimate-code.yml"
-export const GITHUB_APP_INSTALL_URL = "https://github.com/apps/altimate-code-agent/installations/new"
+export const GITHUB_APP_INSTALL_URL = process.env.ALTIMATE_CODE_GITHUB_APP_INSTALL_URL ?? ""
 // altimate_change end
 
 // Event categories for routing
@@ -335,6 +335,12 @@ export const GithubInstallCommand = cmd({
             // Open browser
             // altimate_change start — upstream_fix: GitHub App slug is altimate-code-agent
             const url = GITHUB_APP_INSTALL_URL
+            if (!url) {
+              s.stop(
+                "GitHub app installation URL is not configured. Set ALTIMATE_CODE_GITHUB_APP_INSTALL_URL to your GitHub App install URL.",
+              )
+              throw new UI.CancelledError()
+            }
             // altimate_change end
             const command =
               process.platform === "darwin"

--- a/packages/opencode/test/cli/github-action.test.ts
+++ b/packages/opencode/test/cli/github-action.test.ts
@@ -3,8 +3,8 @@ import { extractResponseText, formatPromptTooLargeError, GITHUB_APP_INSTALL_URL 
 import type { MessageV2 } from "../../src/session/message-v2"
 import { SessionID, MessageID, PartID } from "../../src/session/schema"
 
-test("GitHub App install URL opens the repository-selection flow", () => {
-  expect(GITHUB_APP_INSTALL_URL).toBe("https://github.com/apps/altimate-code-agent/installations/new")
+test("GitHub App install URL is not hardcoded to a public slug", () => {
+  expect(GITHUB_APP_INSTALL_URL).toBe("")
 })
 
 // Helper to create minimal valid parts


### PR DESCRIPTION
## Summary

- remove the nonexistent public `altimate-code-agent` GitHub App links from README/docs
- stop hardcoding a public GitHub App URL in the CLI
- allow private deployments to provide `ALTIMATE_CODE_GITHUB_APP_INSTALL_URL` explicitly
- fail clearly when the CLI install flow needs an app URL but none is configured

## Validation

- `rg -n "github.com/apps/altimate-code-agent|installations/new|Install GitHub App|Install the GitHub App" README.md docs github packages/opencode/src/cli/cmd/github.ts packages/opencode/test/cli/github-action.test.ts` returned no matches
- `bun test --timeout 30000 test/cli/github-action.test.ts test/skill/release-v0.8.5-adversarial.test.ts`
- `bun run typecheck`

Context: PR #900 was already merged and released. GitHub returns 404 for `/apps/altimate-code-agent`, so this PR removes the broken public link instead of replacing it with another guessed URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stop relying on a hardcoded GitHub App installation URL; CLI now validates the install URL and halts with a clear configuration message if unset.

* **Documentation**
  * Removed/updated explicit GitHub App install links and adjusted installation instructions across READMEs and docs.

* **Tests**
  * Updated tests to expect the install URL value is not hardcoded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->