### PR TITLE
docs: correct REVIEW.md inaccuracies flagged by automated review

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -9,7 +9,7 @@ CI here enforces type-safety and marker presence, not runtime correctness of asy
 ## Don't duplicate CI — never flag
 
 - **`bun turbo typecheck` / `tsc`** — pure type errors, unused type imports. If it compiles, don't relitigate types.
-- **Marker Guard** — presence/format of `altimate_change` marker comments is CI-enforced at compile time (see #872, #904). Don't flag a *missing* marker as a guess; CI will fail the PR. Do still flag *misuse* (see Focus Areas below) since Marker Guard checks presence, not correctness.
+- **Marker Guard** — presence/format of `altimate_change` marker comments is enforced by a dedicated CI job (`marker-guard` in `ci.yml`, see #872, #904), not at compile time. Don't flag a *missing* marker as a guess; CI will fail the PR. Do still flag *misuse* (see Focus Areas below) since Marker Guard checks presence, not correctness.
 - **`anti-slop.yml`** — advisory only (made non-blocking after #741 auto-closed legitimate PRs); don't treat its output as a merge gate.
 - **PR title/standards (`pr-standards.yml`)** — conventional-commit-style title checks are automated; don't nitpick title format.
 - Pre-existing issues in code the diff doesn't touch.


### PR DESCRIPTION
## Summary
Follow-up to #983 — corrects a wording inaccuracy in `REVIEW.md` flagged by automated review (CodeRabbit).

- `REVIEW.md` stated the `Marker Guard` / `altimate_change` marker check is "CI-enforced at compile time." It isn't — it's a dedicated `marker-guard` job in `ci.yml` (`bun run script/upstream/analyze.ts --markers`), separate from the typecheck step. The old wording overstated the guarantee and could mislead reviewers about when marker failures actually surface. Fixed to describe it as a CI job, not a compile-time check.

## Test plan
- [x] Verified via `.github/workflows/ci.yml` (`marker-guard` job, line 448) that the marker check runs as its own CI step, not during typecheck/compile.
- [x] `wc -m REVIEW.md` → 9603 (under the 10,000 char budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected REVIEW.md to fix an inaccuracy about Marker Guard enforcement. Clarifies the check is handled by a dedicated CI job (`marker-guard` in `ci.yml`), not at compile time.

<sup>Written for commit 51995765ad21651fcb5fea0b76afb36113e16452. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the “Marker Guard” guidance to reflect that marker checks are enforced by a dedicated CI job.
  * Kept the existing rule to avoid guessing missing markers and to continue flagging incorrect usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->