### PR TITLE
fix(opencode): move volatile date out of cached system prefix

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -969,6 +969,24 @@ export namespace SessionPrompt {
 
       await Plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
+      // altimate_change start — upstream_fix: carry the date in the trailing user message
+      // so it stays out of the cache-controlled system prefix (see session/system.ts).
+      const lastUserForDate = msgs.findLast((m) => m.info.role === "user")
+      if (lastUserForDate) {
+        lastUserForDate.parts = [
+          ...lastUserForDate.parts,
+          {
+            type: "text" as const,
+            id: PartID.ascending(),
+            sessionID,
+            messageID: lastUserForDate.info.id,
+            text: `\n\n${SystemPrompt.currentDate()}`,
+            synthetic: true,
+          },
+        ]
+      }
+      // altimate_change end
+
       // Build system prompt, adding structured output instruction if needed
       const skills = await SystemPrompt.skills(agent)
       // altimate_change start - unified context-aware injection for memory + training

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -75,7 +75,12 @@ export namespace SystemPrompt {
         `  Workspace root folder: ${Instance.worktree}`,
         `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
         `  Platform: ${process.platform}`,
-        `  Today's date: ${new Date().toDateString()}`,
+        // altimate_change start — upstream_fix: move volatile date out of cached system prefix
+        // The date changes daily but environment() is the first entry in the system[]
+        // array, which applyCaching() marks with cacheControl. A session crossing midnight
+        // within the cache TTL would otherwise invalidate the whole system prefix. The date
+        // is appended to the trailing user message instead (see session/prompt.ts).
+        // altimate_change end
         `</env>`,
         `<directories>`,
         `  ${
@@ -90,6 +95,12 @@ export namespace SystemPrompt {
       ].join("\n"),
     ]
   }
+
+  // altimate_change start — upstream_fix: date carried outside the cached system prefix
+  export function currentDate() {
+    return `Today's date is ${new Date().toDateString()}.`
+  }
+  // altimate_change end
 
   export async function skills(agent: Agent.Info) {
     if (PermissionNext.disabled(["skill"], agent.permission).has("skill")) return

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -166,11 +166,12 @@ description: ${description}
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
+        const today = new Date().toDateString()
         const [env] = await SystemPrompt.environment(makeModel({ apiId: "claude-3-7-sonnet" }))
         expect(env).toMatch(/<env>/)
         expect(env).not.toMatch(/Today's date/)
-        expect(env).not.toContain(new Date().toDateString())
-        expect(SystemPrompt.currentDate()).toContain(new Date().toDateString())
+        expect(env).not.toContain(today)
+        expect(SystemPrompt.currentDate()).toContain(today)
       },
     })
   })

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, setSystemTime, test } from "bun:test"
 import path from "path"
 import { Agent } from "../../src/agent/agent"
 import { Instance } from "../../src/project/instance"
@@ -162,17 +162,25 @@ description: ${description}
   })
 
   test("environment() keeps the volatile date out of the cached system prefix", async () => {
-    await using tmp = await tmpdir({ git: true })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const today = new Date().toDateString()
-        const [env] = await SystemPrompt.environment(makeModel({ apiId: "claude-3-7-sonnet" }))
-        expect(env).toMatch(/<env>/)
-        expect(env).not.toMatch(/Today's date/)
-        expect(env).not.toContain(today)
-        expect(SystemPrompt.currentDate()).toContain(today)
-      },
-    })
+    // Freeze the clock so the captured `today` and the `new Date()` inside
+    // currentDate() read the same instant — otherwise the assertion can race
+    // across midnight.
+    setSystemTime(new Date("2026-06-17T12:00:00.000Z"))
+    try {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const today = new Date().toDateString()
+          const [env] = await SystemPrompt.environment(makeModel({ apiId: "claude-3-7-sonnet" }))
+          expect(env).toMatch(/<env>/)
+          expect(env).not.toMatch(/Today's date/)
+          expect(env).not.toContain(today)
+          expect(SystemPrompt.currentDate()).toContain(today)
+        },
+      })
+    } finally {
+      setSystemTime()
+    }
   })
 })

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -160,4 +160,18 @@ description: ${description}
       process.env.OPENCODE_TEST_HOME = home
     }
   })
+
+  test("environment() keeps the volatile date out of the cached system prefix", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const [env] = await SystemPrompt.environment(makeModel({ apiId: "claude-3-7-sonnet" }))
+        expect(env).toMatch(/<env>/)
+        expect(env).not.toMatch(/Today's date/)
+        expect(env).not.toContain(new Date().toDateString())
+        expect(SystemPrompt.currentDate()).toContain(new Date().toDateString())
+      },
+    })
+  })
 })


### PR DESCRIPTION
Fixes #949.

## Summary

The environment system prompt put `Today's date: …` first in the system message array, and `applyCaching` marks the first two system messages with `cacheControl`. So the one token in that block that changes daily lived inside the cached prefix. A session that crosses local midnight while still within the cache TTL gets a different prefix on the next request, missing the cache and re-billing the whole system block as a write.

The fix drops the date line from `environment()` and appends it to the trailing user message, past the cache breakpoint, via a small `currentDate` helper. It reuses the existing synthetic-text-part pattern already used in `loop()`. The model still sees the date; the cached system bytes are now date-invariant. Both edits are wrapped in `altimate_change` / `upstream_fix` markers since the touched code is inherited from upstream.

## Test Plan

Extended `test/session/system.test.ts` to assert the `environment()` output no longer contains the date string and that the new helper does. The test freezes system time so the date assertions are deterministic across a midnight boundary. `bun test test/session/system.test.ts` passes (8); `bun run typecheck` is clean.

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] CHANGELOG updated (if user-facing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the current date is managed in session prompts to ensure consistent availability in chat interactions.

* **Tests**
  * Added test coverage for date handling in session system prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->