### PR TITLE
serve: log trace output directory on startup

### DIFF
--- a/packages/opencode/src/altimate/observability/trace-consumer.ts
+++ b/packages/opencode/src/altimate/observability/trace-consumer.ts
@@ -58,6 +58,12 @@ export class TraceConsumer {
   private exporters: TraceExporter[] | undefined
   private maxFiles: number | undefined
 
+  getTraceDirectory(): string | undefined {
+    const fileExporter = this.exporters?.find((exp) => exp instanceof FileExporter)
+
+    return fileExporter instanceof FileExporter ? fileExporter.getDir() : undefined
+  }
+
   /**
    * Optional overrides bypass config loading entirely — used by tests to
    * inject a FileExporter pointed at a temp directory.
@@ -394,6 +400,15 @@ export function subscribeTraceConsumer(
 
   const loopPromise = (async () => {
     await consumer.loadConfig()
+
+    const traceDir = consumer.getTraceDirectory()
+
+    if (traceDir) {
+      Log.Default.info("[tracing] session traces", {
+        directory: traceDir,
+      })
+    }
+
     // Exponential backoff on repeated failure so a durably-down stream doesn't
     // hot-loop; reset to the base delay after a successful subscription.
     let backoff = BASE_BACKOFF_MS


### PR DESCRIPTION
## Summary

Logs the resolved trace output directory when the trace consumer starts.

This makes session tracing discoverable in `altimate serve` by surfacing where trace files are being written at startup.

## Changes

* Added `TraceConsumer.getTraceDirectory()`
* Logged the resolved trace directory after `loadConfig()` completes
* Only logs when a `FileExporter` is configured

Example log output:

```text
[tracing] session traces directory=/path/to/traces
```

## Validation

* `bun run typecheck`
* Verified typecheck passes successfully
* No behavior changes outside tracing startup logging

Fixes #916


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On startup, `altimate serve` now logs the resolved session trace directory so you can quickly find where trace files are written. The log appears only when a FileExporter is configured.

<sup>Written for commit a6d3617b11ec899085490888a6b340ced8ad19eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced trace observability with improved startup logging that displays the configured trace output directory location when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->