### PR TITLE
ci: add aireceipts pr-check (notice-only cost receipt)

### DIFF
--- a/.github/workflows/aireceipts.yml
+++ b/.github/workflows/aireceipts.yml
@@ -1,0 +1,12 @@
+name: aireceipts
+on: [pull_request]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npx -y aireceipts-cli@latest pr-check
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Adds a **notice-only** aireceipts cost-receipt check (pr-check) — one self-contained workflow, no external reusable workflow, no org Actions-policy change. Never fails a build; posts an aireceipts cost receipt only once a branch carries an aireceipts receipt ref, otherwise a quiet no-op. Coexists with any existing check; remove anytime by deleting the file. Part of an org-wide aireceipts dogfood.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a notice-only aireceipts PR check to post AI cost receipts on pull requests. It never fails builds and is a no-op unless the branch has an aireceipts receipt ref.

- **New Features**
  - Adds `.github/workflows/aireceipts.yml` that runs on pull requests.
  - Executes `npx -y aireceipts-cli@latest pr-check` with `GH_TOKEN`.
  - Posts a cost receipt comment when a receipt ref is present; otherwise quiet.
  - Self-contained and removable by deleting the workflow file.

<sup>Written for commit f46532174b21ff170898b6c8c496530890db25cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated pull request check to help validate changes during review.
  * The new workflow runs on pull request events and posts its results back to the PR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->