### PR TITLE
Fix dbt YAML review file classification

### DIFF
--- a/packages/opencode/src/altimate/review/diff-filter.ts
+++ b/packages/opencode/src/altimate/review/diff-filter.ts
@@ -58,6 +58,7 @@ export type DbtFileKind =
 /** Classify a changed file by its role in a dbt project. */
 export function classifyDbtFile(path: string): DbtFileKind {
   const p = path.replace(/\\/g, "/").toLowerCase()
+  const isYaml = p.endsWith(".yml") || p.endsWith(".yaml")
   if (/(^|\/)(dbt_project|profiles|packages|dependencies)\.ya?ml$/.test(p)) return "project_config"
   if (/(^|\/)macros\//.test(p)) return "macro"
   if (/(^|\/)snapshots\//.test(p)) return "snapshot"
@@ -66,7 +67,8 @@ export function classifyDbtFile(path: string): DbtFileKind {
   if (/(^|\/)analyses\//.test(p)) return "analysis"
   if (/(^|\/)models\//.test(p) && p.endsWith(".py")) return "python_model"
   if (/(^|\/)models\//.test(p) && p.endsWith(".sql")) return "model_sql"
-  if (p.endsWith(".yml") || p.endsWith(".yaml")) return "schema_yml"
+  if (isYaml && /(^|\/)(models|snapshots|seeds|tests)\//.test(p)) return "schema_yml"
+  if (isYaml && /(^|\/)(_?schema|_?models|_?sources|sources|properties)\.ya?ml$/.test(p)) return "schema_yml"
   return "other"
 }
 

--- a/packages/opencode/test/altimate/review-dbt-patterns.test.ts
+++ b/packages/opencode/test/altimate/review-dbt-patterns.test.ts
@@ -146,6 +146,18 @@ describe("dbt-patterns detectors", () => {
     expect(has(f, "test_coverage")).toBe(true)
   })
 
+  test("workflow YAML is not treated as schema.yml", () => {
+    const f = detectSchemaYmlPatterns(
+      {
+        path: ".github/workflows/dbt-pr-review.yml",
+        status: "modified",
+        diff: "-          - name: order_id\n-            description: One row per order",
+      },
+      DEFAULT_RUBRIC,
+    )
+    expect(f.length).toBe(0)
+  })
+
   test("benign additive column produces NO dbt-pattern finding (precision)", () => {
     const sql = `select id, upper(status) as status_upper from {{ ref('x') }}`
     const f = detectModelPatterns(


### PR DESCRIPTION
PINEAPPLE

## Summary
- classify only dbt resource YAML and conventional dbt property YAML as schema.yml
- avoid treating non-dbt YAML, such as GitHub workflow files, as dbt schema metadata
- add a regression test for the workflow YAML false positive

## Validation
- bun test --timeout 30000 test/altimate/review-dbt-patterns.test.ts
- bun run typecheck
- pre-push bun turbo typecheck passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML file classification accuracy. YAML files are now properly categorized as schema files only when located in specific directories or matching schema-related naming patterns. YAML files in workflow directories are no longer incorrectly flagged as schema changes.

* **Tests**
  * Added test coverage to ensure YAML files in workflow directories are correctly excluded from schema file detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->