### PR TITLE
fix: auto-resolve question tool in non-interactive contexts

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -368,6 +368,30 @@ export const RunCommand = cmd({
     // altimate_change end
   },
   handler: async (args) => {
+    // altimate_change start — `run` is the only entrypoint without an answer
+    // channel for the question tool: no TUI is mounted and the in-process
+    // Server.Default() shim below does not bind a port, so a connected IDE
+    // or web client cannot POST /question/:requestID/reply. Without this
+    // flag, Question.ask() awaits a Deferred forever and the parent
+    // supervisor TaskStops the subprocess — looking exactly like a hang.
+    // Server commands (serve/web/acp/workspace-serve) intentionally leave
+    // this unset so their HTTP reply path stays live.
+    //
+    // Skipped when --attach is set: the agent runs on the remote server, so
+    // the local env var would be a no-op and would only pollute the local
+    // process env for other tools that may consult it.
+    //
+    // Child processes spawned by the bash tool would inherit this flag and
+    // misbehave if they themselves are server-mode entrypoints; bash.ts
+    // strips ALTIMATE_NON_INTERACTIVE from mergedEnv to prevent that leak.
+    //
+    // Users can opt out by exporting ALTIMATE_NON_INTERACTIVE=0 before
+    // launching `run`.
+    if (!args.attach && process.env["ALTIMATE_NON_INTERACTIVE"] === undefined) {
+      process.env["ALTIMATE_NON_INTERACTIVE"] = "1"
+    }
+    // altimate_change end
+
     let message = [...args.message, ...(args["--"] || [])]
       .map((arg) => (arg.includes(" ") ? `"${arg.replace(/"/g, '\\"')}"` : arg))
       .join(" ")
@@ -430,7 +454,10 @@ export const RunCommand = cmd({
       message = [extractedParts.join("\n\n"), message].filter(Boolean).join("\n\n")
     }
 
-    if (!process.stdin.isTTY) message += "\n" + (await Bun.stdin.text())
+    // altimate_change start — null-safe stdin access. process.stdin can be
+    // undefined in embedded/child runtimes (see dev-punia review on PR #937).
+    if (!process.stdin?.isTTY) message += "\n" + (await Bun.stdin.text())
+    // altimate_change end
 
     if (message.trim().length === 0 && !args.command) {
       UI.error("You must provide a message or a command")

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -454,9 +454,13 @@ export const RunCommand = cmd({
       message = [extractedParts.join("\n\n"), message].filter(Boolean).join("\n\n")
     }
 
-    // altimate_change start — null-safe stdin access. process.stdin can be
-    // undefined in embedded/child runtimes (see dev-punia review on PR #937).
-    if (!process.stdin?.isTTY) message += "\n" + (await Bun.stdin.text())
+    // altimate_change start — null-safe stdin read. process.stdin can be
+    // undefined in embedded/child runtimes (dev-punia review, PR #937).
+    // Earlier revision used `!process.stdin?.isTTY`, which turned the crash
+    // into a stall: undefined stdin satisfied the guard and we then awaited
+    // Bun.stdin.text() on a stream that would never EOF. Skip the read
+    // entirely when there is no stdin to read from.
+    if (process.stdin && !process.stdin.isTTY) message += "\n" + (await Bun.stdin.text())
     // altimate_change end
 
     if (message.trim().length === 0 && !args.command) {

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -168,6 +168,15 @@ export const BashTool = Tool.define("bash", async () => {
 
       // altimate_change start — prepend bundled tools dir (ALTIMATE_BIN_DIR) and user tools dirs to PATH
       const mergedEnv: Record<string, string | undefined> = { ...process.env, ...shellEnv.env }
+      // altimate_change start — strip ALTIMATE_NON_INTERACTIVE from child env.
+      // `run` sets this flag on its own process so the question tool short-
+      // circuits, but child processes spawned by the bash tool may themselves
+      // be server-mode entrypoints (e.g. `altimate-code serve`) that need
+      // their HTTP question-reply path live. Without this delete, the parent
+      // process.env spread above would silently disable that path in every
+      // nested server invocation. See PR #937 review (Issue #3).
+      delete mergedEnv["ALTIMATE_NON_INTERACTIVE"]
+      // altimate_change end
       const sep = process.platform === "win32" ? ";" : ":"
       const basePath = mergedEnv.PATH ?? mergedEnv.Path ?? ""
       const pathEntries = new Set(basePath.split(sep).filter(Boolean))

--- a/packages/opencode/src/tool/question.ts
+++ b/packages/opencode/src/tool/question.ts
@@ -3,17 +3,78 @@ import { Tool } from "./tool"
 import { Question } from "../question"
 import DESCRIPTION from "./question.txt"
 
+// altimate_change start — non-interactive auto-answer support.
+// When running under `claude --print`, CI, or any other context without a TTY,
+// there is nobody to click an option in the TUI. The default Question.ask()
+// behaviour is to await a Deferred indefinitely, which causes the parent
+// process to TaskStop the subprocess after a long wait — looking exactly like
+// a hang. See deliverable 02 (Run F first sub-session) for the trace.
+//
+// Resolution policy: in non-interactive mode, pick the option whose label
+// contains a "safe" keyword (skip / cancel / profile only / no / abort).
+// If no such option exists, pick the LAST option (UX convention: safer/cancel
+// usually sits at the end). The agent then sees a concrete answer in the
+// tool result and can continue without blocking. Override via env var:
+//   ALTIMATE_AUTO_ANSWER=first    — always pick first option
+//   ALTIMATE_AUTO_ANSWER=last     — always pick last option (default)
+//   ALTIMATE_AUTO_ANSWER=skip     — return Unanswered for all questions
+const SAFE_KEYWORDS = [
+  "skip",
+  "cancel",
+  "no",
+  "abort",
+  "profile only",
+  "profile-only",
+  "decline",
+  "deny",
+  "stop",
+]
+
+function isNonInteractive(): boolean {
+  if (process.env["ALTIMATE_FORCE_INTERACTIVE"] === "1") return false
+  if (process.env["ALTIMATE_NON_INTERACTIVE"] === "1") return true
+  return !process.stdin.isTTY
+}
+
+function autoAnswer(questions: Question.Info[]): Question.Answer[] {
+  const mode = (process.env["ALTIMATE_AUTO_ANSWER"] ?? "last").toLowerCase()
+  return questions.map((q) => {
+    if (mode === "skip") return []
+    if (mode === "first") return q.options[0] ? [q.options[0].label] : []
+    if (mode === "last") {
+      const safe = q.options.find((o) => {
+        const text = `${o.label} ${o.description}`.toLowerCase()
+        return SAFE_KEYWORDS.some((k) => text.includes(k))
+      })
+      if (safe) return [safe.label]
+      const last = q.options[q.options.length - 1]
+      return last ? [last.label] : []
+    }
+    // exact label match for explicit answers, e.g. ALTIMATE_AUTO_ANSWER="Profile only"
+    const match = q.options.find((o) => o.label.toLowerCase() === mode)
+    return match ? [match.label] : []
+  })
+}
+// altimate_change end
+
 export const QuestionTool = Tool.define("question", {
   description: DESCRIPTION,
   parameters: z.object({
     questions: z.array(Question.Info.omit({ custom: true })).describe("Questions to ask"),
   }),
   async execute(params, ctx) {
-    const answers = await Question.ask({
-      sessionID: ctx.sessionID,
-      questions: params.questions,
-      tool: ctx.callID ? { messageID: ctx.messageID, callID: ctx.callID } : undefined,
-    })
+    // altimate_change start — short-circuit when no human is listening.
+    let answers: Question.Answer[]
+    if (isNonInteractive()) {
+      answers = autoAnswer(params.questions)
+    } else {
+      answers = await Question.ask({
+        sessionID: ctx.sessionID,
+        questions: params.questions,
+        tool: ctx.callID ? { messageID: ctx.messageID, callID: ctx.callID } : undefined,
+      })
+    }
+    // altimate_change end
 
     function format(answer: Question.Answer | undefined) {
       if (!answer?.length) return "Unanswered"
@@ -22,9 +83,17 @@ export const QuestionTool = Tool.define("question", {
 
     const formatted = params.questions.map((q, i) => `"${q.question}"="${format(answers[i])}"`).join(", ")
 
+    // altimate_change start — flag auto-answers explicitly so the agent
+    // knows the user didn't actually answer and can decide whether to
+    // proceed with that choice or fail back gracefully.
+    const prefix = isNonInteractive()
+      ? `Running in non-interactive mode (no TTY). Auto-answered with safe defaults: `
+      : `User has answered your questions: `
+    // altimate_change end
+
     return {
       title: `Asked ${params.questions.length} question${params.questions.length > 1 ? "s" : ""}`,
-      output: `User has answered your questions: ${formatted}. You can now continue with the user's answers in mind.`,
+      output: `${prefix}${formatted}. You can now continue with the user's answers in mind.`,
       metadata: {
         answers,
       },

--- a/packages/opencode/src/tool/question.ts
+++ b/packages/opencode/src/tool/question.ts
@@ -5,33 +5,41 @@ import DESCRIPTION from "./question.txt"
 
 // altimate_change start — non-interactive handling for the question tool.
 //
-// When running under `claude --print`, CI, or any other context without a TTY,
-// there is nobody to click an option in the TUI. The upstream Question.ask()
-// awaits a Deferred indefinitely, which looks exactly like a hang to a parent
-// supervisor.
+// Question.ask() resolves via either a TUI click or an HTTP reply at
+// POST /question/:requestID/reply. Server commands (serve / web / acp /
+// workspace-serve) expose the HTTP path, so an IDE or web client CAN answer
+// even though their stdin is not a TTY. Only `altimate-code run` is
+// genuinely headless: it uses an in-process Server.Default() shim with no
+// bound port, so no client can reach the reply route and Question.ask()
+// awaits forever.
 //
-// Policy: when non-interactive, return Unanswered for every question and let
-// the calling agent decide what to do. The agent knows what it was about to
-// do and why it asked; it can pick a safe path from context or report that
-// user input is required. We deliberately do NOT guess based on label text
-// — every heuristic we tried (safe-keyword scan, last-option fallback)
-// either invented decisions the user didn't make or false-positive'd on
-// labels like "Snowflake" that happened to contain "no".
+// Detection is therefore opt-in via env var rather than TTY-based:
+// `run` sets ALTIMATE_NON_INTERACTIVE=1 on startup; every other entrypoint
+// defaults to interactive. Earlier revisions used !process.stdin.isTTY,
+// which misclassified server mode and silently disabled the HTTP reply path
+// for IDE users (see PR #937 review).
 //
-// Explicit overrides (for users who genuinely want a default and accept the
-// responsibility):
+// Policy when non-interactive: return Unanswered for every question and let
+// the calling agent decide. The agent knows what it was about to do and
+// why it asked; it can pick a safe path from context or report that input
+// is required. We deliberately do NOT guess based on label text — every
+// heuristic we tried (safe-keyword scan, last-option fallback) either
+// invented decisions the user didn't make or false-positive'd on labels
+// like "Snowflake" that happened to contain "no".
+//
+// Explicit overrides (for users who genuinely want a default and accept
+// the responsibility):
 //   ALTIMATE_AUTO_ANSWER=first         — always pick the first option
 //   ALTIMATE_AUTO_ANSWER=last          — always pick the last option
 //   ALTIMATE_AUTO_ANSWER="<label>"     — pick the option whose label matches
 //
-// TTY-detection overrides (for harnesses that lie about being a TTY):
-//   ALTIMATE_FORCE_INTERACTIVE=1       — treat as interactive even without TTY
-//   ALTIMATE_NON_INTERACTIVE=1         — treat as non-interactive even with TTY
+// Mode overrides:
+//   ALTIMATE_FORCE_INTERACTIVE=1       — keep Question.ask() (e.g. tests)
+//   ALTIMATE_NON_INTERACTIVE=1         — set by `run`; opt-in elsewhere
 
 function isNonInteractive(): boolean {
   if (process.env["ALTIMATE_FORCE_INTERACTIVE"] === "1") return false
-  if (process.env["ALTIMATE_NON_INTERACTIVE"] === "1") return true
-  return !process.stdin.isTTY
+  return process.env["ALTIMATE_NON_INTERACTIVE"] === "1"
 }
 
 function autoAnswer(questions: Question.Info[]): Question.Answer[] {
@@ -79,16 +87,17 @@ export const QuestionTool = Tool.define("question", {
 
     const formatted = params.questions.map((q, i) => `"${q.question}"="${format(answers[i])}"`).join(", ")
 
-    // altimate_change start — make the non-interactive case unambiguous to
-    // the agent so it doesn't treat "Unanswered" as a real user choice.
-    const prefix = nonInteractive
-      ? `Running in non-interactive mode (no TTY). No user was available to answer. Either pick a safe path from the context of the action you were about to take, or report that user input is required to proceed — the user can set ALTIMATE_AUTO_ANSWER=first|last|<exact option label> to pre-answer questions in this mode. Result: `
-      : `User has answered your questions: `
+    // altimate_change start — split the whole message per mode. The original
+    // trailer "continue with the user's answers in mind" contradicts the
+    // non-interactive branch which tells the agent no user was available.
+    const output = nonInteractive
+      ? `Running in non-interactive mode (no answer channel available). No user was available to answer. Either pick a safe path from the context of the action you were about to take, or report that user input is required to proceed — the user can set ALTIMATE_AUTO_ANSWER=first|last|<exact option label> to pre-answer questions in this mode. Result: ${formatted}.`
+      : `User has answered your questions: ${formatted}. You can now continue with the user's answers in mind.`
     // altimate_change end
 
     return {
       title: `Asked ${params.questions.length} question${params.questions.length > 1 ? "s" : ""}`,
-      output: `${prefix}${formatted}. You can now continue with the user's answers in mind.`,
+      output,
       metadata: {
         answers,
       },

--- a/packages/opencode/src/tool/question.ts
+++ b/packages/opencode/src/tool/question.ts
@@ -3,32 +3,30 @@ import { Tool } from "./tool"
 import { Question } from "../question"
 import DESCRIPTION from "./question.txt"
 
-// altimate_change start — non-interactive auto-answer support.
-// When running under `claude --print`, CI, or any other context without a TTY,
-// there is nobody to click an option in the TUI. The default Question.ask()
-// behaviour is to await a Deferred indefinitely, which causes the parent
-// process to TaskStop the subprocess after a long wait — looking exactly like
-// a hang. See deliverable 02 (Run F first sub-session) for the trace.
+// altimate_change start — non-interactive handling for the question tool.
 //
-// Resolution policy: in non-interactive mode, pick the option whose label
-// contains a "safe" keyword (skip / cancel / profile only / no / abort).
-// If no such option exists, pick the LAST option (UX convention: safer/cancel
-// usually sits at the end). The agent then sees a concrete answer in the
-// tool result and can continue without blocking. Override via env var:
-//   ALTIMATE_AUTO_ANSWER=first    — always pick first option
-//   ALTIMATE_AUTO_ANSWER=last     — always pick last option (default)
-//   ALTIMATE_AUTO_ANSWER=skip     — return Unanswered for all questions
-const SAFE_KEYWORDS = [
-  "skip",
-  "cancel",
-  "no",
-  "abort",
-  "profile only",
-  "profile-only",
-  "decline",
-  "deny",
-  "stop",
-]
+// When running under `claude --print`, CI, or any other context without a TTY,
+// there is nobody to click an option in the TUI. The upstream Question.ask()
+// awaits a Deferred indefinitely, which looks exactly like a hang to a parent
+// supervisor.
+//
+// Policy: when non-interactive, return Unanswered for every question and let
+// the calling agent decide what to do. The agent knows what it was about to
+// do and why it asked; it can pick a safe path from context or report that
+// user input is required. We deliberately do NOT guess based on label text
+// — every heuristic we tried (safe-keyword scan, last-option fallback)
+// either invented decisions the user didn't make or false-positive'd on
+// labels like "Snowflake" that happened to contain "no".
+//
+// Explicit overrides (for users who genuinely want a default and accept the
+// responsibility):
+//   ALTIMATE_AUTO_ANSWER=first         — always pick the first option
+//   ALTIMATE_AUTO_ANSWER=last          — always pick the last option
+//   ALTIMATE_AUTO_ANSWER="<label>"     — pick the option whose label matches
+//
+// TTY-detection overrides (for harnesses that lie about being a TTY):
+//   ALTIMATE_FORCE_INTERACTIVE=1       — treat as interactive even without TTY
+//   ALTIMATE_NON_INTERACTIVE=1         — treat as non-interactive even with TTY
 
 function isNonInteractive(): boolean {
   if (process.env["ALTIMATE_FORCE_INTERACTIVE"] === "1") return false
@@ -37,20 +35,14 @@ function isNonInteractive(): boolean {
 }
 
 function autoAnswer(questions: Question.Info[]): Question.Answer[] {
-  const mode = (process.env["ALTIMATE_AUTO_ANSWER"] ?? "last").toLowerCase()
+  const mode = process.env["ALTIMATE_AUTO_ANSWER"]?.toLowerCase()
   return questions.map((q) => {
-    if (mode === "skip") return []
+    if (!mode) return [] // default — Unanswered, agent decides
     if (mode === "first") return q.options[0] ? [q.options[0].label] : []
     if (mode === "last") {
-      const safe = q.options.find((o) => {
-        const text = `${o.label} ${o.description}`.toLowerCase()
-        return SAFE_KEYWORDS.some((k) => text.includes(k))
-      })
-      if (safe) return [safe.label]
       const last = q.options[q.options.length - 1]
       return last ? [last.label] : []
     }
-    // exact label match for explicit answers, e.g. ALTIMATE_AUTO_ANSWER="Profile only"
     const match = q.options.find((o) => o.label.toLowerCase() === mode)
     return match ? [match.label] : []
   })
@@ -64,8 +56,12 @@ export const QuestionTool = Tool.define("question", {
   }),
   async execute(params, ctx) {
     // altimate_change start — short-circuit when no human is listening.
+    // Cache the mode once: env vars can change across the `await` below, and
+    // we want the result prefix to describe the path the answer actually
+    // came from, not whatever state we observe later.
+    const nonInteractive = isNonInteractive()
     let answers: Question.Answer[]
-    if (isNonInteractive()) {
+    if (nonInteractive) {
       answers = autoAnswer(params.questions)
     } else {
       answers = await Question.ask({
@@ -83,11 +79,10 @@ export const QuestionTool = Tool.define("question", {
 
     const formatted = params.questions.map((q, i) => `"${q.question}"="${format(answers[i])}"`).join(", ")
 
-    // altimate_change start — flag auto-answers explicitly so the agent
-    // knows the user didn't actually answer and can decide whether to
-    // proceed with that choice or fail back gracefully.
-    const prefix = isNonInteractive()
-      ? `Running in non-interactive mode (no TTY). Auto-answered with safe defaults: `
+    // altimate_change start — make the non-interactive case unambiguous to
+    // the agent so it doesn't treat "Unanswered" as a real user choice.
+    const prefix = nonInteractive
+      ? `Running in non-interactive mode (no TTY). No user was available to answer. Either pick a safe path from the context of the action you were about to take, or report that user input is required to proceed — the user can set ALTIMATE_AUTO_ANSWER=first|last|<exact option label> to pre-answer questions in this mode. Result: `
       : `User has answered your questions: `
     // altimate_change end
 

--- a/packages/opencode/test/tool/question.test.ts
+++ b/packages/opencode/test/tool/question.test.ts
@@ -19,12 +19,18 @@ describe("tool.question", () => {
   let askSpy: any
 
   beforeEach(() => {
+    // Force the original interactive path for the legacy tests below — the
+    // test environment is non-TTY (bun:test runs without a terminal), so
+    // without this override the non-interactive auto-answer branch would
+    // short-circuit `Question.ask` and the existing spies would never fire.
+    process.env["ALTIMATE_FORCE_INTERACTIVE"] = "1"
     askSpy = spyOn(QuestionModule.Question, "ask").mockImplementation(async () => {
       return []
     })
   })
 
   afterEach(() => {
+    delete process.env["ALTIMATE_FORCE_INTERACTIVE"]
     askSpy.mockRestore()
   })
 
@@ -105,4 +111,121 @@ describe("tool.question", () => {
   //       expect(e.cause).toBeInstanceOf(z.ZodError)
   //     }
   //   })
+})
+
+describe("tool.question non-interactive auto-answer", () => {
+  let askSpy: any
+
+  beforeEach(() => {
+    process.env["ALTIMATE_NON_INTERACTIVE"] = "1"
+    askSpy = spyOn(QuestionModule.Question, "ask").mockImplementation(async () => [])
+  })
+
+  afterEach(() => {
+    delete process.env["ALTIMATE_NON_INTERACTIVE"]
+    delete process.env["ALTIMATE_AUTO_ANSWER"]
+    askSpy.mockRestore()
+  })
+
+  test("picks safe-keyword option when present and does not invoke Question.ask", async () => {
+    const tool = await QuestionTool.init()
+    const questions = [
+      {
+        question: "May I run row-level hashdiff comparisons?",
+        header: "PII consent",
+        options: [
+          { label: "Approve row diff", description: "Sample rows may appear" },
+          { label: "Profile only", description: "Safer; no row content surfaced" },
+        ],
+      },
+    ]
+
+    const result = await tool.execute({ questions }, ctx)
+    expect(askSpy).not.toHaveBeenCalled()
+    expect(result.output).toContain("Profile only")
+    expect(result.output).toContain("non-interactive mode")
+  })
+
+  test("falls back to last option when no safe keyword matches", async () => {
+    const tool = await QuestionTool.init()
+    const questions = [
+      {
+        question: "Pick a color",
+        header: "Color",
+        options: [
+          { label: "Red", description: "The color of passion" },
+          { label: "Blue", description: "The color of sky" },
+        ],
+      },
+    ]
+
+    const result = await tool.execute({ questions }, ctx)
+    expect(askSpy).not.toHaveBeenCalled()
+    expect(result.output).toContain("Blue")
+  })
+
+  test("ALTIMATE_AUTO_ANSWER=first picks first option", async () => {
+    process.env["ALTIMATE_AUTO_ANSWER"] = "first"
+    const tool = await QuestionTool.init()
+    const questions = [
+      {
+        question: "Pick a color",
+        header: "Color",
+        options: [
+          { label: "Red", description: "" },
+          { label: "Blue", description: "" },
+        ],
+      },
+    ]
+
+    const result = await tool.execute({ questions }, ctx)
+    expect(result.output).toContain("Red")
+  })
+
+  test("ALTIMATE_AUTO_ANSWER=skip returns Unanswered for each question", async () => {
+    process.env["ALTIMATE_AUTO_ANSWER"] = "skip"
+    const tool = await QuestionTool.init()
+    const questions = [
+      {
+        question: "Pick a color",
+        header: "Color",
+        options: [{ label: "Red", description: "" }],
+      },
+    ]
+
+    const result = await tool.execute({ questions }, ctx)
+    expect(result.output).toContain("Unanswered")
+  })
+
+  test("ALTIMATE_AUTO_ANSWER=<exact label> picks matching option", async () => {
+    process.env["ALTIMATE_AUTO_ANSWER"] = "blue"
+    const tool = await QuestionTool.init()
+    const questions = [
+      {
+        question: "Pick a color",
+        header: "Color",
+        options: [
+          { label: "Red", description: "" },
+          { label: "Blue", description: "" },
+        ],
+      },
+    ]
+
+    const result = await tool.execute({ questions }, ctx)
+    expect(result.output).toContain("Blue")
+  })
+
+  test("non-interactive prefix is set when Question.ask is bypassed", async () => {
+    const tool = await QuestionTool.init()
+    const questions = [
+      {
+        question: "OK to proceed?",
+        header: "Proceed",
+        options: [{ label: "Cancel", description: "Stop" }],
+      },
+    ]
+
+    const result = await tool.execute({ questions }, ctx)
+    expect(result.output.startsWith("Running in non-interactive mode")).toBe(true)
+  })
 })

--- a/packages/opencode/test/tool/question.test.ts
+++ b/packages/opencode/test/tool/question.test.ts
@@ -19,10 +19,10 @@ describe("tool.question", () => {
   let askSpy: any
 
   beforeEach(() => {
-    // Force the original interactive path for the legacy tests below — the
-    // test environment is non-TTY (bun:test runs without a terminal), so
-    // without this override the non-interactive auto-answer branch would
-    // short-circuit `Question.ask` and the existing spies would never fire.
+    // Defensive: detection is opt-in via ALTIMATE_NON_INTERACTIVE, so the
+    // default in `bun:test` is already interactive. Setting
+    // ALTIMATE_FORCE_INTERACTIVE=1 protects against env pollution if a
+    // parent shell or earlier test leaked ALTIMATE_NON_INTERACTIVE=1.
     process.env["ALTIMATE_FORCE_INTERACTIVE"] = "1"
     askSpy = spyOn(QuestionModule.Question, "ask").mockImplementation(async () => {
       return []
@@ -258,5 +258,108 @@ describe("tool.question non-interactive auto-answer", () => {
 
     const result = await tool.execute({ questions }, ctx)
     expect(result.output.startsWith("Running in non-interactive mode")).toBe(true)
+  })
+
+  test("non-interactive output does not contradict itself", async () => {
+    // Regression: the trailing literal "continue with the user's answers in
+    // mind" used to be appended unconditionally, contradicting the
+    // non-interactive prefix that says no user answered. See PR #937 review.
+    const tool = await QuestionTool.init()
+    const questions = [
+      {
+        question: "OK to proceed?",
+        header: "Proceed",
+        options: [{ label: "Cancel", description: "Stop" }],
+      },
+    ]
+
+    const result = await tool.execute({ questions }, ctx)
+    expect(result.output).not.toContain("continue with the user's answers in mind")
+  })
+})
+
+describe("tool.question default detection (no env vars)", () => {
+  let askSpy: any
+
+  beforeEach(() => {
+    // Default detection must NOT short-circuit when no env vars are set.
+    // Regression: an earlier revision used !process.stdin.isTTY, which
+    // misclassified `serve`/`web`/`acp`/`workspace-serve` (all non-TTY but
+    // with HTTP /question/:requestID/reply) as non-interactive and silently
+    // disabled the IDE reply path. See PR #937 review (suryaiyer95).
+    delete process.env["ALTIMATE_FORCE_INTERACTIVE"]
+    delete process.env["ALTIMATE_NON_INTERACTIVE"]
+    delete process.env["ALTIMATE_AUTO_ANSWER"]
+    askSpy = spyOn(QuestionModule.Question, "ask").mockImplementation(async () => [["Red"]])
+  })
+
+  afterEach(() => {
+    askSpy.mockRestore()
+  })
+
+  test("calls Question.ask by default — does not short-circuit on missing TTY", async () => {
+    const tool = await QuestionTool.init()
+    const questions = [
+      {
+        question: "Pick a color",
+        header: "Color",
+        options: [
+          { label: "Red", description: "" },
+          { label: "Blue", description: "" },
+        ],
+      },
+    ]
+
+    const result = await tool.execute({ questions }, ctx)
+    expect(askSpy).toHaveBeenCalledTimes(1)
+    expect(result.output.startsWith("User has answered your questions")).toBe(true)
+  })
+
+  test("ALTIMATE_NON_INTERACTIVE=0 honored as explicit opt-out", async () => {
+    // run.ts auto-sets this env var only when undefined, so a user-set "0"
+    // is preserved. isNonInteractive() matches strict "=== '1'", so "0"
+    // falls through to the interactive path. PR #937 comment promises this
+    // works; lock the contract.
+    process.env["ALTIMATE_NON_INTERACTIVE"] = "0"
+
+    const tool = await QuestionTool.init()
+    const questions = [
+      {
+        question: "Pick a color",
+        header: "Color",
+        options: [
+          { label: "Red", description: "" },
+          { label: "Blue", description: "" },
+        ],
+      },
+    ]
+
+    const result = await tool.execute({ questions }, ctx)
+    expect(askSpy).toHaveBeenCalledTimes(1)
+    expect(result.output.startsWith("User has answered your questions")).toBe(true)
+  })
+
+  test("ALTIMATE_FORCE_INTERACTIVE=1 overrides ALTIMATE_NON_INTERACTIVE=1", async () => {
+    // FORCE_INTERACTIVE is checked first in isNonInteractive() so it wins
+    // even when NON_INTERACTIVE is also set. Used by tests to keep the
+    // interactive path live regardless of parent-shell env pollution.
+    process.env["ALTIMATE_NON_INTERACTIVE"] = "1"
+    process.env["ALTIMATE_FORCE_INTERACTIVE"] = "1"
+
+    const tool = await QuestionTool.init()
+    const questions = [
+      {
+        question: "Pick a color",
+        header: "Color",
+        options: [
+          { label: "Red", description: "" },
+          { label: "Blue", description: "" },
+        ],
+      },
+    ]
+
+    const result = await tool.execute({ questions }, ctx)
+    expect(askSpy).toHaveBeenCalledTimes(1)
+    expect(result.output.startsWith("User has answered your questions")).toBe(true)
   })
 })

--- a/packages/opencode/test/tool/question.test.ts
+++ b/packages/opencode/test/tool/question.test.ts
@@ -117,11 +117,15 @@ describe("tool.question non-interactive auto-answer", () => {
   let askSpy: any
 
   beforeEach(() => {
+    // Defensive: clear FORCE_INTERACTIVE so a parent-shell export can't
+    // silently flip this suite to the interactive path and lose coverage.
+    delete process.env["ALTIMATE_FORCE_INTERACTIVE"]
     process.env["ALTIMATE_NON_INTERACTIVE"] = "1"
     askSpy = spyOn(QuestionModule.Question, "ask").mockImplementation(async () => [])
   })
 
   afterEach(() => {
+    delete process.env["ALTIMATE_FORCE_INTERACTIVE"]
     delete process.env["ALTIMATE_NON_INTERACTIVE"]
     delete process.env["ALTIMATE_AUTO_ANSWER"]
     askSpy.mockRestore()

--- a/packages/opencode/test/tool/question.test.ts
+++ b/packages/opencode/test/tool/question.test.ts
@@ -127,7 +127,7 @@ describe("tool.question non-interactive auto-answer", () => {
     askSpy.mockRestore()
   })
 
-  test("picks safe-keyword option when present and does not invoke Question.ask", async () => {
+  test("default returns Unanswered for every question and does not invoke Question.ask", async () => {
     const tool = await QuestionTool.init()
     const questions = [
       {
@@ -142,29 +142,39 @@ describe("tool.question non-interactive auto-answer", () => {
 
     const result = await tool.execute({ questions }, ctx)
     expect(askSpy).not.toHaveBeenCalled()
-    expect(result.output).toContain("Profile only")
+    expect(result.output).toContain('"May I run row-level hashdiff comparisons?"="Unanswered"')
+    // The non-interactive prefix tells the agent to pick a safe path from context
+    // AND tells the agent about the escape hatch so it can surface it to the user
+    // when reporting that input is required.
     expect(result.output).toContain("non-interactive mode")
+    expect(result.output).toContain("safe path")
+    expect(result.output).toContain("ALTIMATE_AUTO_ANSWER")
   })
 
-  test("falls back to last option when no safe keyword matches", async () => {
+  test("does not invent answers based on label text (no label-text heuristic)", async () => {
+    // Regression: a prior implementation scanned labels for substrings like
+    // "skip" / "cancel" / "no". That false-positived on labels like
+    // "Snowflake" (contains "no") and quietly picked the wrong option. The
+    // default now returns Unanswered — the agent decides.
     const tool = await QuestionTool.init()
     const questions = [
       {
-        question: "Pick a color",
-        header: "Color",
+        question: "Pick a warehouse",
+        header: "Warehouse",
         options: [
-          { label: "Red", description: "The color of passion" },
-          { label: "Blue", description: "The color of sky" },
+          { label: "Snowflake", description: "Continue with Snowflake" },
+          { label: "Cancel", description: "Stop here" },
         ],
       },
     ]
 
     const result = await tool.execute({ questions }, ctx)
-    expect(askSpy).not.toHaveBeenCalled()
-    expect(result.output).toContain("Blue")
+    expect(result.output).toContain('"Pick a warehouse"="Unanswered"')
+    expect(result.output).not.toContain('"Snowflake"')
+    expect(result.output).not.toContain('"Cancel"')
   })
 
-  test("ALTIMATE_AUTO_ANSWER=first picks first option", async () => {
+  test("ALTIMATE_AUTO_ANSWER=first picks first option (explicit opt-in)", async () => {
     process.env["ALTIMATE_AUTO_ANSWER"] = "first"
     const tool = await QuestionTool.init()
     const questions = [
@@ -179,22 +189,25 @@ describe("tool.question non-interactive auto-answer", () => {
     ]
 
     const result = await tool.execute({ questions }, ctx)
-    expect(result.output).toContain("Red")
+    expect(result.output).toContain('"Pick a color"="Red"')
   })
 
-  test("ALTIMATE_AUTO_ANSWER=skip returns Unanswered for each question", async () => {
-    process.env["ALTIMATE_AUTO_ANSWER"] = "skip"
+  test("ALTIMATE_AUTO_ANSWER=last picks last option (explicit opt-in)", async () => {
+    process.env["ALTIMATE_AUTO_ANSWER"] = "last"
     const tool = await QuestionTool.init()
     const questions = [
       {
         question: "Pick a color",
         header: "Color",
-        options: [{ label: "Red", description: "" }],
+        options: [
+          { label: "Red", description: "" },
+          { label: "Blue", description: "" },
+        ],
       },
     ]
 
     const result = await tool.execute({ questions }, ctx)
-    expect(result.output).toContain("Unanswered")
+    expect(result.output).toContain('"Pick a color"="Blue"')
   })
 
   test("ALTIMATE_AUTO_ANSWER=<exact label> picks matching option", async () => {
@@ -212,7 +225,25 @@ describe("tool.question non-interactive auto-answer", () => {
     ]
 
     const result = await tool.execute({ questions }, ctx)
-    expect(result.output).toContain("Blue")
+    expect(result.output).toContain('"Pick a color"="Blue"')
+  })
+
+  test("ALTIMATE_AUTO_ANSWER=<unknown label> falls through to Unanswered", async () => {
+    process.env["ALTIMATE_AUTO_ANSWER"] = "green"
+    const tool = await QuestionTool.init()
+    const questions = [
+      {
+        question: "Pick a color",
+        header: "Color",
+        options: [
+          { label: "Red", description: "" },
+          { label: "Blue", description: "" },
+        ],
+      },
+    ]
+
+    const result = await tool.execute({ questions }, ctx)
+    expect(result.output).toContain('"Pick a color"="Unanswered"')
   })
 
   test("non-interactive prefix is set when Question.ask is bypassed", async () => {


### PR DESCRIPTION
Closes #936

## Summary

`packages/opencode/src/tool/question.ts` calls `Question.ask()`, which awaits an Effect `Deferred` that only resolves on a TUI click. When `altimate-code run` is invoked as a subprocess (Claude Code's Bash tool, CI, `subprocess.run`, plugin host) and a skill that uses the `question` tool fires, nobody can ever click — the deferred awaits forever and the parent eventually `TaskStop`s the subprocess. Symptom: 0% CPU, no log activity, no error, indistinguishable from a hang.

This PR short-circuits the `question` tool in non-interactive contexts with a conservative-by-default auto-answer policy.

## Resolution policy

- **Non-interactive detection:** `!process.stdin.isTTY`. Overrides:
  - `ALTIMATE_FORCE_INTERACTIVE=1` — keep the original interactive Deferred path even when isTTY is false.
  - `ALTIMATE_NON_INTERACTIVE=1` — force non-interactive even when isTTY is true (useful for tests + CI assertions).
- **Default in non-TTY (`ALTIMATE_AUTO_ANSWER=last`):** pick the option whose label/description contains a safe keyword (`skip`, `cancel`, `no`, `abort`, `profile only`, `decline`, `deny`, `stop`); fall back to the last option (UX convention: safer/cancel typically sits at the end).
- **Explicit overrides:**
  - `ALTIMATE_AUTO_ANSWER=first` — always pick first option.
  - `ALTIMATE_AUTO_ANSWER=skip` — return `Unanswered` for all questions.
  - `ALTIMATE_AUTO_ANSWER="<exact label>"` — exact-match an option's label (case-insensitive).
- **Tool result prefix reflects mode** — `"Running in non-interactive mode (no TTY). Auto-answered with safe defaults: ..."` vs the original `"User has answered your questions: ..."` — so the agent knows the choice was not a real user answer and can adapt strategy.

## Why not just always pick "cancel"?

Picking cancel/abort blindly fails open in the opposite direction: skills that ask permission to do reasonable work would always get a no, breaking the user's actual intent. The safe-keyword scan tries to match the question author's intent (these are typically *"may I do destructive thing X?"* prompts) without blocking legitimate flows.

## Where this lives

Two reasonable choices:

1. **At the tool boundary (this PR)** — `packages/opencode/src/tool/question.ts` short-circuits before calling `Question.ask()`.
2. **At the Effect layer** — push the non-interactive detection into `Question.ask()` itself, so any caller of `Question.ask` (not just the tool) benefits.

Option 1 is what this PR ships; the scope is contained and the diff is reviewable. Option 2 is the deeper, more invasive change and may be the right long-term home. Happy to refactor if reviewers prefer.

## Test plan

- [x] `bun test test/tool/question.test.ts` → **8 pass, 0 fail**, 12 expect() calls. Verified locally before pushing.
  - 2 pre-existing legacy tests retained (gated with `ALTIMATE_FORCE_INTERACTIVE=1` in `beforeEach` so they preserve their original intent under non-TTY CI).
  - 6 new tests covering: safe-keyword selection, last-option fallback, `ALTIMATE_AUTO_ANSWER=first`, `=skip`, `=<exact label>`, non-interactive prefix wording.
- [ ] Reviewer smoke: trigger any skill using `question` from Claude Code's Bash tool — expect completion in seconds with auto-answered output, not a hang.

## Diff size

```
packages/opencode/src/tool/question.ts       |  81 ++++++++++++++++--
packages/opencode/test/tool/question.test.ts | 123 +++++++++++++++++++++++++++
2 files changed, 198 insertions(+), 6 deletions(-)
```

The patch is roughly 70 lines of source change plus tests. Larger than #935 (the stdin-wedge guard) because the resolution policy has real branching to implement; still bounded to one tool file.

## Risk

Low. Default behavior under TTY is unchanged (the new branch only fires when `!isTTY` or `ALTIMATE_NON_INTERACTIVE=1`). The non-TTY auto-answer surfaces explicitly in the tool result, so a downstream agent treating the choice as a real user click is impossible. `ALTIMATE_FORCE_INTERACTIVE=1` provides an escape hatch for any consumer that wants the original behavior even in non-TTY.

## Links

- Issue: #936
- Original repro: deliverable 02 Run F first sub-session (the `data-parity` skill's PII consent question wedge)
- Catalog entry: `plugin-skill-experiments/03-issues-and-fixes.md` Issue #5
- Sister fix: #935 (stdin wedge in `run.ts` — same surface area, different code path)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hangs in the `question` tool for headless runs by treating `altimate-code run` as non-interactive, defaulting to Unanswered, and clearly labeling the mode. Interactive server flows remain unchanged; addresses #936.

- **Bug Fixes**
  - Env-driven detection: `ALTIMATE_NON_INTERACTIVE=1` enables non-interactive; `ALTIMATE_FORCE_INTERACTIVE=1` forces interactive; `ALTIMATE_NON_INTERACTIVE=0` opts out. `run` sets `ALTIMATE_NON_INTERACTIVE=1` by default (skipped with `--attach`).
  - Non-interactive behavior: return Unanswered for all questions; removed label heuristics. Optional auto-answer via `ALTIMATE_AUTO_ANSWER=first`, `=last`, or `="<exact label>"`.
  - Output: prefix states “non-interactive mode (no answer channel available)”, removes the interactive trailer, and points to `ALTIMATE_AUTO_ANSWER`.
  - `bash` tool strips `ALTIMATE_NON_INTERACTIVE` from child env to avoid breaking nested server reply paths.
  - `run` stdin read is now fully null-safe: use `process.stdin && !process.stdin.isTTY` and skip the read when stdin is undefined to prevent stalls.
  - Tests cover env-var detection, precedence (`FORCE_INTERACTIVE` over `NON_INTERACTIVE`), explicit opt-out (`NON_INTERACTIVE=0`), non-interactive prefix, and suite isolation fixes.

<sup>Written for commit 764291c0c3182aae43918e6cf9a8f345705f2ec8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved non-interactive execution with deterministic question auto-answering (first, last, or exact option label) via configuration, or leaving items unanswered.
  * Mode-specific messaging now clearly indicates when the tool is running non-interactively and how to preconfigure answers.

* **Bug Fixes**
  * Reduced risk of blocking in the run entrypoint by enabling non-interactive mode by default when not attaching.
  * Improved robustness when stdin is unavailable.
  * Prevented non-interactive settings from affecting nested executions.

* **Tests**
  * Added coverage for auto-answer modes, option-label matching, unanswered fallback, and non-interactive vs interactive messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->