### PR TITLE
fix: skip stdin read when positional message provided

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -430,7 +430,16 @@ export const RunCommand = cmd({
       message = [extractedParts.join("\n\n"), message].filter(Boolean).join("\n\n")
     }
 
-    if (!process.stdin.isTTY) message += "\n" + (await Bun.stdin.text())
+    // Only read stdin when no positional message was provided. The original
+    // unconditional `!isTTY` guard matched a non-TTY parent process even when
+    // it inherited (but never closed) stdin — `Bun.stdin.text()` would then
+    // wait forever for an EOF that never arrives, producing a silent 0% CPU
+    // hang for any subprocess / CI / agent caller that passed a positional
+    // message. Positional-overrides-stdin matches conventional CLI semantics;
+    // pipe-only invocations without a positional arg still work as before.
+    if (!process.stdin.isTTY && message.trim().length === 0) {
+      message += "\n" + (await Bun.stdin.text())
+    }
 
     if (message.trim().length === 0 && !args.command) {
       UI.error("You must provide a message or a command")

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -29,6 +29,7 @@ import { TodoWriteTool } from "../../tool/todo"
 import { Locale } from "../../util/locale"
 import { Tracer, FileExporter, HttpExporter, type TraceExporter } from "../../altimate/observability/tracing"
 import { Config } from "../../config/config"
+import { readStdinIfAvailable, assembleStdinMessage } from "../../util/stdin"
 
 type ToolProps<T extends Tool.Info> = {
   input: Tool.InferParameters<T>
@@ -430,16 +431,9 @@ export const RunCommand = cmd({
       message = [extractedParts.join("\n\n"), message].filter(Boolean).join("\n\n")
     }
 
-    // Only read stdin when no positional message was provided. The original
-    // unconditional `!isTTY` guard matched a non-TTY parent process even when
-    // it inherited (but never closed) stdin — `Bun.stdin.text()` would then
-    // wait forever for an EOF that never arrives, producing a silent 0% CPU
-    // hang for any subprocess / CI / agent caller that passed a positional
-    // message. Positional-overrides-stdin matches conventional CLI semantics;
-    // pipe-only invocations without a positional arg still work as before.
-    if (!process.stdin.isTTY && message.trim().length === 0) {
-      message += "\n" + (await Bun.stdin.text())
-    }
+    // Read piped/redirected stdin without wedging on inherited-but-idle fds.
+    // See `src/util/stdin.ts` for the failure mode and the first-byte-race fix.
+    message = assembleStdinMessage(message, await readStdinIfAvailable())
 
     if (message.trim().length === 0 && !args.command) {
       UI.error("You must provide a message or a command")

--- a/packages/opencode/src/util/stdin.ts
+++ b/packages/opencode/src/util/stdin.ts
@@ -99,13 +99,12 @@ export async function readStdinIfAvailable(deps: ReadStdinDeps = {}): Promise<st
 
   if (result === "") {
     // An empty result can come from the timer firing (slow producer), a
-    // clean `end` with zero bytes (intentionally empty pipe), or an error
-    // event. Wording is cause-neutral; the env-var tip is still useful for
-    // the slow-producer case and harmless otherwise.
-    warn(
-      `altimate-code: stdin produced no data; proceeding without it. ` +
-        `Tip: set ${STDIN_TIMEOUT_ENV}=N (ms) higher if upstream is a slow producer.`,
-    )
+    // clean `end` with zero bytes (intentionally empty pipe), or a stream
+    // error. The previous version included a `set ${STDIN_TIMEOUT_ENV}=N`
+    // tip; cubic-dev-ai flagged it as misleading for the error and the
+    // dominant inherited-idle subprocess cases. The env var stays
+    // documented in code/docs for the rare slow-producer scenario.
+    warn(`altimate-code: stdin produced no data; proceeding without it.`)
   }
 
   return result

--- a/packages/opencode/src/util/stdin.ts
+++ b/packages/opencode/src/util/stdin.ts
@@ -1,7 +1,8 @@
 import fs from "fs"
 import type { Stats } from "fs"
 
-const FIRST_BYTE_TIMEOUT_MS = 100
+const STDIN_TIMEOUT_ENV = "ALTIMATE_STDIN_TIMEOUT_MS"
+const DEFAULT_FIRST_BYTE_TIMEOUT_MS = 500
 
 type Stat = Pick<Stats, "isFIFO" | "isFile" | "isSocket">
 
@@ -15,6 +16,25 @@ export interface ReadStdinDeps {
   // implementation in tests.
   readStdin?: (timeoutMs: number) => Promise<string>
   timeoutMs?: number
+  // Called once with a human-readable note when fd 0 looked like a real
+  // input source (FIFO / file / socket) but no first byte arrived within
+  // the timeout — so a user whose pipe was silently dropped finds out.
+  // Default writes to stderr; tests inject a no-op to silence.
+  warn?: (msg: string) => void
+}
+
+function resolveTimeoutMs(): number {
+  const raw = process.env[STDIN_TIMEOUT_ENV]
+  if (raw === undefined) return DEFAULT_FIRST_BYTE_TIMEOUT_MS
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_FIRST_BYTE_TIMEOUT_MS
+  return parsed
+}
+
+function defaultWarn(msg: string): void {
+  try {
+    process.stderr?.write(msg + "\n")
+  } catch {}
 }
 
 // Read piped/redirected stdin without wedging on an inherited-but-idle fd.
@@ -35,16 +55,36 @@ export interface ReadStdinDeps {
 //      wait up to `timeoutMs` for the first readable byte. If no byte
 //      arrives in that window, we treat stdin as inherited-idle and skip.
 //      If a byte arrives, we drain to EOF without further deadline — so a
-//      slow producer that takes >100ms total but flushes its first chunk
-//      within the window is not truncated. This avoids the two pitfalls of
-//      a whole-stream race: (a) the orphaned `Bun.stdin.text()` continuing
-//      to hold fd 0 open after the loser is abandoned, and (b) silent
-//      mid-stream truncation of legitimate slow / large producers.
+//      slow producer that takes >500ms total but flushes its first chunk
+//      within the window is not truncated. The 500ms default is chosen to
+//      cover realistic slow-to-first-byte producers (DB queries that need
+//      to plan, decompression headers, network calls with DNS+TLS handshake)
+//      while still failing fast enough to keep the inherited-idle wedge fix
+//      effective. Users can override via `ALTIMATE_STDIN_TIMEOUT_MS=N` (ms)
+//      for environments with even slower producers. This avoids the two
+//      pitfalls of a whole-stream race: (a) the orphaned `Bun.stdin.text()`
+//      continuing to hold fd 0 open after the loser is abandoned, and
+//      (b) silent mid-stream truncation of legitimate slow / large producers.
+//
+//   3. Stderr note on silent drop: if we got past the fstat gate (fd 0
+//      looked like real input) but the read came back empty, we write one
+//      line to stderr so a user whose pipe was dropped finds out instead
+//      of silently getting no input. The note also tells them how to bump
+//      the timeout. This fires on the dominant inherited-idle path too —
+//      that's intentional, since stderr is captured but not surfaced for
+//      most subprocess callers (Claude Code's Bash tool, CI) and a single
+//      line of noise per call is worth the explicitness for the
+//      slow-producer case.
 export async function readStdinIfAvailable(deps: ReadStdinDeps = {}): Promise<string> {
+  // `process.stdin` can be undefined in embedded / child runtimes (flagged
+  // by dev-punia on PR #937). Treat absence as "no stdin to read."
+  if (deps.isTTY === undefined && !process.stdin) return ""
+
   const isTTY = deps.isTTY ?? Boolean(process.stdin.isTTY)
   const fstat = deps.fstat ?? (() => fs.fstatSync(0) as Stat)
   const readStdin = deps.readStdin ?? defaultReadStdin
-  const timeoutMs = deps.timeoutMs ?? FIRST_BYTE_TIMEOUT_MS
+  const timeoutMs = deps.timeoutMs ?? resolveTimeoutMs()
+  const warn = deps.warn ?? defaultWarn
 
   if (isTTY) return ""
 
@@ -55,7 +95,16 @@ export async function readStdinIfAvailable(deps: ReadStdinDeps = {}): Promise<st
     return ""
   }
 
-  return readStdin(timeoutMs)
+  const result = await readStdin(timeoutMs)
+
+  if (result === "") {
+    warn(
+      `altimate-code: stdin appears piped but no data received within ${timeoutMs}ms; ` +
+        `proceeding without it. Set ${STDIN_TIMEOUT_ENV}=N (ms) to wait longer.`,
+    )
+  }
+
+  return result
 }
 
 // Compose the final prompt from a positional message and stdin input.

--- a/packages/opencode/src/util/stdin.ts
+++ b/packages/opencode/src/util/stdin.ts
@@ -77,10 +77,10 @@ function defaultWarn(msg: string): void {
 //      slow-producer case.
 export async function readStdinIfAvailable(deps: ReadStdinDeps = {}): Promise<string> {
   // `process.stdin` can be undefined in embedded / child runtimes (flagged
-  // by dev-punia on PR #937). Treat absence as "no stdin to read."
-  if (deps.isTTY === undefined && !process.stdin) return ""
-
-  const isTTY = deps.isTTY ?? Boolean(process.stdin.isTTY)
+  // by dev-punia on PR #937, suryaiyer95 review on PR #935 #3). Optional
+  // chaining keeps the access safe; the fstat catch below covers the case
+  // where fd 0 itself isn't open.
+  const isTTY = deps.isTTY ?? Boolean(process.stdin?.isTTY)
   const fstat = deps.fstat ?? (() => fs.fstatSync(0) as Stat)
   const readStdin = deps.readStdin ?? defaultReadStdin
   const timeoutMs = deps.timeoutMs ?? resolveTimeoutMs()

--- a/packages/opencode/src/util/stdin.ts
+++ b/packages/opencode/src/util/stdin.ts
@@ -98,9 +98,13 @@ export async function readStdinIfAvailable(deps: ReadStdinDeps = {}): Promise<st
   const result = await readStdin(timeoutMs)
 
   if (result === "") {
+    // An empty result can come from the timer firing (slow producer), a
+    // clean `end` with zero bytes (intentionally empty pipe), or an error
+    // event. Wording is cause-neutral; the env-var tip is still useful for
+    // the slow-producer case and harmless otherwise.
     warn(
-      `altimate-code: stdin appears piped but no data received within ${timeoutMs}ms; ` +
-        `proceeding without it. Set ${STDIN_TIMEOUT_ENV}=N (ms) to wait longer.`,
+      `altimate-code: stdin produced no data; proceeding without it. ` +
+        `Tip: set ${STDIN_TIMEOUT_ENV}=N (ms) higher if upstream is a slow producer.`,
     )
   }
 
@@ -132,6 +136,11 @@ export function assembleStdinMessage(positional: string, stdinInput: string): st
 function defaultReadStdin(timeoutMs: number): Promise<string> {
   return new Promise<string>((resolve) => {
     const stdin = process.stdin
+    // Defensive: a caller can reach this path with `deps.isTTY` set but
+    // `process.stdin` undefined (embedded/child runtime). The outer
+    // `process.stdin?.isTTY` guard short-circuits the default case but not
+    // this one. Treat absence as "no data" to match the function's contract.
+    if (!stdin) return resolve("")
     const chunks: Buffer[] = []
     let firstByteReceived = false
     let firstByteTimer: ReturnType<typeof setTimeout> | undefined

--- a/packages/opencode/src/util/stdin.ts
+++ b/packages/opencode/src/util/stdin.ts
@@ -1,0 +1,137 @@
+import fs from "fs"
+import type { Stats } from "fs"
+
+const FIRST_BYTE_TIMEOUT_MS = 100
+
+type Stat = Pick<Stats, "isFIFO" | "isFile" | "isSocket">
+
+export interface ReadStdinDeps {
+  isTTY?: boolean
+  fstat?: () => Stat
+  // Returns "" if no first byte arrives within timeoutMs; otherwise drains
+  // stdin to EOF and returns the full content. Default implementation uses
+  // process.stdin events so that a wedged-after-first-byte case still has a
+  // well-defined behavior (waits for `end`); callers can inject a faster
+  // implementation in tests.
+  readStdin?: (timeoutMs: number) => Promise<string>
+  timeoutMs?: number
+}
+
+// Read piped/redirected stdin without wedging on an inherited-but-idle fd.
+//
+// The failure mode this guards against: subprocess callers (Claude Code's
+// Bash tool, Python `subprocess.run(..., stdin=None)`, CI, plugin hosts)
+// leave stdin attached to a parent pipe that is never written to and never
+// closed. A blind `Bun.stdin.text()` waits forever for an EOF that never
+// arrives.
+//
+// Strategy — two gates:
+//
+//   1. fstat gate: only FIFOs (pipes), regular files (redirects), and
+//      sockets (process supervisors, socket activation, `nc -l`) can carry
+//      real input. TTYs and character devices (e.g. `< /dev/null`) skip.
+//
+//   2. First-byte timeout: instead of bounding the whole-stream drain, we
+//      wait up to `timeoutMs` for the first readable byte. If no byte
+//      arrives in that window, we treat stdin as inherited-idle and skip.
+//      If a byte arrives, we drain to EOF without further deadline — so a
+//      slow producer that takes >100ms total but flushes its first chunk
+//      within the window is not truncated. This avoids the two pitfalls of
+//      a whole-stream race: (a) the orphaned `Bun.stdin.text()` continuing
+//      to hold fd 0 open after the loser is abandoned, and (b) silent
+//      mid-stream truncation of legitimate slow / large producers.
+export async function readStdinIfAvailable(deps: ReadStdinDeps = {}): Promise<string> {
+  const isTTY = deps.isTTY ?? Boolean(process.stdin.isTTY)
+  const fstat = deps.fstat ?? (() => fs.fstatSync(0) as Stat)
+  const readStdin = deps.readStdin ?? defaultReadStdin
+  const timeoutMs = deps.timeoutMs ?? FIRST_BYTE_TIMEOUT_MS
+
+  if (isTTY) return ""
+
+  try {
+    const stat = fstat()
+    if (!stat.isFIFO() && !stat.isFile() && !stat.isSocket()) return ""
+  } catch {
+    return ""
+  }
+
+  return readStdin(timeoutMs)
+}
+
+// Compose the final prompt from a positional message and stdin input.
+// Extracted as a pure function so the regression case from PR #935
+// (`echo ctx | run "prompt"` must concatenate, not silently drop ctx) can
+// be unit-tested without spawning the full run command.
+export function assembleStdinMessage(positional: string, stdinInput: string): string {
+  if (stdinInput.trim().length === 0) return positional
+  if (positional.length === 0) return stdinInput
+  return positional + "\n" + stdinInput
+}
+
+// Default implementation of the first-byte race over `process.stdin`.
+//
+// Why not `Bun.stdin.text()`: that reads the entire stream as a single
+// uncancellable Promise. If we race it against a timer and the timer wins,
+// the read still holds fd 0 open until the producer eventually closes,
+// blocking process exit (the original wedge moved to teardown).
+//
+// Using `process.stdin` event listeners lets us:
+//   - bind the timeout to "first byte" rather than "full drain", so slow
+//     producers and large payloads aren't truncated;
+//   - cleanly remove our listeners and `unref` the stream on the no-data
+//     path, so an inherited-open fd doesn't pin the event loop.
+function defaultReadStdin(timeoutMs: number): Promise<string> {
+  return new Promise<string>((resolve) => {
+    const stdin = process.stdin
+    const chunks: Buffer[] = []
+    let firstByteReceived = false
+    let firstByteTimer: ReturnType<typeof setTimeout> | undefined
+    let settled = false
+
+    const cleanup = () => {
+      stdin.off("data", onData)
+      stdin.off("end", onEnd)
+      stdin.off("error", onError)
+      if (firstByteTimer) clearTimeout(firstByteTimer)
+      try {
+        stdin.pause()
+      } catch {}
+      try {
+        stdin.unref?.()
+      } catch {}
+    }
+
+    const settle = (result: string) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve(result)
+    }
+
+    const onData = (chunk: Buffer) => {
+      if (!firstByteReceived) {
+        firstByteReceived = true
+        if (firstByteTimer) {
+          clearTimeout(firstByteTimer)
+          firstByteTimer = undefined
+        }
+      }
+      chunks.push(chunk)
+    }
+    const onEnd = () => settle(Buffer.concat(chunks).toString("utf8"))
+    const onError = () => settle(Buffer.concat(chunks).toString("utf8"))
+
+    firstByteTimer = setTimeout(() => {
+      if (!firstByteReceived) settle("")
+    }, timeoutMs)
+
+    stdin.on("data", onData)
+    stdin.on("end", onEnd)
+    stdin.on("error", onError)
+    try {
+      stdin.resume()
+    } catch {
+      settle("")
+    }
+  })
+}

--- a/packages/opencode/test/util/stdin-e2e.test.ts
+++ b/packages/opencode/test/util/stdin-e2e.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+
+// The fixture imports the real helper and prints { result, elapsed } as JSON.
+// Spawning it lets us exercise the actual `process.stdin` event path against
+// real fd 0 conditions — something dependency injection can't cover.
+const FIXTURE = path.join(__dirname, "stdin-fixture.ts")
+
+type FileSink = { write(chunk: string | Uint8Array): number; end(): Promise<number> | number }
+
+async function runFixture(opts: {
+  writeStdin?: (sink: FileSink) => Promise<void>
+  killAfterMs?: number
+}): Promise<{ code: number | null; result?: string; elapsed?: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["bun", "run", FIXTURE], {
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+
+  if (opts.writeStdin) {
+    await opts.writeStdin(proc.stdin as unknown as FileSink)
+  }
+
+  let killTimer: ReturnType<typeof setTimeout> | undefined
+  if (opts.killAfterMs) {
+    killTimer = setTimeout(() => proc.kill(), opts.killAfterMs)
+  }
+  const code = await proc.exited
+  if (killTimer) clearTimeout(killTimer)
+
+  const stdout = await new Response(proc.stdout).text()
+  const stderr = await new Response(proc.stderr).text()
+
+  try {
+    const parsed = JSON.parse(stdout)
+    return { code, result: parsed.result, elapsed: parsed.elapsed, stdout, stderr }
+  } catch {
+    return { code, stdout, stderr }
+  }
+}
+
+describe("readStdinIfAvailable (spawned subprocess)", () => {
+  // M1-regression — the canonical wedge: an inherited pipe that's never
+  // written to and never closed. Pre-fix this hung forever; with the
+  // previous Promise.race fix, the await released at 100ms but fd 0 stayed
+  // open until the parent closed. With the first-byte event race + unref,
+  // the child exits promptly.
+  test(
+    "exits promptly with empty result when stdin is an inherited-but-idle pipe",
+    async () => {
+      const { code, result, elapsed } = await runFixture({
+        // Don't write — leave the pipe open and silent. Close after 1s so
+        // the parent's writer isn't garbage-collected; by then the child
+        // should have already exited via the first-byte timeout.
+        writeStdin: async (sink) => {
+          await new Promise((r) => setTimeout(r, 1000))
+          try {
+            await sink.end()
+          } catch {}
+        },
+        killAfterMs: 5000,
+      })
+      expect(code).toBe(0)
+      expect(result).toBe("")
+      expect(elapsed).toBeLessThan(500)
+    },
+    10000,
+  )
+
+  // MAJOR-regression from PR #935: `echo ctx | run "prompt"` must still
+  // deliver "ctx". Verified here by writing data + closing the pipe.
+  test(
+    "returns piped data when producer writes and closes",
+    async () => {
+      const { code, result } = await runFixture({
+        writeStdin: async (sink) => {
+          sink.write("context data")
+          await sink.end()
+        },
+      })
+      expect(code).toBe(0)
+      expect(result).toBe("context data")
+    },
+    10000,
+  )
+
+  // M2-regression: a producer that takes >100ms to flush first byte was
+  // truncated by the old Promise.race timeout. The first-byte gate must
+  // accept the byte once it arrives and then drain the rest without a
+  // deadline.
+  test(
+    "preserves data from slow producer (first byte arrives just before timeout)",
+    async () => {
+      const { code, result } = await runFixture({
+        writeStdin: async (sink) => {
+          // Sleep close to but under the 100ms first-byte budget, then
+          // flush. The whole-stream-race fix would have returned "".
+          await new Promise((r) => setTimeout(r, 60))
+          sink.write("slow ctx")
+          await sink.end()
+        },
+      })
+      expect(code).toBe(0)
+      expect(result).toBe("slow ctx")
+    },
+    10000,
+  )
+
+  // Negative control: a producer slow enough to miss the first-byte window
+  // should yield "" (intentional cutoff, no truncation of in-flight data).
+  test(
+    "returns empty when first byte arrives after the first-byte timeout",
+    async () => {
+      const { code, result } = await runFixture({
+        writeStdin: async (sink) => {
+          await new Promise((r) => setTimeout(r, 400))
+          try {
+            sink.write("too late")
+            await sink.end()
+          } catch {}
+        },
+      })
+      expect(code).toBe(0)
+      expect(result).toBe("")
+    },
+    10000,
+  )
+})

--- a/packages/opencode/test/util/stdin-e2e.test.ts
+++ b/packages/opencode/test/util/stdin-e2e.test.ts
@@ -50,22 +50,24 @@ describe("readStdinIfAvailable (spawned subprocess)", () => {
     "exits promptly with empty result when stdin is an inherited-but-idle pipe",
     async () => {
       const { code, result, elapsed } = await runFixture({
-        // Don't write — leave the pipe open and silent. Close after 1s so
+        // Don't write — leave the pipe open and silent. Close after 3s so
         // the parent's writer isn't garbage-collected; by then the child
-        // should have already exited via the first-byte timeout.
+        // should have already exited via the 500ms first-byte timeout.
         writeStdin: async (sink) => {
-          await new Promise((r) => setTimeout(r, 1000))
+          await new Promise((r) => setTimeout(r, 3000))
           try {
             await sink.end()
           } catch {}
         },
-        killAfterMs: 5000,
+        killAfterMs: 8000,
       })
       expect(code).toBe(0)
       expect(result).toBe("")
-      expect(elapsed).toBeLessThan(500)
+      // 1500 = timeout (500ms) × 3 for CI scheduler headroom. Well under
+      // "infinite hang" — the assertion guards the wedge fix, not perf.
+      expect(elapsed).toBeLessThan(1500)
     },
-    10000,
+    15000,
   )
 
   // MAJOR-regression from PR #935: `echo ctx | run "prompt"` must still
@@ -85,18 +87,16 @@ describe("readStdinIfAvailable (spawned subprocess)", () => {
     10000,
   )
 
-  // M2-regression: a producer that takes >100ms to flush first byte was
-  // truncated by the old Promise.race timeout. The first-byte gate must
-  // accept the byte once it arrives and then drain the rest without a
-  // deadline.
+  // Sury PR #935 review #2: 500ms must cover realistic slow-first-byte
+  // producers (DB queries that need to plan, decompression, network calls
+  // with DNS+TLS handshake). 300ms is comfortably under the 500ms budget;
+  // the previous 100ms config would have truncated this.
   test(
-    "preserves data from slow producer (first byte arrives just before timeout)",
+    "preserves data from slow producer (first byte arrives ~300ms after spawn)",
     async () => {
       const { code, result } = await runFixture({
         writeStdin: async (sink) => {
-          // Sleep close to but under the 100ms first-byte budget, then
-          // flush. The whole-stream-race fix would have returned "".
-          await new Promise((r) => setTimeout(r, 60))
+          await new Promise((r) => setTimeout(r, 300))
           sink.write("slow ctx")
           await sink.end()
         },
@@ -109,12 +109,13 @@ describe("readStdinIfAvailable (spawned subprocess)", () => {
 
   // Negative control: a producer slow enough to miss the first-byte window
   // should yield "" (intentional cutoff, no truncation of in-flight data).
+  // 1200ms > 500ms timeout with margin for CI scheduler latency.
   test(
     "returns empty when first byte arrives after the first-byte timeout",
     async () => {
       const { code, result } = await runFixture({
         writeStdin: async (sink) => {
-          await new Promise((r) => setTimeout(r, 400))
+          await new Promise((r) => setTimeout(r, 1200))
           try {
             sink.write("too late")
             await sink.end()
@@ -124,6 +125,6 @@ describe("readStdinIfAvailable (spawned subprocess)", () => {
       expect(code).toBe(0)
       expect(result).toBe("")
     },
-    10000,
+    15000,
   )
 })

--- a/packages/opencode/test/util/stdin-fixture.ts
+++ b/packages/opencode/test/util/stdin-fixture.ts
@@ -1,0 +1,9 @@
+// Subprocess fixture used by stdin-e2e.test.ts.
+// Imports the real helper, invokes it against real fd 0, and prints the
+// result as JSON so the test can assert on it.
+import { readStdinIfAvailable } from "../../src/util/stdin"
+
+const start = Date.now()
+const result = await readStdinIfAvailable()
+const elapsed = Date.now() - start
+process.stdout.write(JSON.stringify({ result, elapsed }))

--- a/packages/opencode/test/util/stdin.test.ts
+++ b/packages/opencode/test/util/stdin.test.ts
@@ -138,6 +138,28 @@ describe("readStdinIfAvailable", () => {
     }
   })
 
+  // cubic P2 on commit 7fceb85a1: a caller that passes `deps.isTTY` bypasses
+  // the outer `process.stdin?.isTTY` guard. If `process.stdin` is undefined,
+  // the default reader path used to crash on `stdin.on(...)`. The defensive
+  // check inside `defaultReadStdin` covers this.
+  test("default reader returns empty when process.stdin is undefined even when deps.isTTY is passed", async () => {
+    const original = process.stdin
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(process as any).stdin = undefined
+    try {
+      const out = await readStdinIfAvailable({
+        isTTY: false,
+        fstat: () => fifo,
+        // no readStdin → exercises defaultReadStdin
+        warn: () => {},
+      })
+      expect(out).toBe("")
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(process as any).stdin = original
+    }
+  })
+
   // Sury PR #935 review #2: silent drop is bad UX. When fd 0 looked like
   // real input but no first byte arrived, warn so the user knows.
   test("warns when stdin looked like input but readStdin returned empty (silent-drop fix)", async () => {
@@ -150,7 +172,7 @@ describe("readStdinIfAvailable", () => {
     })
     expect(out).toBe("")
     expect(seen).toHaveLength(1)
-    expect(seen[0]).toContain("stdin appears piped")
+    expect(seen[0]).toContain("stdin produced no data")
     expect(seen[0]).toContain("ALTIMATE_STDIN_TIMEOUT_MS")
   })
 

--- a/packages/opencode/test/util/stdin.test.ts
+++ b/packages/opencode/test/util/stdin.test.ts
@@ -173,7 +173,6 @@ describe("readStdinIfAvailable", () => {
     expect(out).toBe("")
     expect(seen).toHaveLength(1)
     expect(seen[0]).toContain("stdin produced no data")
-    expect(seen[0]).toContain("ALTIMATE_STDIN_TIMEOUT_MS")
   })
 
   test("does NOT warn when isTTY (no pipe to drop in the first place)", async () => {

--- a/packages/opencode/test/util/stdin.test.ts
+++ b/packages/opencode/test/util/stdin.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test"
+import { readStdinIfAvailable, assembleStdinMessage } from "../../src/util/stdin"
+
+const fifo = { isFIFO: () => true, isFile: () => false, isSocket: () => false }
+const file = { isFIFO: () => false, isFile: () => true, isSocket: () => false }
+const sock = { isFIFO: () => false, isFile: () => false, isSocket: () => true }
+const charDev = { isFIFO: () => false, isFile: () => false, isSocket: () => false }
+
+describe("readStdinIfAvailable", () => {
+  test("returns empty when stdin is a TTY (no fstat, no read)", async () => {
+    let read = false
+    const out = await readStdinIfAvailable({
+      isTTY: true,
+      fstat: () => {
+        throw new Error("fstat should not run when isTTY")
+      },
+      readStdin: async () => {
+        read = true
+        return "should not happen"
+      },
+    })
+    expect(out).toBe("")
+    expect(read).toBe(false)
+  })
+
+  test("returns empty for `< /dev/null` (character device — neither FIFO, file, nor socket)", async () => {
+    let read = false
+    const out = await readStdinIfAvailable({
+      isTTY: false,
+      fstat: () => charDev,
+      readStdin: async () => {
+        read = true
+        return "should not happen"
+      },
+    })
+    expect(out).toBe("")
+    expect(read).toBe(false)
+  })
+
+  test("returns empty when fstat throws (e.g. EBADF — fd 0 not open)", async () => {
+    const out = await readStdinIfAvailable({
+      isTTY: false,
+      fstat: () => {
+        throw new Error("EBADF")
+      },
+      readStdin: async () => "should not happen",
+    })
+    expect(out).toBe("")
+  })
+
+  // MAJOR-regression: `echo ctx | run "prompt"` must still deliver "ctx".
+  test("returns piped data when stdin is a FIFO with available bytes", async () => {
+    const out = await readStdinIfAvailable({
+      isTTY: false,
+      fstat: () => fifo,
+      readStdin: async () => "context data",
+    })
+    expect(out).toBe("context data")
+  })
+
+  test("returns redirected file contents (run < file.txt)", async () => {
+    const out = await readStdinIfAvailable({
+      isTTY: false,
+      fstat: () => file,
+      readStdin: async () => "from-file",
+    })
+    expect(out).toBe("from-file")
+  })
+
+  // m1 fix: sockets are now accepted (used by process supervisors, socket
+  // activation, `nc -l`). Pre-fix the helper silently skipped them.
+  test("accepts socket-backed stdin (process supervisors, socket activation, nc -l)", async () => {
+    const out = await readStdinIfAvailable({
+      isTTY: false,
+      fstat: () => sock,
+      readStdin: async () => "via-socket",
+    })
+    expect(out).toBe("via-socket")
+  })
+
+  // M1-regression: timed-out wait must propagate as "" (no orphan, no wedge).
+  test("returns empty when readStdin times out (idle inherited FIFO)", async () => {
+    const out = await readStdinIfAvailable({
+      isTTY: false,
+      fstat: () => fifo,
+      readStdin: async () => "", // simulates first-byte timeout
+    })
+    expect(out).toBe("")
+  })
+
+  // M2-regression: a producer that takes >100ms total but flushes its first
+  // byte inside the window must NOT be truncated. The helper trusts readStdin
+  // to wait for EOF after first byte; we verify the no-truncation contract by
+  // injecting a readStdin that resolves slowly with full content.
+  test("returns full content from slow-but-pre-timeout producer", async () => {
+    const out = await readStdinIfAvailable({
+      isTTY: false,
+      fstat: () => fifo,
+      readStdin: () => new Promise<string>((r) => setTimeout(() => r("ctx after 80ms"), 80)),
+      timeoutMs: 100,
+    })
+    expect(out).toBe("ctx after 80ms")
+  })
+
+  test("returns empty for FIFO with immediate EOF (empty pipe)", async () => {
+    const out = await readStdinIfAvailable({
+      isTTY: false,
+      fstat: () => fifo,
+      readStdin: async () => "",
+    })
+    expect(out).toBe("")
+  })
+
+  test("returns whitespace-only stdin verbatim (caller decides to trim)", async () => {
+    const out = await readStdinIfAvailable({
+      isTTY: false,
+      fstat: () => fifo,
+      readStdin: async () => "   \n\t  ",
+    })
+    expect(out).toBe("   \n\t  ")
+  })
+})
+
+describe("assembleStdinMessage", () => {
+  // MAJOR-regression from PR #935: positional must NOT silently override stdin.
+  test("concatenates positional + stdin with newline", () => {
+    expect(assembleStdinMessage("summarize:", "context data")).toBe("summarize:\ncontext data")
+  })
+
+  test("returns stdin when positional is empty", () => {
+    expect(assembleStdinMessage("", "stdin only")).toBe("stdin only")
+  })
+
+  test("returns positional when stdin is empty", () => {
+    expect(assembleStdinMessage("msg", "")).toBe("msg")
+  })
+
+  test("ignores whitespace-only stdin", () => {
+    expect(assembleStdinMessage("msg", "  \n  ")).toBe("msg")
+  })
+
+  test("returns empty string when both are empty", () => {
+    expect(assembleStdinMessage("", "")).toBe("")
+  })
+})

--- a/packages/opencode/test/util/stdin.test.ts
+++ b/packages/opencode/test/util/stdin.test.ts
@@ -84,6 +84,7 @@ describe("readStdinIfAvailable", () => {
       isTTY: false,
       fstat: () => fifo,
       readStdin: async () => "", // simulates first-byte timeout
+      warn: () => {}, // silence the stderr note in test output
     })
     expect(out).toBe("")
   })
@@ -107,6 +108,7 @@ describe("readStdinIfAvailable", () => {
       isTTY: false,
       fstat: () => fifo,
       readStdin: async () => "",
+      warn: () => {},
     })
     expect(out).toBe("")
   })
@@ -118,6 +120,116 @@ describe("readStdinIfAvailable", () => {
       readStdin: async () => "   \n\t  ",
     })
     expect(out).toBe("   \n\t  ")
+  })
+
+  // PR #937 / dev-punia review: `process.stdin` can be undefined in
+  // embedded/child runtimes. The helper must not throw when accessing
+  // `process.stdin.isTTY` in that case.
+  test("returns empty when process.stdin is undefined (embedded/child runtime)", async () => {
+    const original = process.stdin
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(process as any).stdin = undefined
+    try {
+      const out = await readStdinIfAvailable()
+      expect(out).toBe("")
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(process as any).stdin = original
+    }
+  })
+
+  // Sury PR #935 review #2: silent drop is bad UX. When fd 0 looked like
+  // real input but no first byte arrived, warn so the user knows.
+  test("warns when stdin looked like input but readStdin returned empty (silent-drop fix)", async () => {
+    const seen: string[] = []
+    const out = await readStdinIfAvailable({
+      isTTY: false,
+      fstat: () => fifo,
+      readStdin: async () => "",
+      warn: (msg) => seen.push(msg),
+    })
+    expect(out).toBe("")
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toContain("stdin appears piped")
+    expect(seen[0]).toContain("ALTIMATE_STDIN_TIMEOUT_MS")
+  })
+
+  test("does NOT warn when isTTY (no pipe to drop in the first place)", async () => {
+    const seen: string[] = []
+    const out = await readStdinIfAvailable({
+      isTTY: true,
+      readStdin: async () => "",
+      warn: (msg) => seen.push(msg),
+    })
+    expect(out).toBe("")
+    expect(seen).toHaveLength(0)
+  })
+
+  test("does NOT warn when fstat says char device (/dev/null) — intentional skip", async () => {
+    const seen: string[] = []
+    const out = await readStdinIfAvailable({
+      isTTY: false,
+      fstat: () => charDev,
+      readStdin: async () => "",
+      warn: (msg) => seen.push(msg),
+    })
+    expect(out).toBe("")
+    expect(seen).toHaveLength(0)
+  })
+
+  test("does NOT warn when stdin delivered data (no drop happened)", async () => {
+    const seen: string[] = []
+    const out = await readStdinIfAvailable({
+      isTTY: false,
+      fstat: () => fifo,
+      readStdin: async () => "ctx",
+      warn: (msg) => seen.push(msg),
+    })
+    expect(out).toBe("ctx")
+    expect(seen).toHaveLength(0)
+  })
+
+  // Sury PR #935 review #2: env override for slow-pipeline users.
+  test("ALTIMATE_STDIN_TIMEOUT_MS env override is forwarded to readStdin", async () => {
+    const original = process.env["ALTIMATE_STDIN_TIMEOUT_MS"]
+    process.env["ALTIMATE_STDIN_TIMEOUT_MS"] = "2500"
+    let observed: number | undefined
+    try {
+      await readStdinIfAvailable({
+        isTTY: false,
+        fstat: () => fifo,
+        readStdin: async (ms) => {
+          observed = ms
+          return "data"
+        },
+        warn: () => {},
+      })
+    } finally {
+      if (original === undefined) delete process.env["ALTIMATE_STDIN_TIMEOUT_MS"]
+      else process.env["ALTIMATE_STDIN_TIMEOUT_MS"] = original
+    }
+    expect(observed).toBe(2500)
+  })
+
+  test("ALTIMATE_STDIN_TIMEOUT_MS falls back to default when unparseable", async () => {
+    const original = process.env["ALTIMATE_STDIN_TIMEOUT_MS"]
+    process.env["ALTIMATE_STDIN_TIMEOUT_MS"] = "not-a-number"
+    let observed: number | undefined
+    try {
+      await readStdinIfAvailable({
+        isTTY: false,
+        fstat: () => fifo,
+        readStdin: async (ms) => {
+          observed = ms
+          return "data"
+        },
+        warn: () => {},
+      })
+    } finally {
+      if (original === undefined) delete process.env["ALTIMATE_STDIN_TIMEOUT_MS"]
+      else process.env["ALTIMATE_STDIN_TIMEOUT_MS"] = original
+    }
+    expect(observed).toBe(500)
   })
 })
 


### PR DESCRIPTION
PINEAPPLE

Closes #934

## Summary

`altimate-code run "<task>"` hangs at 0% CPU forever when invoked as a subprocess from a context that inherits stdin without closing it (Claude Code's Bash tool, Python `subprocess.run`, CI, plugin hosts that don't pin stdin to `/dev/null`). The root cause is a blind `Bun.stdin.text()` on a non-TTY stdin that waits forever for an EOF the parent never sends.

This PR replaces the unbounded read with a deliberate two-gate strategy in a new util helper (`packages/opencode/src/util/stdin.ts`):

1. **fstat gate** — only FIFOs (pipes), regular files (redirects), and sockets carry real input. TTYs and character devices (`< /dev/null`) skip immediately. The `isSocket()` branch is load-bearing: when spawned with `stdio: ["pipe","pipe","pipe"]` on Bun on macOS, the inherited stdin actually reports as a socket, not a FIFO (verified empirically during review).
2. **First-byte timeout** — instead of bounding the whole-stream drain, wait up to 500ms for the first readable byte. If no byte arrives in that window, treat stdin as inherited-idle and skip. If a byte arrives, drain to EOF without further deadline — so a slow producer that takes longer than 500ms total but flushes its first chunk within the window is not truncated.

Default reader uses `process.stdin` events (not `Bun.stdin.text()`) with explicit listener cleanup + `unref()` on the no-data path so an idle inherited fd doesn't pin the event loop.

## Behavior at the `run` call site

`run.ts:434-436` now reads:

```ts
message = assembleStdinMessage(message, await readStdinIfAvailable())
```

`assembleStdinMessage` is an exported pure function — `positional + "\n" + stdin` when both are non-empty; either alone when only one is present. **Conventional CLI semantics**: positional and stdin are concatenated, not mutually exclusive. So `echo "context" | altimate-code run "summarize:"` delivers `"summarize:\ncontext"`, matching the `git diff | tool "review this"` pattern that the original PR #935 reviewer (anandgupta42) asked us to preserve.

## Tunables

- **`ALTIMATE_STDIN_TIMEOUT_MS=N`** — env override for the first-byte timeout (ms). Set higher for environments with slow-flush producers (DB queries that need to plan, decompression, network calls with DNS+TLS handshake).
- **Stderr note** — if the fstat gate passed (fd 0 looked like real input) but the first-byte window timed out, the helper writes one line to stderr so a user whose pipe was silently dropped finds out instead of seeing nothing. The note also points at the env var.

## Downstream context

Downstream consumers have been working around the wedge by spawning altimate-code with `stdio: ["ignore", "pipe", "pipe"]` — see [altimate-opencode-plugin `plugins/altimate-code/index.ts:28`](https://github.com/AltimateAI/altimate-opencode-plugin/blob/main/plugins/altimate-code/index.ts#L28). That workaround is fine for the plugin but doesn't protect any other caller (Claude Code's Bash tool, ad-hoc CI scripts, future plugins that forget). This PR is the proper fix at the source.

## Test plan

- [x] **Unit (injection)**: 20 cases in `test/util/stdin.test.ts` — TTY skip, `< /dev/null` skip, EBADF, FIFO + data, file redirect, socket accepted, idle timeout, slow-but-pre-timeout, empty FIFO, whitespace-only, undefined `process.stdin`, warn fires when input was expected but empty, warn does NOT fire for TTY / char-device / data-delivered, env override + invalid-env fallback. Plus 5 cases for `assembleStdinMessage` covering the PR #935 concatenation regression.
- [x] **E2E (spawned subprocess)**: 4 cases in `test/util/stdin-e2e.test.ts` — inherited-idle pipe exits in <1500ms; `echo`-style data is delivered; slow producer (~300ms first byte) is preserved; post-timeout writes (1200ms) are discarded. These exercise the actual `process.stdin` event path against real fd 0.
- [x] Broader: 840 tests across `test/util/` + `test/cli/` pass; `bun run typecheck` clean.

## Notes for reviewers

- The `tui/thread.ts:58-63` call site has the same vulnerable pattern as the pre-fix `run.ts`. Pre-existing on `main`, untouched by this PR's diff — filing as a follow-up (the helper is now in `src/util/` ready to be reused).
- This branch is rebased on top of #937 (which fixes a sister hang in the `question` tool); the cross-PR conflict on the `run.ts` stdin line is resolved by keeping the helper call and folding #937's `process.stdin` null-safety into `readStdinIfAvailable`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Fixed a hang in the `run` command when stdin was inherited but idle.
* Improved safe handling of redirected/piped stdin so the command only consumes input when appropriate.

## New Features
* Added robust stdin ingestion with a configurable first-byte timeout.
* Introduced `ALTIMATE_STDIN_TIMEOUT_MS` to tune how long to wait for stdin data.
* Better support for different stdin source types (including pipes, files, and sockets).

## Tests
* Added unit and end-to-end coverage for stdin timing, empty-input behavior, and warning output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->