### PR TITLE
fix: trigger auto-update check on headless `serve` startup

### DIFF
--- a/packages/opencode/src/cli/cmd/serve-upgrade-check.ts
+++ b/packages/opencode/src/cli/cmd/serve-upgrade-check.ts
@@ -44,18 +44,20 @@ const defaultDeps: StartupUpgradeDeps = {
 }
 
 /**
- * Runs a single best-effort upgrade check. Resolves, never rejects: `run()`
- * (upgrade) swallows its own errors via the inner catch; the outer guard only
- * fires for an `Instance.provide` failure. A flaky network/registry therefore
- * can't take the server down.
+ * Runs a single best-effort upgrade check. Resolves, never rejects, via two
+ * layers: the inner `.catch` swallows any error from `run()` (`upgrade()` can
+ * throw, e.g. from `Config.global()` / `Installation.method()`), and the outer
+ * try/catch guards an `Instance.provide` (bootstrap) failure. A flaky
+ * network/registry therefore can't take the server down. Errors are passed as
+ * `Error` objects so `Log` formats the message + `cause` chain.
  */
 export async function runStartupUpgradeCheck(deps: StartupUpgradeDeps = defaultDeps): Promise<void> {
   try {
     await deps.provide(process.cwd(), () =>
-      deps.run().catch((err) => log.error("startup upgrade check failed", { error: String(err) })),
+      deps.run().catch((err) => log.error("startup upgrade check failed", { error: err })),
     )
   } catch (err) {
-    log.error("startup upgrade instance failed", { error: String(err) })
+    log.error("startup upgrade instance failed", { error: err })
   }
 }
 

--- a/packages/opencode/src/cli/cmd/serve-upgrade-check.ts
+++ b/packages/opencode/src/cli/cmd/serve-upgrade-check.ts
@@ -10,33 +10,50 @@ const log = Log.create({ service: "serve" })
 export const STARTUP_UPGRADE_DELAY_MS = 1000
 
 /**
- * Runs a single best-effort upgrade check, mirroring the TUI worker
- * (`cli/cmd/tui/worker.ts` → `checkUpgrade`): provide an `Instance` context for
- * `upgrade()` but — exactly like the worker — do NOT dispose it.
+ * Collaborators for {@link runStartupUpgradeCheck}, injectable for tests.
  *
- * `upgrade()` reads only global config + `Installation`, but `Bus.publish`
- * (its update notifications) needs an ambient instance. We use the same
- * `process.cwd()` key the server's default-directory requests use
- * (`server/server.ts:196`), so we reuse/seed that shared cached instance rather
- * than a throwaway one, and Bus notifications still reach default-directory SSE
- * subscribers.
- *
- * Crucially we never dispose: an earlier version wrapped this in `bootstrap()`,
- * whose `finally` → `Instance.dispose()` tears down the entire `process.cwd()`
- * bucket — including state created by concurrent server requests that defaulted
- * to that directory (use-after-dispose / needless churn). The worker avoids
- * this by running in a separate thread; in-process we avoid it by not disposing.
- *
- * Resolves, never rejects: `upgrade()` swallows its own errors via the inner
- * catch; the outer guard only fires for an `Instance.provide` failure.
+ * Injected rather than module-mocked on purpose: bun's `mock.module` is
+ * process-global, so mocking `../upgrade` / `../../project/instance` here would
+ * clobber those modules for every other test in the run (e.g. blow away
+ * `cli/upgrade`'s `compareVersions`/`isValidVersion` exports).
  */
