### PR TITLE
ci(release): cap dist-* build-artifact retention at 2 days

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,8 +130,9 @@ jobs:
           # These are intra-run couriers: the publish + gh-release jobs download
           # them within the same run, then the binaries live permanently as npm
           # packages + GitHub Release assets. Keep them only long enough to span
-          # the run so they don't accumulate against the org artifact-storage quota.
-          retention-days: 2
+          # the run (worst run ~62 min) plus margin for a next-day partial re-run,
+          # so they don't accumulate against the org artifact-storage quota.
+          retention-days: 5
 
   # ---------------------------------------------------------------------------
   # Verdaccio sanity suite — tests the real `npm install -g` flow BEFORE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,11 @@ jobs:
           name: dist-${{ matrix.name }}
           path: packages/opencode/dist/
           compression-level: 1
+          # These are intra-run couriers: the publish + gh-release jobs download
+          # them within the same run, then the binaries live permanently as npm
+          # packages + GitHub Release assets. Keep them only long enough to span
+          # the run so they don't accumulate against the org artifact-storage quota.
+          retention-days: 2
 
   # ---------------------------------------------------------------------------
   # Verdaccio sanity suite — tests the real `npm install -g` flow BEFORE


### PR DESCRIPTION
## Why

The Release workflow's per-platform `dist-*` artifacts (`actions/upload-artifact`, no `retention-days` set) were inheriting the org's 90-day default and piling up to **~90 GB across releases dating back to March 20** — single-handedly exhausting the **shared org Actions artifact-storage quota** and causing `Failed to CreateArtifact: Artifact storage quota has been hit` failures in *other* repos (e.g. altimate-ingestion PR builds).

## These artifacts are spent intra-run couriers

`dist-*` only exists to hand the compiled binaries from the build matrix to the publish/release jobs **within the same run**. Job chain (no `environment:`/approval gates — verified):

```
build (uploads dist-*) → sanity-verdaccio → publish-npm (downloads dist-*, npm publish) → github-release (downloads dist-*, uploads Release assets)
```

After the run, the binaries live permanently in two places, **neither of which is an Actions artifact and neither counts against the storage quota**:
- **npm registry** — `npm publish` uploads an immutable copy; npm never references the GitHub artifact again.
- **GitHub Release assets** — `*.tar.gz`/`*.zip` + `checksums.txt`; these carry real download counts (v0.8.0 linux-x64 = 200, v0.8.7 darwin-arm64 = 179), proving this is the actual distribution path the installers use.

Org-wide code search confirmed **nothing downloads `dist-*` cross-run or cross-repo**.

## Why `retention-days: 5` is safe (evidence)

The artifact only needs to survive one release run. Measured durations of recent runs:

| Release | Duration |
|---|---|
| v0.7.1 (longest in history) | 62 min |
| v0.8.5 | 37 min |
| v0.8.0–v0.8.7 (typical) | 13–15 min |

5 days → **~116x margin over the worst-ever run** (62 min), ~480x over typical. Bumped from an initial 2 days to give comfortable headroom for re-running a partial publish/release job days later without a full rebuild.

**Residual risk (accepted):** re-running *only* the `publish-npm`/`github-release` job >2 days after the build would find the artifact expired — fix is to re-run the whole release (rebuilds `dist-*`), which is normal practice.

## Cleanup already done

Separately deleted the existing backlog: 324 `dist-*` artifacts older than June 1 (**74.3 GB**) via the API. altimate-code live artifact storage dropped 90.73 GB → 16.40 GB, bringing the org back under the storage quota (after GitHub's 6–12h usage recalc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal CI/CD workflow configuration to optimize artifact storage management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->