### PR TITLE
fix: bubble real dbt show error instead of generic "Could not parse"

### DIFF
--- a/packages/dbt-tools/src/dbt-cli.ts
+++ b/packages/dbt-tools/src/dbt-cli.ts
@@ -222,9 +222,9 @@ export async function execDbtShow(sql: string, limit?: number) {
   if (limit !== undefined) args.push("--limit", String(limit))
 
   let lines: Record<string, unknown>[]
-  // AI-7082: capture the run() error so we can bubble the real dbt failure
-  // up if all parse tiers fail; the generic "Could not parse" alone misleads
-  // callers into treating structural project errors as transient.
+  // Capture the run() error so we can bubble the real dbt failure up if all
+  // parse tiers fail; the generic "Could not parse" alone misleads callers
+  // into treating structural project errors as transient.
   let primaryRunError: ExecFileError | undefined
   try {
     const { stdout } = await run(args)
@@ -305,8 +305,8 @@ export async function execDbtShow(sql: string, limit?: number) {
     plainRunError = e as ExecFileError
   }
 
-  // AI-7082: if either run() rejected, dbt actually crashed — surface the real
-  // error instead of the generic "Could not parse" message.
+  // If either run() rejected, dbt actually crashed — surface the real error
+  // instead of the generic "Could not parse" message.
   const realError = extractDbtError(lines, primaryRunError, plainRunError)
   if (realError) {
     throw new Error(`dbt show failed: ${realError}`)
@@ -318,7 +318,7 @@ export async function execDbtShow(sql: string, limit?: number) {
   )
 }
 
-/** AI-7082: shape of an execFile rejection — carries stdout/stderr alongside message. */
+/** Shape of an execFile rejection — carries stdout/stderr alongside message. */
 interface ExecFileError extends Error {
   stdout?: string
   stderr?: string
@@ -326,7 +326,7 @@ interface ExecFileError extends Error {
 }
 
 /**
- * AI-7082: pick the best human-readable error from a failed `dbt show` invocation.
+ * Pick the best human-readable error from a failed `dbt show` invocation.
  *
  * Preference order:
  *   1. A structured `level: "error"` event in the JSON log (dbt's own error msg).

--- a/packages/dbt-tools/src/dbt-cli.ts
+++ b/packages/dbt-tools/src/dbt-cli.ts
@@ -222,11 +222,16 @@ export async function execDbtShow(sql: string, limit?: number) {
   if (limit !== undefined) args.push("--limit", String(limit))
 
   let lines: Record<string, unknown>[]
+  // AI-7082: capture the run() error so we can bubble the real dbt failure
+  // up if all parse tiers fail; the generic "Could not parse" alone misleads
+  // callers into treating structural project errors as transient.
+  let primaryRunError: ExecFileError | undefined
   try {
     const { stdout } = await run(args)
     lines = parseJsonLines(stdout)
-  } catch {
-    lines = []
+  } catch (e) {
+    primaryRunError = e as ExecFileError
+    lines = parseJsonLines(primaryRunError.stdout ?? "")
   }
 
   // --- Tier 1: known field paths ---
@@ -281,6 +286,7 @@ export async function execDbtShow(sql: string, limit?: number) {
   }
 
   // --- Tier 3: plain text fallback (ASCII table) ---
+  let plainRunError: ExecFileError | undefined
   try {
     const plainArgs = ["show", "--inline", sql]
     if (limit !== undefined) plainArgs.push("--limit", String(limit))
@@ -295,13 +301,64 @@ export async function execDbtShow(sql: string, limit?: number) {
         compiledSql: sql,
       }
     }
-  } catch {
-    // Plain text dbt show also failed — fall through to error below
+  } catch (e) {
+    plainRunError = e as ExecFileError
+  }
+
+  // AI-7082: if either run() rejected, dbt actually crashed — surface the real
+  // error instead of the generic "Could not parse" message.
+  const realError = extractDbtError(lines, primaryRunError, plainRunError)
+  if (realError) {
+    throw new Error(`dbt show failed: ${realError}`)
   }
 
   throw new Error(
     "Could not parse dbt show output in any format (JSON, heuristic, or plain text). " +
       `Got ${lines.length} JSON lines.`,
+  )
+}
+
+/** AI-7082: shape of an execFile rejection — carries stdout/stderr alongside message. */
+interface ExecFileError extends Error {
+  stdout?: string
+  stderr?: string
+  code?: number | string
+}
+
+/**
+ * AI-7082: pick the best human-readable error from a failed `dbt show` invocation.
+ *
+ * Preference order:
+ *   1. A structured `level: "error"` event in the JSON log (dbt's own error msg).
+ *   2. Stderr from the JSON-mode run.
+ *   3. Stderr from the plain-text-mode run.
+ *   4. The exception message itself.
+ *
+ * Returns undefined if neither run rejected — caller falls back to the generic
+ * "Could not parse" message, which is correct when dbt exited 0 but emitted
+ * something we can't decode.
+ */
+function extractDbtError(
+  lines: Record<string, unknown>[],
+  primary?: ExecFileError,
+  plain?: ExecFileError,
+): string | undefined {
+  if (!primary && !plain) return undefined
+
+  const errorEvent = lines.find(
+    (l: any) => l.info?.level === "error" || l.level === "error",
+  ) as any
+  const structuredMsg = errorEvent?.info?.msg ?? errorEvent?.msg
+
+  const primaryStderr = primary?.stderr?.toString().trim()
+  const plainStderr = plain?.stderr?.toString().trim()
+
+  return (
+    (typeof structuredMsg === "string" && structuredMsg.length > 0 ? structuredMsg : undefined) ??
+    (primaryStderr && primaryStderr.length > 0 ? primaryStderr : undefined) ??
+    (plainStderr && plainStderr.length > 0 ? plainStderr : undefined) ??
+    primary?.message ??
+    plain?.message
   )
 }
 

--- a/packages/dbt-tools/test/dbt-cli.test.ts
+++ b/packages/dbt-tools/test/dbt-cli.test.ts
@@ -150,9 +150,9 @@ describe("execDbtShow", () => {
     await expect(execDbtShow("SELECT 1")).rejects.toThrow("Could not parse dbt show output in any format")
   })
 
-  // --- AI-7082: bubble real dbt error instead of generic "Could not parse" ---
+  // --- Bubble real dbt error instead of generic "Could not parse" ---
 
-  test("AI-7082: surfaces real dbt stderr when run fails", async () => {
+  test("surfaces real dbt stderr when run fails", async () => {
     mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: Function) => {
       const err: any = new Error("Command failed: dbt show --inline ...")
       err.code = 1
@@ -166,7 +166,7 @@ describe("execDbtShow", () => {
     await expect(execDbtShow("SELECT 1")).rejects.toThrow(/dbt show failed/)
   })
 
-  test("AI-7082: prefers structured error event in JSON log over raw stderr", async () => {
+  test("prefers structured error event in JSON log over raw stderr", async () => {
     const errorLog = JSON.stringify({
       info: {
         level: "error",
@@ -184,7 +184,7 @@ describe("execDbtShow", () => {
     await expect(execDbtShow("SELECT 1")).rejects.toThrow(/Compilation Error.*Model 'foo'/)
   })
 
-  test("AI-7082: does not surface generic 'Could not parse' when dbt actually crashed", async () => {
+  test("does not surface generic 'Could not parse' when dbt actually crashed", async () => {
     mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: Function) => {
       const err: any = new Error("Command failed")
       err.code = 2
@@ -196,7 +196,7 @@ describe("execDbtShow", () => {
     await expect(execDbtShow("SELECT 1")).rejects.not.toThrow(/Could not parse dbt show output/)
   })
 
-  test("AI-7082: preserves generic 'Could not parse' when dbt exited 0 but output unparseable", async () => {
+  test("preserves generic 'Could not parse' when dbt exited 0 but output unparseable", async () => {
     // Existing behavior — dbt didn't crash, we just couldn't decode its output.
     mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: Function) => {
       cb(null, "some unparseable output", "")
@@ -205,7 +205,7 @@ describe("execDbtShow", () => {
     await expect(execDbtShow("SELECT 1")).rejects.toThrow("Could not parse dbt show output in any format")
   })
 
-  test("AI-7082: falls back to error message when stderr is empty", async () => {
+  test("falls back to error message when stderr is empty", async () => {
     mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: Function) => {
       const err: any = new Error("spawn ENOENT")
       err.code = "ENOENT"

--- a/packages/dbt-tools/test/dbt-cli.test.ts
+++ b/packages/dbt-tools/test/dbt-cli.test.ts
@@ -149,6 +149,73 @@ describe("execDbtShow", () => {
 
     await expect(execDbtShow("SELECT 1")).rejects.toThrow("Could not parse dbt show output in any format")
   })
+
+  // --- AI-7082: bubble real dbt error instead of generic "Could not parse" ---
+
+  test("AI-7082: surfaces real dbt stderr when run fails", async () => {
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: Function) => {
+      const err: any = new Error("Command failed: dbt show --inline ...")
+      err.code = 1
+      err.stdout = ""
+      err.stderr =
+        "Runtime Error: Failed to read package: No dbt_project.yml found at expected path dbt_packages/dbt_utils/dbt_project.yml"
+      cb(err, err.stdout, err.stderr)
+    })
+
+    await expect(execDbtShow("SELECT 1")).rejects.toThrow(/Failed to read package/)
+    await expect(execDbtShow("SELECT 1")).rejects.toThrow(/dbt show failed/)
+  })
+
+  test("AI-7082: prefers structured error event in JSON log over raw stderr", async () => {
+    const errorLog = JSON.stringify({
+      info: {
+        level: "error",
+        msg: "Compilation Error: Model 'foo' depends on a node named 'bar' which was not found",
+      },
+    })
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: Function) => {
+      const err: any = new Error("Command failed")
+      err.code = 1
+      err.stdout = errorLog
+      err.stderr = "exit status 1"
+      cb(err, err.stdout, err.stderr)
+    })
+
+    await expect(execDbtShow("SELECT 1")).rejects.toThrow(/Compilation Error.*Model 'foo'/)
+  })
+
+  test("AI-7082: does not surface generic 'Could not parse' when dbt actually crashed", async () => {
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: Function) => {
+      const err: any = new Error("Command failed")
+      err.code = 2
+      err.stdout = ""
+      err.stderr = "Database Error: connection refused"
+      cb(err, err.stdout, err.stderr)
+    })
+
+    await expect(execDbtShow("SELECT 1")).rejects.not.toThrow(/Could not parse dbt show output/)
+  })
+
+  test("AI-7082: preserves generic 'Could not parse' when dbt exited 0 but output unparseable", async () => {
+    // Existing behavior — dbt didn't crash, we just couldn't decode its output.
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: Function) => {
+      cb(null, "some unparseable output", "")
+    })
+
+    await expect(execDbtShow("SELECT 1")).rejects.toThrow("Could not parse dbt show output in any format")
+  })
+
+  test("AI-7082: falls back to error message when stderr is empty", async () => {
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: Function) => {
+      const err: any = new Error("spawn ENOENT")
+      err.code = "ENOENT"
+      err.stdout = ""
+      err.stderr = ""
+      cb(err, "", "")
+    })
+
+    await expect(execDbtShow("SELECT 1")).rejects.toThrow(/spawn ENOENT|dbt show failed/)
+  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #932

## Summary

`altimate-dbt execute --query "..."` (which calls `execDbtShow` in `packages/dbt-tools/src/dbt-cli.ts`) swallows the real error from `dbt show` and surfaces a misleading generic message:

```json
{
  "error": "Could not parse dbt show output in any format (JSON, heuristic, or plain text). Got 0 JSON lines.",
  "fix": "Run: altimate-dbt doctor"
}
```

But running `dbt show` directly produces a clear actionable error, e.g.:

```
Runtime Error: Failed to read package: No dbt_project.yml found at expected path dbt_packages/dbt_utils/dbt_project.yml
```

The real error never reaches the caller. Agents read "could not parse" as transient and retry alternate commands instead of bailing out — burns budget on a project that is structurally broken.

## Root cause

`packages/dbt-tools/src/dbt-cli.ts` has two adjacent catch blocks in `execDbtShow` that swallow the `run()` rejection silently:

```ts
// ~line 224 — Tier 1 JSON attempt
try { const { stdout } = await run(args); lines = parseJsonLines(stdout) }
catch { lines = [] }            // ← discards err.stderr

// ~line 298 — Tier 3 plain-text fallback
try { ... await run(plainArgs) ... }
catch { /* fall through */ }    // ← also discards err.stderr

throw new Error("Could not parse dbt show output in any format (JSON, heuristic, or plain text). ...")
```

When `execFile` rejects with a non-zero exit, the error object carries `.stderr` and `.stdout`. Both catches discard them. The generic "Could not parse" message was designed for the case *"dbt exited 0 but the output is unparseable"* — but it currently fires for the *"dbt actually crashed"* case as well, conflating two very different failure modes.

## Fix

- Capture the `execFile` rejection on both tiers (`primaryRunError`, `plainRunError`).
- Recover any partial JSON log lines from the failed run's `stdout` — dbt with `--log-format json` emits structured `level: "error"` events before exit.
- Before the generic throw, call `extractDbtError(...)` which picks (in order): structured error event > primary stderr > plain stderr > exception message.
- If `extractDbtError` returns anything, surface it as `dbt show failed: <real msg>`. Fall through to the generic message only when both runs exited 0.

Net: ~45 lines in `dbt-cli.ts` (helper + 2 small guard sites), 6 new test cases.

## Scope

Limited to `execDbtShow`. `execDbtCompile` and `execDbtCompileInline` share the same `catch { lines = [] }` pattern but have additional fallback paths (manifest.json for compile, no-args plain-text retry for inline) that reduce caller impact. Worth addressing in a follow-up PR if telemetry shows masking there too — kept out of this PR to keep the diff focused.

## Test plan

- [x] `bun test test/dbt-cli.test.ts` → 24/24 pass (18 pre-existing + 6 new)
- [x] Generic "Could not parse" message still surfaces when `dbt show` exits 0 but emits unparseable output (regression guard preserved)
- [x] Real stderr from a crashing `dbt show` surfaces in the thrown error
- [x] Structured `level: "error"` event preferred over raw stderr when both present
- [x] `spawn ENOENT` (no dbt binary) surfaces clearly
- [ ] Reviewer: smoke against a real project with a corrupted `dbt_packages/<pkg>/dbt_project.yml`; expect to see the real "Failed to read package" message, not "Could not parse"

## Links

- Issue: #932
- Catalog entry: `03-issues-and-fixes.md` Issue #14
- Discovered while investigating the auto-deps clobber on a sister repo ([altimate-dbt-integration#120](https://github.com/AltimateAI/altimate-dbt-integration/pull/120)); the masked error happened to be a corrupted `dbt_packages/` fixture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * dbt error messages now display actual error details instead of generic fallback messages
  * Enhanced error reporting to prioritize structured error information from dbt logs when available
  * Improved error capture and synthesis across execution modes, providing more accurate failure diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->