### PR TITLE
fix: pin release-v0.8.5 gate to constant version (unblocks all PRs)

### DIFF
--- a/packages/opencode/test/skill/release-v0.8.5-adversarial.test.ts
+++ b/packages/opencode/test/skill/release-v0.8.5-adversarial.test.ts
@@ -228,10 +228,15 @@ describe("v0.8.5 adversarial - composite action", () => {
   })
 
   test("docs point at the action patch, not the already-published broken tag", async () => {
+    // This is the 0.8.5 release gate: it asserts the 0.8.5 docs reference the
+    // patched action tag (@v0.8.5) and NOT the already-published broken @v0.8.4.
+    // It must stay pinned to the constant "0.8.5" — earlier this derived `version`
+    // from the changelog's TOP entry, which later releases (0.8.6+) move, breaking
+    // the gate on every subsequent release. Assert the 0.8.5 entry EXISTS in the
+    // changelog rather than that it is the latest.
+    const version = "0.8.5"
     const changelog = await fs.readFile(path.join(repoRoot, "CHANGELOG.md"), "utf8")
-    // Match whether the entry is still "Unreleased" or has been date-stamped at release.
-    const version = changelog.match(/^## \[(\d+\.\d+\.\d+)\] - (?:Unreleased|\d{4}-\d{2}-\d{2})$/m)?.[1]
-    expect(version).toBe("0.8.5")
+    expect(changelog).toContain(`## [${version}]`)
 
     for (const relative of ["docs/docs/usage/dbt-pr-review.md", "github/review/examples/altimate-ingestion.yml"]) {
       const content = await fs.readFile(path.join(repoRoot, relative), "utf8")


### PR DESCRIPTION
### What does this PR do?

Fixes a **stale release-gate test** that is broken on `main` and blocks every current PR (observed on #918 and #854).

`release-v0.8.5-adversarial.test.ts` → "docs point at the action patch…" derived the version from the CHANGELOG's **top entry** and asserted it equals hardcoded `"0.8.5"`. Once 0.8.6 shipped, the top entry became `0.8.6` → the assertion permanently fails (`Expected "0.8.5", Received "0.8.6"`). Only the 0.8.5 gate has this pattern (0.8.6's does not).

The 0.8.5 gate is release-specific (docs must reference the patched `@v0.8.5`, not the broken `@v0.8.4`). Fix: pin to the constant `"0.8.5"` and assert that changelog entry **exists** rather than that it is the latest. The docs assertions are unchanged and already pass.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Issue for this PR

Closes #922

### How did you verify your code works?

- `release-v0.8.5-adversarial.test.ts` now passes (13/13; was failing on the version assertion).
- Confirmed the breakage is pre-existing on `main` (independent of feature work) and that only the 0.8.5 gate uses the changelog-top pattern.
- Marker guard clean (test-only change).

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the v0.8.5 release-gate test to "0.8.5" and assert the changelog entry exists, fixing a failure on main and unblocking all PRs.

- **Bug Fixes**
  - Stop deriving the version from the CHANGELOG’s top entry; use "0.8.5" and check for `## [0.8.5]`.
  - Keep the docs checks as-is to ensure they reference `@v0.8.5` (not `@v0.8.4`).

<sup>Written for commit c01e0bab5766ca588618446729a82bbb1e3a7c84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test verification for changelog entries to explicitly validate version-specific header presence in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->