### PR TITLE
feat: [AI-7401] stamp launch_surface on serve telemetry events

### DIFF
--- a/packages/opencode/src/altimate/telemetry/index.ts
+++ b/packages/opencode/src/altimate/telemetry/index.ts
@@ -1325,8 +1325,12 @@ export namespace Telemetry {
         // Account unavailable — proceed without user ID
       }
       // Set by the IDE extension when it spawns `altimate serve`; absent for
-      // direct CLI/TUI invocations.
-      launchSurface = process.env.ALTIMATE_LAUNCH_SURFACE ?? ""
+      // direct CLI/TUI invocations. Normalize casing/whitespace and restrict to
+      // a known set so a stray env value can't inflate the launch_surface
+      // dimension's cardinality. New surfaces must be added to KNOWN_LAUNCH_SURFACES.
+      const KNOWN_LAUNCH_SURFACES = new Set(["ide", "cli", "tui"])
+      const rawLaunchSurface = (process.env.ALTIMATE_LAUNCH_SURFACE ?? "").trim().toLowerCase()
+      launchSurface = KNOWN_LAUNCH_SURFACES.has(rawLaunchSurface) ? rawLaunchSurface : ""
       try {
         const machineIdPath = path.join(os.homedir(), ".altimate", "machine-id")
         try {

--- a/packages/opencode/src/altimate/telemetry/index.ts
+++ b/packages/opencode/src/altimate/telemetry/index.ts
@@ -1198,6 +1198,10 @@ export namespace Telemetry {
   let flushTimer: ReturnType<typeof setInterval> | undefined
   let userEmail = ""
   let machineId = ""
+  // Where this serve process was launched from ("ide" when spawned by an
+  // editor extension, "" for CLI/TUI). Stamped onto every event so analytics
+  // can attribute sessions to IDE vs terminal usage.
+  let launchSurface = ""
   let sessionId = ""
   let projectId = ""
   let appInsights: AppInsightsConfig | undefined
@@ -1228,6 +1232,7 @@ export namespace Telemetry {
         cli_version: Installation.VERSION,
         project_id: fields.project_id ?? projectId,
         ...(machineId && { machine_id: machineId }),
+        ...(launchSurface && { launch_surface: launchSurface }),
       }
       const measurements: Record<string, number> = {}
 
@@ -1319,6 +1324,9 @@ export namespace Telemetry {
       } catch {
         // Account unavailable — proceed without user ID
       }
+      // Set by the IDE extension when it spawns `altimate serve`; absent for
+      // direct CLI/TUI invocations.
+      launchSurface = process.env.ALTIMATE_LAUNCH_SURFACE ?? ""
       try {
         const machineIdPath = path.join(os.homedir(), ".altimate", "machine-id")
         try {
@@ -1449,6 +1457,7 @@ export namespace Telemetry {
     sessionId = ""
     projectId = ""
     machineId = ""
+    launchSurface = ""
     initPromise = undefined
     initDone = false
   }

--- a/packages/opencode/test/telemetry/telemetry.test.ts
+++ b/packages/opencode/test/telemetry/telemetry.test.ts
@@ -596,6 +596,40 @@ describe("telemetry.toAppInsightsEnvelopes (indirect)", () => {
     }
   })
 
+  test("launch_surface is stamped on every event when ALTIMATE_LAUNCH_SURFACE is set", async () => {
+    const origSurface = process.env.ALTIMATE_LAUNCH_SURFACE
+    process.env.ALTIMATE_LAUNCH_SURFACE = "ide"
+    const { fetchCalls, cleanup } = await initWithMockedFetch()
+    try {
+      Telemetry.track({ type: "session_start", timestamp: 1700000000000, session_id: "sess-ide" })
+      await Telemetry.flush()
+
+      const envelopes = JSON.parse(fetchCalls[0].body)
+      expect(envelopes[0].data.baseData.properties.launch_surface).toBe("ide")
+    } finally {
+      cleanup()
+      if (origSurface !== undefined) process.env.ALTIMATE_LAUNCH_SURFACE = origSurface
+      else delete process.env.ALTIMATE_LAUNCH_SURFACE
+    }
+  })
+
+  test("launch_surface is omitted when ALTIMATE_LAUNCH_SURFACE is unset (CLI/TUI)", async () => {
+    const origSurface = process.env.ALTIMATE_LAUNCH_SURFACE
+    delete process.env.ALTIMATE_LAUNCH_SURFACE
+    const { fetchCalls, cleanup } = await initWithMockedFetch()
+    try {
+      Telemetry.track({ type: "session_start", timestamp: 1700000000000, session_id: "sess-cli" })
+      await Telemetry.flush()
+
+      const envelopes = JSON.parse(fetchCalls[0].body)
+      expect(envelopes[0].data.baseData.properties.launch_surface).toBeUndefined()
+    } finally {
+      cleanup()
+      if (origSurface !== undefined) process.env.ALTIMATE_LAUNCH_SURFACE = origSurface
+      else delete process.env.ALTIMATE_LAUNCH_SURFACE
+    }
+  })
+
   test("numeric fields go to measurements, string fields go to properties", async () => {
     const { fetchCalls, cleanup } = await initWithMockedFetch()
     try {

--- a/packages/opencode/test/telemetry/telemetry.test.ts
+++ b/packages/opencode/test/telemetry/telemetry.test.ts
@@ -604,7 +604,9 @@ describe("telemetry.toAppInsightsEnvelopes (indirect)", () => {
       Telemetry.track({ type: "session_start", timestamp: 1700000000000, session_id: "sess-ide" })
       await Telemetry.flush()
 
+      expect(fetchCalls.length).toBeGreaterThan(0)
       const envelopes = JSON.parse(fetchCalls[0].body)
+      expect(envelopes.length).toBeGreaterThan(0)
       expect(envelopes[0].data.baseData.properties.launch_surface).toBe("ide")
     } finally {
       cleanup()
@@ -621,7 +623,47 @@ describe("telemetry.toAppInsightsEnvelopes (indirect)", () => {
       Telemetry.track({ type: "session_start", timestamp: 1700000000000, session_id: "sess-cli" })
       await Telemetry.flush()
 
+      expect(fetchCalls.length).toBeGreaterThan(0)
       const envelopes = JSON.parse(fetchCalls[0].body)
+      expect(envelopes.length).toBeGreaterThan(0)
+      expect(envelopes[0].data.baseData.properties.launch_surface).toBeUndefined()
+    } finally {
+      cleanup()
+      if (origSurface !== undefined) process.env.ALTIMATE_LAUNCH_SURFACE = origSurface
+      else delete process.env.ALTIMATE_LAUNCH_SURFACE
+    }
+  })
+
+  test("launch_surface normalizes casing and surrounding whitespace", async () => {
+    const origSurface = process.env.ALTIMATE_LAUNCH_SURFACE
+    process.env.ALTIMATE_LAUNCH_SURFACE = "  IDE "
+    const { fetchCalls, cleanup } = await initWithMockedFetch()
+    try {
+      Telemetry.track({ type: "session_start", timestamp: 1700000000000, session_id: "sess-norm" })
+      await Telemetry.flush()
+
+      expect(fetchCalls.length).toBeGreaterThan(0)
+      const envelopes = JSON.parse(fetchCalls[0].body)
+      expect(envelopes.length).toBeGreaterThan(0)
+      expect(envelopes[0].data.baseData.properties.launch_surface).toBe("ide")
+    } finally {
+      cleanup()
+      if (origSurface !== undefined) process.env.ALTIMATE_LAUNCH_SURFACE = origSurface
+      else delete process.env.ALTIMATE_LAUNCH_SURFACE
+    }
+  })
+
+  test("launch_surface drops unrecognized values to keep the dimension low-cardinality", async () => {
+    const origSurface = process.env.ALTIMATE_LAUNCH_SURFACE
+    process.env.ALTIMATE_LAUNCH_SURFACE = "totally-bogus"
+    const { fetchCalls, cleanup } = await initWithMockedFetch()
+    try {
+      Telemetry.track({ type: "session_start", timestamp: 1700000000000, session_id: "sess-bogus" })
+      await Telemetry.flush()
+
+      expect(fetchCalls.length).toBeGreaterThan(0)
+      const envelopes = JSON.parse(fetchCalls[0].body)
+      expect(envelopes.length).toBeGreaterThan(0)
       expect(envelopes[0].data.baseData.properties.launch_surface).toBeUndefined()
     } finally {
       cleanup()


### PR DESCRIPTION
## Goal

Tie IDE sessions to Altimate Code telemetry (AI-7401). The serve harness already emits `session_start`, `session_end`, and `agent_outcome` (`completed` / `aborted` / `abandoned` / `error`) plus returning-user identity (`machine_id`, `first_launch`). The one missing dimension is **launch surface** — there is no way to tell an IDE-webview session from a CLI/TUI one. This adds it.

## Change

`packages/opencode/src/altimate/telemetry/index.ts`:
- Read `ALTIMATE_LAUNCH_SURFACE` once at telemetry init into a module-level `launchSurface`.
- Stamp it as a `launch_surface` property on every App Insights envelope, alongside the existing `machine_id` (omitted when the env var is unset).
- Reset it on `shutdown()`.

The IDE extension sets `ALTIMATE_LAUNCH_SURFACE=ide` when it spawns `altimate serve` (see paired PR `AltimateAI/vscode-altimate-mcp-server#<EXT_PR>`). Direct CLI/TUI invocations leave it unset, so `launch_surface` is absent — querying `launch_surface == "ide"` selects IDE sessions; everything else is terminal.

No new event types and no per-session plumbing: the existing lifecycle events simply gain a filterable dimension.

## Tests

Two new cases in `test/telemetry/telemetry.test.ts` (present-when-set, omitted-when-unset). Full file: **132 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013aDZXEPBPcBAYNNcrKZomN

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `launch_surface` property to all serve telemetry events to distinguish IDE vs terminal sessions (AI-7401). Read `ALTIMATE_LAUNCH_SURFACE` at init, trim/lowercase, allow only `ide`/`cli`/`tui`, and omit the field when unset or unrecognized.

<sup>Written for commit 58adf31075002d7f400d1e4814ce3b90382e8ed9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry events now include the app’s launch surface (e.g., IDE, CLI, TUI) to better distinguish how the app was started.

* **Bug Fixes**
  * Improved normalization and validation of launch-surface data, ensuring it’s omitted when unavailable or unrecognized.
  * Added test coverage for launch-surface behavior across multiple environment-variable scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->