### PR TITLE
ci: add aireceipts auto-attach hook (two-file kit)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "npx -y aireceipts-cli@latest hook pre-push",
-            "timeout": 10
+            "timeout": 60
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -y aireceipts-cli@latest hook pre-push",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds the **second file** of the aireceipts two-file kit: the `.claude/settings.json` `PreToolUse` hook that auto-attaches a receipt ref on push, so receipts generate **automatically** (no manual command) and the existing `pr-check` workflow has something to post.

- The hook runs `npx -y aireceipts-cli@latest hook pre-push`; it **never blocks your push** (exits 0 on every path, no output) and only acts on a real branch push to `origin`.
- This repo runs **no other `refs/receipts/*` producer**, so there is no collision.
- Remove anytime by deleting/reverting the file.

Part of the org-wide aireceipts dogfood (v0.6.0).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `.claude/settings.json` PreToolUse hook that auto-attaches an aireceipts receipt on push. Receipts generate automatically so the `pr-check` workflow has data to post.

- **New Features**
  - Runs `npx -y aireceipts-cli@latest hook pre-push` with a 60s timeout (cold-cache headroom).
  - Never blocks pushes (always exits 0, no output).
  - Only runs on real branch pushes to `origin`.

<sup>Written for commit 43208086973753b7103f4fb54c4428dac2994c97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated pre-push hook to run an `aireceipts-cli` pre-push check before changes are sent.
  * The hook includes a timeout to keep the pre-push step responsive.
  * Helps catch issues earlier and improves consistency in the local development workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->