-export async function runStartupUpgradeCheck(): Promise<void> {
+export interface StartupUpgradeDeps {
+  /**
+   * Runs `fn` inside an ambient `Instance` for `directory` and, like the TUI
+   * worker, does NOT dispose it (see note on the default below).
+   */
+  provide: (directory: string, fn: () => Promise<unknown>) => Promise<unknown>
+  /** The upgrade check itself. */
+  run: () => Promise<unknown>
+}
+
+const defaultDeps: StartupUpgradeDeps = {
+  // Mirror the TUI worker (cli/cmd/tui/worker.ts → checkUpgrade): provide an
+  // Instance context for upgrade() — Bus.publish needs one — but never dispose.
+  //
+  // We use the same process.cwd() key the server's default-directory requests
+  // use (server/server.ts:196), so we reuse/seed that shared cached instance and
+  // Bus notifications still reach default-directory SSE subscribers. Crucially we
+  // do NOT dispose: an earlier version wrapped this in bootstrap(), whose
+  // finally → Instance.dispose() tears down the entire process.cwd() bucket —
+  // including state created by concurrent server requests that defaulted to that
+  // directory (use-after-dispose / needless churn). The worker avoids this by
+  // running in a separate thread; in-process we avoid it by not disposing.
+  provide: (directory, fn) => Instance.provide({ directory, init: InstanceBootstrap, fn }),
+  run: upgrade,
+}
+
+/**
+ * Runs a single best-effort upgrade check. Resolves, never rejects: `run()`
+ * (upgrade) swallows its own errors via the inner catch; the outer guard only
+ * fires for an `Instance.provide` failure. A flaky network/registry therefore
+ * can't take the server down.
+ */
+export async function runStartupUpgradeCheck(deps: StartupUpgradeDeps = defaultDeps): Promise<void> {
   try {
-    await Instance.provide({
-      directory: process.cwd(),
-      init: InstanceBootstrap,
-      fn: () => upgrade().catch((err) => log.error("startup upgrade check failed", { error: String(err) })),
-    })
+    await deps.provide(process.cwd(), () =>
+      deps.run().catch((err) => log.error("startup upgrade check failed", { error: String(err) })),
+    )
   } catch (err) {
     log.error("startup upgrade instance failed", { error: String(err) })
   }

--- a/packages/opencode/src/cli/cmd/serve-upgrade-check.ts
+++ b/packages/opencode/src/cli/cmd/serve-upgrade-check.ts
@@ -1,0 +1,49 @@
+// altimate_change start — self-update trigger for headless serve
+import { Instance } from "../../project/instance"
+import { InstanceBootstrap } from "../../project/bootstrap"
+import { upgrade } from "../upgrade"
+import { Log } from "../../util/log"
+
+const log = Log.create({ service: "serve" })
+
+/** Delay before the one-shot startup check, letting the listener settle first. */
+export const STARTUP_UPGRADE_DELAY_MS = 1000
+
+/**
+ * Runs a single best-effort upgrade check, mirroring the TUI worker
+ * (`cli/cmd/tui/worker.ts` → `checkUpgrade`): provide an `Instance` context for
+ * `upgrade()` but — exactly like the worker — do NOT dispose it.
+ *
+ * `upgrade()` reads only global config + `Installation`, but `Bus.publish`
+ * (its update notifications) needs an ambient instance. We use the same
+ * `process.cwd()` key the server's default-directory requests use
+ * (`server/server.ts:196`), so we reuse/seed that shared cached instance rather
+ * than a throwaway one, and Bus notifications still reach default-directory SSE
+ * subscribers.
+ *
+ * Crucially we never dispose: an earlier version wrapped this in `bootstrap()`,
+ * whose `finally` → `Instance.dispose()` tears down the entire `process.cwd()`
+ * bucket — including state created by concurrent server requests that defaulted
+ * to that directory (use-after-dispose / needless churn). The worker avoids
+ * this by running in a separate thread; in-process we avoid it by not disposing.
+ *
+ * Resolves, never rejects: `upgrade()` swallows its own errors via the inner
+ * catch; the outer guard only fires for an `Instance.provide` failure.
+ */
+export async function runStartupUpgradeCheck(): Promise<void> {
+  try {
+    await Instance.provide({
+      directory: process.cwd(),
+      init: InstanceBootstrap,
+      fn: () => upgrade().catch((err) => log.error("startup upgrade check failed", { error: String(err) })),
+    })
+  } catch (err) {
+    log.error("startup upgrade instance failed", { error: String(err) })
+  }
+}
+
+/** Schedules {@link runStartupUpgradeCheck} after a short settle delay; non-blocking. */
+export function scheduleStartupUpgradeCheck(): void {
+  setTimeout(() => void runStartupUpgradeCheck(), STARTUP_UPGRADE_DELAY_MS).unref?.()
+}
+// altimate_change end

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -9,11 +9,7 @@ import { Installation } from "../../installation"
 import { subscribeTraceConsumer } from "../../altimate/observability/trace-consumer"
 // altimate_change end
 // altimate_change start — self-update on headless serve startup
-import { bootstrap } from "../bootstrap"
-import { upgrade } from "../upgrade"
-import { Log } from "../../util/log"
-
-const log = Log.create({ service: "serve" })
+import { scheduleStartupUpgradeCheck } from "./serve-upgrade-check"
 // altimate_change end
 
 export const ServeCommand = cmd({
@@ -48,18 +44,9 @@ export const ServeCommand = cmd({
     // checked for updates: auto-update was wired solely into the TUI bootstrap
     // (cli/cmd/tui/thread.ts → worker.checkUpgrade → upgrade()). As a result the
     // extension fleet froze at whatever version was installed at onboarding.
-    //
-    // Mirror the TUI here: fire a single best-effort upgrade check shortly after
-    // the server is listening. All policy lives inside upgrade() — install-method
-    // detection, the `autoupdate` config gate (true / false / "notify"), the
-    // downgrade guard, and telemetry — so this is just the missing trigger.
-    // Fire-and-forget and fully detached from request handling; errors are logged,
-    // never thrown, so a flaky network or registry can't take the server down.
-    setTimeout(() => {
-      bootstrap(process.cwd(), () =>
-        upgrade().catch((err) => log.error("startup upgrade check failed", { error: String(err) })),
-      ).catch((err) => log.error("startup upgrade bootstrap failed", { error: String(err) }))
-    }, 1000).unref?.()
+    // Fire the missing trigger here; see serve-upgrade-check.ts for why it runs
+    // in (but never disposes) the process.cwd() instance.
+    scheduleStartupUpgradeCheck()
     // altimate_change end
 
     // Finalize traces on shutdown. `serve` blocks forever on the promise below

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -2,9 +2,6 @@ import { Server } from "../../server/server"
 import { cmd } from "./cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "../../flag/flag"
-import { Workspace } from "../../control-plane/workspace"
-import { Project } from "../../project/project"
-import { Installation } from "../../installation"
 // altimate_change start — trace: session tracing in headless serve
 import { subscribeTraceConsumer } from "../../altimate/observability/trace-consumer"
 // altimate_change end

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -8,6 +8,13 @@ import { Installation } from "../../installation"
 // altimate_change start — trace: session tracing in headless serve
 import { subscribeTraceConsumer } from "../../altimate/observability/trace-consumer"
 // altimate_change end
+// altimate_change start — self-update on headless serve startup
+import { bootstrap } from "../bootstrap"
+import { upgrade } from "../upgrade"
+import { Log } from "../../util/log"
+
+const log = Log.create({ service: "serve" })
+// altimate_change end
 
 export const ServeCommand = cmd({
   command: "serve",
@@ -34,6 +41,26 @@ export const ServeCommand = cmd({
     // location — trace files always go to the configured tracing dir
     // (`tracing.dir`, default ~/.local/share/altimate-code/traces/).
     const traceSub = subscribeTraceConsumer({ directory: process.cwd() })
+
+    // altimate_change start — self-update on startup
+    // A headless `serve` is how the VS Code / Cursor extension runs
+    // altimate-code, and it is the ONLY long-running entrypoint that never
+    // checked for updates: auto-update was wired solely into the TUI bootstrap
+    // (cli/cmd/tui/thread.ts → worker.checkUpgrade → upgrade()). As a result the
+    // extension fleet froze at whatever version was installed at onboarding.
+    //
+    // Mirror the TUI here: fire a single best-effort upgrade check shortly after
+    // the server is listening. All policy lives inside upgrade() — install-method
+    // detection, the `autoupdate` config gate (true / false / "notify"), the
+    // downgrade guard, and telemetry — so this is just the missing trigger.
+    // Fire-and-forget and fully detached from request handling; errors are logged,
+    // never thrown, so a flaky network or registry can't take the server down.
+    setTimeout(() => {
+      bootstrap(process.cwd(), () =>
+        upgrade().catch((err) => log.error("startup upgrade check failed", { error: String(err) })),
+      ).catch((err) => log.error("startup upgrade bootstrap failed", { error: String(err) }))
+    }, 1000).unref?.()
+    // altimate_change end
 
     // Finalize traces on shutdown. `serve` blocks forever on the promise below
     // and otherwise dies abruptly on signal, so without these handlers the

--- a/packages/opencode/test/cli/serve-upgrade-check.test.ts
+++ b/packages/opencode/test/cli/serve-upgrade-check.test.ts
@@ -1,59 +1,64 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test"
+import { beforeEach, describe, expect, test } from "bun:test"
 import { Log } from "../../src/util/log"
+import { runStartupUpgradeCheck, STARTUP_UPGRADE_DELAY_MS, type StartupUpgradeDeps } from "../../src/cli/cmd/serve-upgrade-check"
 
 Log.init({ print: false })
 
-// State the mocks record so each test can assert orchestration.
-let upgradeCalls = 0
-let upgradeShouldThrow = false
-let provideDirectory: string | undefined
-let provideCalls = 0
-
-// Mirror the real Instance.provide contract just enough: capture the directory
-// key and run the supplied fn (no real instance, no dispose).
-mock.module("../../src/project/instance", () => ({
-  Instance: {
-    provide: async (input: { directory: string; fn: () => Promise<unknown> }) => {
-      provideCalls++
-      provideDirectory = input.directory
-      return input.fn()
-    },
-  },
-}))
-
-mock.module("../../src/project/bootstrap", () => ({
-  InstanceBootstrap: async () => {},
-}))
-
-mock.module("../../src/cli/upgrade", () => ({
-  upgrade: async () => {
-    upgradeCalls++
-    if (upgradeShouldThrow) throw new Error("boom")
-  },
-}))
-
-const { runStartupUpgradeCheck, STARTUP_UPGRADE_DELAY_MS } = await import("../../src/cli/cmd/serve-upgrade-check")
-
+// No mock.module here: it is process-global in bun and would clobber
+// ../upgrade / ../../project/instance for every other test in the run. The
+// collaborators are injected instead.
 describe("serve-upgrade-check", () => {
+  let runCalls: number
+  let runShouldThrow: boolean
+  let provideCalls: number
+  let provideDirectory: string | undefined
+
+  function makeDeps(): StartupUpgradeDeps {
+    return {
+      provide: async (directory, fn) => {
+        provideCalls++
+        provideDirectory = directory
+        return fn()
+      },
+      run: async () => {
+        runCalls++
+        if (runShouldThrow) throw new Error("boom")
+      },
+    }
+  }
+
   beforeEach(() => {
-    upgradeCalls = 0
-    upgradeShouldThrow = false
-    provideDirectory = undefined
+    runCalls = 0
+    runShouldThrow = false
     provideCalls = 0
+    provideDirectory = undefined
   })
 
   test("runs upgrade() once inside the process.cwd() instance", async () => {
-    await runStartupUpgradeCheck()
-    expect(upgradeCalls).toBe(1)
+    await runStartupUpgradeCheck(makeDeps())
+    expect(runCalls).toBe(1)
     expect(provideCalls).toBe(1)
     expect(provideDirectory).toBe(process.cwd())
   })
 
   test("resolves without throwing when upgrade() rejects", async () => {
-    upgradeShouldThrow = true
+    runShouldThrow = true
     // Must not reject — a flaky network/registry can't take the server down.
-    await expect(runStartupUpgradeCheck()).resolves.toBeUndefined()
-    expect(upgradeCalls).toBe(1)
+    await expect(runStartupUpgradeCheck(makeDeps())).resolves.toBeUndefined()
+    expect(runCalls).toBe(1)
+  })
+
+  test("resolves without throwing when provide() itself rejects", async () => {
+    const deps: StartupUpgradeDeps = {
+      provide: async () => {
+        throw new Error("instance boom")
+      },
+      run: async () => {
+        runCalls++
+      },
+    }
+    await expect(runStartupUpgradeCheck(deps)).resolves.toBeUndefined()
+    expect(runCalls).toBe(0)
   })
 
   test("uses a short, sane settle delay", () => {

--- a/packages/opencode/test/cli/serve-upgrade-check.test.ts
+++ b/packages/opencode/test/cli/serve-upgrade-check.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test"
+import { Log } from "../../src/util/log"
+
+Log.init({ print: false })
+
+// State the mocks record so each test can assert orchestration.
+let upgradeCalls = 0
+let upgradeShouldThrow = false
+let provideDirectory: string | undefined
+let provideCalls = 0
+
+// Mirror the real Instance.provide contract just enough: capture the directory
+// key and run the supplied fn (no real instance, no dispose).
+mock.module("../../src/project/instance", () => ({
+  Instance: {
+    provide: async (input: { directory: string; fn: () => Promise<unknown> }) => {
+      provideCalls++
+      provideDirectory = input.directory
+      return input.fn()
+    },
+  },
+}))
+
+mock.module("../../src/project/bootstrap", () => ({
+  InstanceBootstrap: async () => {},
+}))
+
+mock.module("../../src/cli/upgrade", () => ({
+  upgrade: async () => {
+    upgradeCalls++
+    if (upgradeShouldThrow) throw new Error("boom")
+  },
+}))
+
+const { runStartupUpgradeCheck, STARTUP_UPGRADE_DELAY_MS } = await import("../../src/cli/cmd/serve-upgrade-check")
+
+describe("serve-upgrade-check", () => {
+  beforeEach(() => {
+    upgradeCalls = 0
+    upgradeShouldThrow = false
+    provideDirectory = undefined
+    provideCalls = 0
+  })
+
+  test("runs upgrade() once inside the process.cwd() instance", async () => {
+    await runStartupUpgradeCheck()
+    expect(upgradeCalls).toBe(1)
+    expect(provideCalls).toBe(1)
+    expect(provideDirectory).toBe(process.cwd())
+  })
+
+  test("resolves without throwing when upgrade() rejects", async () => {
+    upgradeShouldThrow = true
+    // Must not reject — a flaky network/registry can't take the server down.
+    await expect(runStartupUpgradeCheck()).resolves.toBeUndefined()
+    expect(upgradeCalls).toBe(1)
+  })
+
+  test("uses a short, sane settle delay", () => {
+    expect(STARTUP_UPGRADE_DELAY_MS).toBeGreaterThan(0)
+    expect(STARTUP_UPGRADE_DELAY_MS).toBeLessThanOrEqual(5000)
+  })
+})


### PR DESCRIPTION
PINEAPPLE

## Summary

Triggers a best-effort auto-update check when headless `altimate serve` starts, so extension-launched servers follow the same upgrade path as TUI.

Updated implementation details to match the final code:

- Schedules a one-time startup check (~1s after server listen) via a dedicated helper.
- Runs the check in `Instance.provide({ directory: process.cwd(), init: InstanceBootstrap, fn: ... })` (no `bootstrap()` wrapper), avoiding unintended `Instance.dispose()` teardown during in-process server runtime.
- Keeps all update policy inside `upgrade()` (autoupdate gating, install method handling, downgrade guard, telemetry).
- Uses explicit error handling/logging for both upgrade execution failures and outer orchestration failures.
- Extracts logic into `packages/opencode/src/cli/cmd/serve-upgrade-check.ts`.
- Adds dependency injection for collaborators in the helper to avoid process-global module mocking in tests.

## Test Plan

- Ran targeted tests for startup upgrade check behavior:
  - delayed scheduling
  - `process.cwd()` instance usage
  - non-throwing behavior when upgrade/provide fail
- Verified combined CLI test coverage after mock isolation fix:
  - `packages/opencode/test/cli` suite passing (`512 pass, 0 fail`).
- Verified CI TypeScript failure caused by leaked `mock.module` state is resolved by DI-based test rewrite.

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] CHANGELOG updated (if user-facing)