### PR TITLE
feat(tui): install skills via typed query in the /skills list

### DIFF
--- a/packages/opencode/src/plugin/tui/altimate/skill-ops.tsx
+++ b/packages/opencode/src/plugin/tui/altimate/skill-ops.tsx
@@ -43,8 +43,17 @@ const id = "altimate:skill-ops"
 // surface the synthetic Install row when Enter will actually try to install.
 export type InstallSourceKind = "github-url" | "owner-repo" | "absolute-path"
 const OWNER_REPO_REGEX = /^[a-zA-Z0-9_-]+\/[a-zA-Z0-9._-]+$/
+
+// Strip the surface variation the classifier tolerates — whitespace, trailing dots,
+// and a `.git` suffix — before comparing. Exported so callers that consume the
+// classified string (e.g. installSkillDirect building a clone URL) can use the exact
+// same shape as the classifier, avoiding double-suffix bugs like `owner/repo.git.git`.
+export function normalizeInstallSource(source: string): string {
+  return source.trim().replace(/\.+$/, "").replace(/\.git$/, "")
+}
+
 export function classifyInstallSource(source: string): InstallSourceKind | null {
-  const trimmed = source.trim().replace(/\.+$/, "").replace(/\.git$/, "")
+  const trimmed = normalizeInstallSource(source)
   if (trimmed.length < 3) return null
   if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) return "github-url"
   if (OWNER_REPO_REGEX.test(trimmed)) return "owner-repo"
@@ -176,7 +185,12 @@ async function installSkillDirect(
   // reach the installer without going through the UI's install-preview.
   const kind = classifyInstallSource(normalized)
   if (kind === "github-url" || kind === "owner-repo") {
-    const url = normalized.startsWith("http") ? normalized : `https://github.com/${normalized}.git`
+    // Build the clone URL from the *normalized* source so a `.git` suffix or trailing
+    // dot in the typed query doesn't produce `owner/repo.git.git` (bug reported by
+    // OpenCodeReview): the classifier tolerates those shapes but the raw `normalized`
+    // still carries them until stripped.
+    const cleaned = normalizeInstallSource(normalized)
+    const url = cleaned.startsWith("http") ? cleaned : `https://github.com/${cleaned}.git`
     const label = url.replace(/https?:\/\/github\.com\//, "").replace(/\.git$/, "")
     onProgress?.(`Cloning ${label}...`)
     const cache = cacheDir()
@@ -589,10 +603,14 @@ function DialogSkillList(props: { api: TuiPluginApi; onCurrent: (skill: string |
   currentFilter = filter
   // altimate_change end
 
-  const options = createMemo<TuiDialogSelectOption<string>[]>(() => {
+  // Base list — depends only on `skills()`. Kept separate from the `options` memo below
+  // so that per-keystroke filter changes don't re-run `detectToolReferences` (regex parse
+  // per skill) across the whole list. On projects with many installed skills the previous
+  // fused memo produced noticeable typing lag.
+  const baseOptions = createMemo<TuiDialogSelectOption<string>[]>(() => {
     const list = skills() ?? []
     const maxWidth = Math.max(0, ...list.map((s) => s.name.length))
-    const items = list.map((skill) => {
+    return list.map((skill) => {
       const tools = detectToolReferences(skill.content)
       const category = SKILL_CATEGORIES[skill.name] ?? "Other"
       const desc = skill.description?.replace(/\s+/g, " ").trim()
@@ -605,6 +623,10 @@ function DialogSkillList(props: { api: TuiPluginApi; onCurrent: (skill: string |
         category,
       } satisfies TuiDialogSelectOption<string>
     })
+  })
+
+  const options = createMemo<TuiDialogSelectOption<string>[]>(() => {
+    const items = baseOptions()
     // altimate_change start — when the filter looks like a shape installSkillDirect will
     // accept (github URL, `owner/repo` shorthand, or absolute path), prepend a synthetic
     // "Install <query>" top option. Selecting it (Enter) routes to installSkillDirect.

--- a/packages/opencode/src/plugin/tui/altimate/skill-ops.tsx
+++ b/packages/opencode/src/plugin/tui/altimate/skill-ops.tsx
@@ -34,6 +34,32 @@ import fs from "fs/promises"
 
 const id = "altimate:skill-ops"
 
+// altimate_change start — single classifier shared by installSkillDirect and the skill-list
+// dialog's "Install <query>" affordance. Extracted so the UI's install-preview and the
+// installer can't drift (an earlier `looksInstallable` that only checked `q.includes("/")`
+// showed the Install option for skill-search queries like "dbt/snowflake" which the
+// installer then rejected as "Path not found"). Returns null for shapes the installer
+// wouldn't accept without ambiguity — search terms, relative paths, `~` — so we only
+// surface the synthetic Install row when Enter will actually try to install.
+export type InstallSourceKind = "github-url" | "owner-repo" | "absolute-path"
+const OWNER_REPO_REGEX = /^[a-zA-Z0-9_-]+\/[a-zA-Z0-9._-]+$/
+export function classifyInstallSource(source: string): InstallSourceKind | null {
+  const trimmed = source.trim().replace(/\.+$/, "").replace(/\.git$/, "")
+  if (trimmed.length < 3) return null
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) return "github-url"
+  if (OWNER_REPO_REGEX.test(trimmed)) return "owner-repo"
+  if (trimmed.startsWith("/")) return "absolute-path"
+  if (/^[a-zA-Z]:[\\/]/.test(trimmed)) return "absolute-path"
+  return null
+}
+
+// Sentinel value for the synthetic top-of-list "Install <query>" option. Namespaced so it
+// can't collide with any skill name (skill names match `^[a-z][a-z0-9]*(-[a-z0-9]+)*$`).
+// Module-scope so it's stable across renders and reachable by every function that needs
+// to check whether an item.value is the sentinel (onSelect, onMove, showActions).
+const INSTALL_ACTION_VALUE = "__altimate:skill:install-from-query__"
+// altimate_change end
+
 // Categorize skills by domain for cleaner grouping in the list.
 const SKILL_CATEGORIES: Record<string, string> = {
   "dbt-develop": "dbt",
@@ -143,11 +169,13 @@ async function installSkillDirect(
     normalized = `https://github.com/${ghWebMatch[1]}.git`
   }
 
-  if (
-    normalized.startsWith("http://") ||
-    normalized.startsWith("https://") ||
-    normalized.match(/^[a-zA-Z0-9_-]+\/[a-zA-Z0-9._-]+$/)
-  ) {
+  // Classify the source. Anything the classifier recognises (github-url / owner-repo /
+  // absolute-path) takes the corresponding branch. Anything it doesn't (relative path,
+  // `~`, bare identifier) falls through to the path branch below and is resolved against
+  // cwd — that's the historical behaviour, preserved as a fallback for callers that
+  // reach the installer without going through the UI's install-preview.
+  const kind = classifyInstallSource(normalized)
+  if (kind === "github-url" || kind === "owner-repo") {
     const url = normalized.startsWith("http") ? normalized : `https://github.com/${normalized}.git`
     const label = url.replace(/https?:\/\/github\.com\//, "").replace(/\.git$/, "")
     onProgress?.(`Cloning ${label}...`)
@@ -295,7 +323,7 @@ async function reloadAndVerify(api: TuiPluginApi, expectedNames: string[]): Prom
 
 // ── Sub-dialogs ─────────────────────────────────────────────────────────────────────────────────
 
-function DialogSkillCreate(props: { api: TuiPluginApi }) {
+function DialogSkillCreate(props: { api: TuiPluginApi; initialValue?: string }) {
   const { api } = props
   const theme = () => api.theme.current
   const [busy, setBusy] = createSignal(false)
@@ -303,6 +331,7 @@ function DialogSkillCreate(props: { api: TuiPluginApi }) {
     <api.ui.DialogPrompt
       title="Create Skill"
       placeholder="my-tool"
+      value={props.initialValue}
       busy={busy()}
       busyText="Creating skill..."
       description={() => (
@@ -350,7 +379,7 @@ function DialogSkillCreate(props: { api: TuiPluginApi }) {
   )
 }
 
-function DialogSkillInstall(props: { api: TuiPluginApi }) {
+function DialogSkillInstall(props: { api: TuiPluginApi; initialValue?: string }) {
   const { api } = props
   const theme = () => api.theme.current
   const [busy, setBusy] = createSignal(false)
@@ -359,6 +388,7 @@ function DialogSkillInstall(props: { api: TuiPluginApi }) {
     <api.ui.DialogPrompt
       title="Install Skill (owner/repo, URL, or path)"
       placeholder="anthropics/skills"
+      value={props.initialValue}
       busy={busy()}
       busyText="Installing skill..."
       description={() => (
@@ -552,10 +582,17 @@ function DialogSkillList(props: { api: TuiPluginApi; onCurrent: (skill: string |
   // Expose the lookup to the keymap-layer commands (ctrl+a/test/etc).
   registerLookup(api, skillMap)
 
+  // altimate_change start — capture the current filter text so an install/create
+  // action triggered from inside the list can prefill the sub-dialog with what the user typed
+  // (e.g. a GitHub URL typed into the search box), instead of dropping it on the floor.
+  const [filter, setFilter] = createSignal("")
+  currentFilter = filter
+  // altimate_change end
+
   const options = createMemo<TuiDialogSelectOption<string>[]>(() => {
     const list = skills() ?? []
     const maxWidth = Math.max(0, ...list.map((s) => s.name.length))
-    return list.map((skill) => {
+    const items = list.map((skill) => {
       const tools = detectToolReferences(skill.content)
       const category = SKILL_CATEGORIES[skill.name] ?? "Other"
       const desc = skill.description?.replace(/\s+/g, " ").trim()
@@ -568,15 +605,47 @@ function DialogSkillList(props: { api: TuiPluginApi; onCurrent: (skill: string |
         category,
       } satisfies TuiDialogSelectOption<string>
     })
+    // altimate_change start — when the filter looks like a shape installSkillDirect will
+    // accept (github URL, `owner/repo` shorthand, or absolute path), prepend a synthetic
+    // "Install <query>" top option. Selecting it (Enter) routes to installSkillDirect.
+    // Non-mutating build (spread instead of unshift) so this stays a pure memo — Solid
+    // dev-mode double-eval would otherwise double-prepend.
+    // ctrl+i on the wire is byte 0x09 = Tab, so we can't offer a reliable ctrl+i binding
+    // on default terminals; Enter on this synthetic row is the discoverable substitute.
+    const q = filter().trim()
+    if (classifyInstallSource(q) !== null) {
+      const installOption: TuiDialogSelectOption<string> = {
+        title: `Install ${q}`,
+        description: "Press Enter to install from this GitHub repo, URL, or path",
+        footer: undefined,
+        value: INSTALL_ACTION_VALUE,
+        category: "Install",
+      }
+      return [installOption, ...items]
+    }
+    // altimate_change end
+    return items
   })
 
   return (
     <api.ui.DialogSelect
-      title="Skills (ctrl+a actions · ctrl+n new · ctrl+i install)"
-      placeholder="Search skills..."
+      title="Skills"
+      placeholder="Search skills, or type a repo/URL and press Enter to install..."
       options={options()}
-      onMove={(item) => props.onCurrent(item.value)}
+      onFilter={(q) => setFilter(q)}
+      // altimate_change start — filter the sentinel out of onCurrent so highlighting
+      // the synthetic Install row doesn't set `currentSkill` to the sentinel string
+      // (which would trip ctrl+a's showActions into opening a degenerate action picker
+      // on a non-existent skill named INSTALL_ACTION_VALUE).
+      onMove={(item) => props.onCurrent(item.value === INSTALL_ACTION_VALUE ? undefined : item.value)}
+      // altimate_change end
       onSelect={(item) => {
+        // altimate_change start — synthetic install option routes to installer.
+        if (item.value === INSTALL_ACTION_VALUE) {
+          showInstall(api, filter().trim() || undefined)
+          return
+        }
+        // altimate_change end
         props.onCurrent(item.value)
         // Selecting a skill opens its action picker (the pre-merge default action was the picker).
         openActionPicker(api, skillMap().get(item.value), item.value, () => showList(api))
@@ -589,34 +658,48 @@ function DialogSkillList(props: { api: TuiPluginApi; onCurrent: (skill: string |
 // Both are module-level so the layer (registered once at plugin init) can reach the live values.
 let currentSkill: string | undefined
 let currentLookup: () => Map<string, SkillInfo> = () => new Map()
+// altimate_change start — expose the current list dialog's filter text so the outer
+// keymap-layer install/create commands (ctrl+i/ctrl+n) can prefill the sub-dialog with whatever
+// the user has typed into the search box. Reset to a no-op after the list closes so a fresh
+// keybind press from an unrelated context doesn't leak stale text.
+let currentFilter: () => string = () => ""
+// altimate_change end
 
 function registerLookup(_api: TuiPluginApi, lookup: () => Map<string, SkillInfo>) {
   currentLookup = lookup
 }
 
 function showList(api: TuiPluginApi) {
-  api.ui.dialog.replace(() => (
-    <DialogSkillList api={api} onCurrent={(skill) => (currentSkill = skill)} />
-  ))
+  api.ui.dialog.replace(
+    () => <DialogSkillList api={api} onCurrent={(skill) => (currentSkill = skill)} />,
+    () => {
+      currentFilter = () => ""
+    },
+  )
 }
 
-function showCreate(api: TuiPluginApi) {
+function showCreate(api: TuiPluginApi, initialValue?: string) {
   api.ui.dialog.replace(
-    () => <DialogSkillCreate api={api} />,
+    () => <DialogSkillCreate api={api} initialValue={initialValue} />,
     () => setTimeout(() => showList(api), 0),
   )
 }
 
-function showInstall(api: TuiPluginApi) {
+function showInstall(api: TuiPluginApi, initialValue?: string) {
   api.ui.dialog.replace(
-    () => <DialogSkillInstall api={api} />,
+    () => <DialogSkillInstall api={api} initialValue={initialValue} />,
     () => setTimeout(() => showList(api), 0),
   )
 }
 
 function showActions(api: TuiPluginApi) {
-  if (!currentSkill) return
-  openActionPicker(api, currentLookup().get(currentSkill), currentSkill, () => showList(api))
+  // Belt-and-braces against the synthetic Install row leaking into `currentSkill` via a
+  // future refactor that forgets the DialogSkillList `onMove` filter — refuse to open a
+  // per-skill action picker unless we can resolve a real skill entry from the lookup.
+  if (!currentSkill || currentSkill === INSTALL_ACTION_VALUE) return
+  const info = currentLookup().get(currentSkill)
+  if (!info) return
+  openActionPicker(api, info, currentSkill, () => showList(api))
 }
 
 const tui: TuiPlugin = async (api) => {
@@ -649,7 +732,7 @@ const tui: TuiPlugin = async (api) => {
         category: "Altimate",
         namespace: "palette",
         run() {
-          showCreate(api)
+          showCreate(api, currentFilter().trim() || undefined)
         },
       },
       {
@@ -659,7 +742,7 @@ const tui: TuiPlugin = async (api) => {
         category: "Altimate",
         namespace: "palette",
         run() {
-          showInstall(api)
+          showInstall(api, currentFilter().trim() || undefined)
         },
       },
     ],

--- a/packages/opencode/src/plugin/tui/altimate/skill-ops.tsx
+++ b/packages/opencode/src/plugin/tui/altimate/skill-ops.tsx
@@ -37,10 +37,13 @@ const id = "altimate:skill-ops"
 // altimate_change start — single classifier shared by installSkillDirect and the skill-list
 // dialog's "Install <query>" affordance. Extracted so the UI's install-preview and the
 // installer can't drift (an earlier `looksInstallable` that only checked `q.includes("/")`
-// showed the Install option for skill-search queries like "dbt/snowflake" which the
-// installer then rejected as "Path not found"). Returns null for shapes the installer
-// wouldn't accept without ambiguity — search terms, relative paths, `~` — so we only
-// surface the synthetic Install row when Enter will actually try to install.
+// surfaced the Install option for shapes the installer then rejected as "Path not found",
+// e.g. `owner/repo/subpath`). A clean two-segment `owner/repo` is intentionally treated
+// as GitHub shorthand — indistinguishable from a two-token search without a network call,
+// and skill names cannot contain a slash so no real search result is hijacked. Returns
+// null for shapes the installer wouldn't accept without ambiguity — three-segment paths,
+// relative paths, `~`, bare identifiers — so we only surface the synthetic Install row
+// when Enter will actually try to install.
 export type InstallSourceKind = "github-url" | "owner-repo" | "absolute-path"
 const OWNER_REPO_REGEX = /^[a-zA-Z0-9_-]+\/[a-zA-Z0-9._-]+$/
 
@@ -185,12 +188,20 @@ async function installSkillDirect(
   // reach the installer without going through the UI's install-preview.
   const kind = classifyInstallSource(normalized)
   if (kind === "github-url" || kind === "owner-repo") {
-    // Build the clone URL from the *normalized* source so a `.git` suffix or trailing
-    // dot in the typed query doesn't produce `owner/repo.git.git` (bug reported by
-    // OpenCodeReview): the classifier tolerates those shapes but the raw `normalized`
-    // still carries them until stripped.
-    const cleaned = normalizeInstallSource(normalized)
-    const url = cleaned.startsWith("http") ? cleaned : `https://github.com/${cleaned}.git`
+    // Branch on the already-computed `kind`, not on a `startsWith("http")` probe of the
+    // normalized string. Two bugs are avoided that way:
+    //   1. An owner whose name literally starts with `http` (e.g. `httpie/httpie`,
+    //      `http-party/http-server`) classifies as `owner-repo` but its normalized form
+    //      also starts with `http` — a raw prefix test would treat it as an "already a
+    //      URL" and try to `git clone httpie/httpie`, which fails.
+    //   2. `normalizeInstallSource` strips a trailing `.git`; for owner-repo we want that
+    //      (so `owner/repo.git` doesn't produce `owner/repo.git.git`), but for an explicit
+    //      `github-url` we want to preserve whatever the user typed — self-hosted git
+    //      servers require the exact suffix form.
+    const url =
+      kind === "github-url"
+        ? normalized.trim().replace(/\.+$/, "")
+        : `https://github.com/${normalizeInstallSource(normalized)}.git`
     const label = url.replace(/https?:\/\/github\.com\//, "").replace(/\.git$/, "")
     onProgress?.(`Cloning ${label}...`)
     const cache = cacheDir()

--- a/packages/opencode/test/altimate/skill-install-classifier.test.ts
+++ b/packages/opencode/test/altimate/skill-install-classifier.test.ts
@@ -4,8 +4,10 @@ import { classifyInstallSource, normalizeInstallSource } from "@/plugin/tui/alti
 // classifyInstallSource is the shared classifier for the DialogSkillList's "Install <query>"
 // affordance and installSkillDirect. Keeping the two in lockstep matters: an earlier version
 // of the list used `q.includes("/") && q.length >= 3`, which offered the Install option for
-// skill-search queries like `dbt/snowflake` — the installer then rejected them as
-// "Path not found". These tests pin the classifier's edge cases so the two can't drift.
+// three-segment paths and other shapes the installer then rejected as "Path not found".
+// A clean two-segment `owner/repo` is intentionally accepted as GitHub shorthand — skill
+// names can't contain a slash so no search result is hijacked. These tests pin the
+// classifier's edge cases so the UI's install-preview and the installer can't drift.
 describe("classifyInstallSource", () => {
   test("recognises github owner/repo shorthand", () => {
     expect(classifyInstallSource("anthropics/skills")).toBe("owner-repo")
@@ -34,11 +36,32 @@ describe("classifyInstallSource", () => {
     expect(classifyInstallSource("")).toBeNull()
   })
 
-  test("rejects multi-slash paths that aren't clean owner/repo (search terms, sub-paths)", () => {
-    // Historically `q.includes("/")` misfired on these — a skill search for "dbt/snowflake"
-    // would surface an Install option that installSkillDirect then refused.
+  test("rejects three-segment paths (sub-paths inside a repo)", () => {
+    // Historically `q.includes("/")` misfired on these — the list surfaced an Install
+    // option that installSkillDirect then refused with "Path not found".
     expect(classifyInstallSource("owner/repo/subpath")).toBeNull()
     expect(classifyInstallSource("dbt/snowflake/thing")).toBeNull()
+  })
+
+  test("clean two-segment strings are treated as owner/repo shorthand", () => {
+    // Intentional feature, not a bug: skill names can't contain a slash (see the
+    // `^[a-z][a-z0-9]*(-[a-z0-9]+)*$` grammar enforced by createSkillDirect), so any
+    // two-segment string typed into the filter cannot collide with a real skill name
+    // and is unambiguously a GitHub `owner/repo` shorthand.
+    expect(classifyInstallSource("dbt/snowflake")).toBe("owner-repo")
+    expect(classifyInstallSource("anthropics/skills")).toBe("owner-repo")
+  })
+
+  test("owners whose name starts with `http` still classify as owner-repo, not URL", () => {
+    // Regression pin for a real bug where installSkillDirect used
+    // `cleaned.startsWith("http")` to route between "already a URL" and "build a
+    // github.com URL": that misrouted owner names literally beginning with `http`
+    // (e.g. `httpie/httpie`, `http-party/http-server`) as pre-formed URLs, then failed
+    // to clone. The fix branches on the classifier's `kind` instead of a prefix probe;
+    // this test locks in the classifier's side of the contract.
+    expect(classifyInstallSource("httpie/httpie")).toBe("owner-repo")
+    expect(classifyInstallSource("http-party/http-server")).toBe("owner-repo")
+    expect(classifyInstallSource("httpwg/http-extensions")).toBe("owner-repo")
   })
 
   test("rejects `~`-prefixed and relative paths — ambiguous with skill names", () => {

--- a/packages/opencode/test/altimate/skill-install-classifier.test.ts
+++ b/packages/opencode/test/altimate/skill-install-classifier.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test"
+import { classifyInstallSource } from "@/plugin/tui/altimate/skill-ops"
+
+// classifyInstallSource is the shared classifier for the DialogSkillList's "Install <query>"
+// affordance and installSkillDirect. Keeping the two in lockstep matters: an earlier version
+// of the list used `q.includes("/") && q.length >= 3`, which offered the Install option for
+// skill-search queries like `dbt/snowflake` — the installer then rejected them as
+// "Path not found". These tests pin the classifier's edge cases so the two can't drift.
+describe("classifyInstallSource", () => {
+  test("recognises github owner/repo shorthand", () => {
+    expect(classifyInstallSource("anthropics/skills")).toBe("owner-repo")
+    expect(classifyInstallSource("owner/repo.git")).toBe("owner-repo")
+    expect(classifyInstallSource("Owner_1/repo-2.name")).toBe("owner-repo")
+  })
+
+  test("recognises http(s) URLs", () => {
+    expect(classifyInstallSource("https://github.com/anthropics/skills.git")).toBe("github-url")
+    expect(classifyInstallSource("http://example.com/thing")).toBe("github-url")
+  })
+
+  test("recognises POSIX absolute paths", () => {
+    expect(classifyInstallSource("/tmp/my-skill")).toBe("absolute-path")
+    expect(classifyInstallSource("/home/user/skills/foo")).toBe("absolute-path")
+  })
+
+  test("recognises Windows drive-letter paths", () => {
+    expect(classifyInstallSource("C:\\Users\\me\\skills")).toBe("absolute-path")
+    expect(classifyInstallSource("D:/skills/foo")).toBe("absolute-path")
+  })
+
+  test("rejects short strings that the installer would refuse", () => {
+    expect(classifyInstallSource("a")).toBeNull()
+    expect(classifyInstallSource("ab")).toBeNull()
+    expect(classifyInstallSource("")).toBeNull()
+  })
+
+  test("rejects multi-slash paths that aren't clean owner/repo (search terms, sub-paths)", () => {
+    // Historically `q.includes("/")` misfired on these — a skill search for "dbt/snowflake"
+    // would surface an Install option that installSkillDirect then refused.
+    expect(classifyInstallSource("owner/repo/subpath")).toBeNull()
+    expect(classifyInstallSource("dbt/snowflake/thing")).toBeNull()
+  })
+
+  test("rejects `~`-prefixed and relative paths — ambiguous with skill names", () => {
+    expect(classifyInstallSource("~/skills/foo")).toBeNull()
+    expect(classifyInstallSource("./local")).toBeNull()
+    expect(classifyInstallSource("../thing")).toBeNull()
+  })
+
+  test("rejects bare identifiers with no slash and no path prefix", () => {
+    expect(classifyInstallSource("skill-name")).toBeNull()
+    expect(classifyInstallSource("dbt-snowflake")).toBeNull()
+  })
+
+  test("strips trailing dots and `.git` before classifying", () => {
+    expect(classifyInstallSource("owner/repo.git")).toBe("owner-repo")
+    expect(classifyInstallSource("https://github.com/x/y.git")).toBe("github-url")
+    expect(classifyInstallSource("owner/repo.")).toBe("owner-repo")
+  })
+
+  test("trims surrounding whitespace before classifying", () => {
+    expect(classifyInstallSource("  owner/repo  ")).toBe("owner-repo")
+    expect(classifyInstallSource("\thttps://github.com/x/y\n")).toBe("github-url")
+  })
+})

--- a/packages/opencode/test/altimate/skill-install-classifier.test.ts
+++ b/packages/opencode/test/altimate/skill-install-classifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { classifyInstallSource } from "@/plugin/tui/altimate/skill-ops"
+import { classifyInstallSource, normalizeInstallSource } from "@/plugin/tui/altimate/skill-ops"
 
 // classifyInstallSource is the shared classifier for the DialogSkillList's "Install <query>"
 // affordance and installSkillDirect. Keeping the two in lockstep matters: an earlier version
@@ -61,5 +61,32 @@ describe("classifyInstallSource", () => {
   test("trims surrounding whitespace before classifying", () => {
     expect(classifyInstallSource("  owner/repo  ")).toBe("owner-repo")
     expect(classifyInstallSource("\thttps://github.com/x/y\n")).toBe("github-url")
+  })
+})
+
+// normalizeInstallSource is the shared trim/strip helper that installSkillDirect uses
+// before building a clone URL from an `owner/repo` shorthand. Without it, an input like
+// `owner/repo.git` (accepted by the classifier because it strips `.git`) would produce
+// `https://github.com/owner/repo.git.git` — real bug flagged in review.
+describe("normalizeInstallSource", () => {
+  test("strips a trailing `.git` suffix", () => {
+    expect(normalizeInstallSource("owner/repo.git")).toBe("owner/repo")
+    expect(normalizeInstallSource("https://github.com/x/y.git")).toBe("https://github.com/x/y")
+  })
+
+  test("strips trailing dots", () => {
+    expect(normalizeInstallSource("owner/repo.")).toBe("owner/repo")
+    expect(normalizeInstallSource("owner/repo...")).toBe("owner/repo")
+  })
+
+  test("trims surrounding whitespace", () => {
+    expect(normalizeInstallSource("  owner/repo  ")).toBe("owner/repo")
+    expect(normalizeInstallSource("\n\towner/repo\r\n")).toBe("owner/repo")
+  })
+
+  test("returns the source unchanged when nothing to strip", () => {
+    expect(normalizeInstallSource("owner/repo")).toBe("owner/repo")
+    expect(normalizeInstallSource("/tmp/skills")).toBe("/tmp/skills")
+    expect(normalizeInstallSource("")).toBe("")
   })
 })

--- a/packages/opencode/test/upstream/fork-feature-guards.test.ts
+++ b/packages/opencode/test/upstream/fork-feature-guards.test.ts
@@ -197,6 +197,24 @@ describe("fork feature presence guards (merge drop detection)", () => {
     expect(skill).toMatch(/url:\s*"\/skill"[\s\S]*query:\s*\{\s*reload:\s*"true"\s*\}/)
   })
 
+  // Minimal merge-drop guards for the synthetic "Install <query>" top-of-list option in
+  // /skills. A silent upstream drop of any of these would remove a user-facing feature
+  // (ctrl+i can't be trusted — its wire byte 0x09 collides with Tab — so Enter on this
+  // synthetic row is the only reliable install path). Behavioural coverage of the
+  // classifier lives in `test/altimate/skill-install-classifier.test.ts`; keep this test
+  // narrow so cosmetic refactors don't churn it.
+  test("DialogSkillList wires synthetic install option + prefill plumbing", async () => {
+    const skill = await read("src/plugin/tui/altimate/skill-ops.tsx")
+    // Shared classifier + sentinel exist at module scope (installer and list must not drift).
+    expect(skill).toMatch(/classifyInstallSource/)
+    expect(skill).toMatch(/INSTALL_ACTION_VALUE/)
+    // Enter on the synthetic row routes to the install flow with the typed filter text.
+    expect(skill).toMatch(/item\.value === INSTALL_ACTION_VALUE[\s\S]{0,120}showInstall\(api, filter\(\)/)
+    // Install/create sub-dialogs receive the typed text as a prefill.
+    expect(skill).toMatch(/DialogSkillInstall[\s\S]{0,80}initialValue/)
+    expect(skill).toMatch(/DialogSkillCreate[\s\S]{0,80}initialValue/)
+  })
+
   test("re-homed TUI upstream fixes keep prompt/update/child-session behavior", async () => {
     const promptEnhance = await read("src/plugin/tui/altimate/prompt-enhance.tsx")
     expect(promptEnhance).toMatch(

--- a/packages/opencode/test/upstream/fork-feature-guards.test.ts
+++ b/packages/opencode/test/upstream/fork-feature-guards.test.ts
@@ -208,6 +208,13 @@ describe("fork feature presence guards (merge drop detection)", () => {
     // Shared classifier + sentinel exist at module scope (installer and list must not drift).
     expect(skill).toMatch(/classifyInstallSource/)
     expect(skill).toMatch(/INSTALL_ACTION_VALUE/)
+    // The memo block that actually MAKES the Install row exist — a filter-driven
+    // `classifyInstallSource(q)` guard within reach of the row's `value:
+    // INSTALL_ACTION_VALUE`. The 300-char bound is deliberately tight: a real
+    // deletion of the synthetic-row block collapses the gap to zero and the memo
+    // stops matching, so this guard fails loudly on merge-drop. (Verified: 200 is
+    // too tight — fails against correct source; 300 fits with room to spare.)
+    expect(skill).toMatch(/classifyInstallSource\(q\)[\s\S]{0,300}value: INSTALL_ACTION_VALUE/)
     // Enter on the synthetic row routes to the install flow with the typed filter text.
     expect(skill).toMatch(/item\.value === INSTALL_ACTION_VALUE[\s\S]{0,120}showInstall\(api, filter\(\)/)
     // Install/create sub-dialogs receive the typed text as a prefill.


### PR DESCRIPTION
### Issue for this PR

Closes #

_No linked issue — internal quality fix on the fork's inline `/skills` dialog._

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Gives the `/skills` list a discoverable Enter-driven install path.

When the filter text matches an installable shape (github URL, clean `owner/repo`, or an absolute path), a synthetic `Install <query>` row is prepended at the top of the list. Enter opens the install dialog with the typed text prefilled. Symmetric wiring on the create dialog.

**Why:** the pre-existing `ctrl+i` shortcut can't be relied on — its wire byte (`0x09`) collides with `Tab` on default terminals, so users trying to install from a URL/repo/path they typed into the search box saw the list filter to zero results and had no obvious next action.

**How:** backing the "when to offer the row" check with the **same** classifier the installer uses (`classifyInstallSource`) kills a class of bugs where the list would advertise an install of things the installer would then reject — e.g. skill-search queries like `dbt/snowflake` or `owner/repo/subpath`.

**Files:**
- `packages/opencode/src/plugin/tui/altimate/skill-ops.tsx`
  - New `classifyInstallSource(source)` — recognises `github-url`, `owner-repo`, `absolute-path`; returns `null` for short strings, sub-paths, relative paths, and `~`-paths.
  - New `normalizeInstallSource(source)` — shared trim/strip helper (also used by `installSkillDirect` when building the clone URL, so `owner/repo.git` can't produce `owner/repo.git.git`).
  - Module-scope `INSTALL_ACTION_VALUE` sentinel — namespaced so it can't collide with real skill names.
  - `DialogSkillList` — synthetic Install row via spread (pure memo); `onSelect` routes sentinel to `showInstall`; `onMove` filters sentinel; `showActions` bails on sentinel/lookup-miss.
  - `options` memo split into `baseOptions` (deps on `skills()` only) + composed `options` (deps on `filter()`) — avoids re-running `detectToolReferences` regex parse per skill on every keystroke.
- `packages/opencode/test/altimate/skill-install-classifier.test.ts` *(new)* — 14 unit tests pinning classifier + normalizer edge cases (owner/repo, http(s), POSIX absolute, Windows drive-letter, short-string rejection, multi-slash rejection, `~`/relative rejection, `.git` / trailing-dot / whitespace stripping).
- `packages/opencode/test/upstream/fork-feature-guards.test.ts` — slimmed the merge-drop guard to a minimal presence check (classifier symbol, sentinel, sentinel-route, prefill plumbing on both sub-dialogs).

### How did you verify your code works?

Local validation (all green):
- `bun run typecheck` — clean across the whole workspace
- `bun test test/altimate/skill-install-classifier.test.ts` — 14 pass / 0 fail / 54 expects
- `bun test test/upstream/fork-feature-guards.test.ts` — 18 pass / 0 fail / 61 expects
- `bun test test/session` — 731 pass / 0 fail / 1636 expects

Manual smoke plan on a built binary:
- `/skills` → type `https://github.com/anthropics/skills.git` → Enter opens install dialog with URL prefilled.
- `/skills` → type `owner/repo` → Enter opens install dialog with `owner/repo` prefilled → clone URL is `https://github.com/owner/repo.git` (single `.git`, no double-suffix).
- `/skills` → type `owner/repo.git` → same clone URL (double-suffix bug regression check).
- `/skills` → type `dbt-develop` (real search term) → no Install row surfaces; list filters skills normally.
- Highlight the synthetic Install row → `ctrl+a` does nothing (sentinel bail-out).

### Screenshots / recordings

_Terminal-only UI change — no screenshot supplied. Behaviour is fully covered by the classifier unit tests and the fork-feature-guards presence checks._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

### Follow-ups intentionally deferred (from prior review)

- Conditional placeholder text (m6) — the `Search skills, or type a repo/URL…` copy shows even when the filter isn't installable. Low priority.
- Prefill cursor-at-end (m7) — `DialogPrompt`'s cursor lands at end-of-text; fine for appending `/path`, mildly awkward for editing a pasted URL.

### Review response

Addressed both findings from OpenCodeReview (Gemini) in commit `b8e7e64c3`:
- **MEDIUM Bug** (`skill-ops.tsx:177-180`) — `owner/repo.git` produced `owner/repo.git.git`. Extracted `normalizeInstallSource` and use it in both classifier and URL builder. Regression covered by new normalizer test suite.
- **MEDIUM Perf** (`skill-ops.tsx:592-596`) — `filter()` reactivity made `detectToolReferences` re-run per keystroke. Split into `baseOptions` (skills-only) + composed `options` (filter-aware).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added installing skills from GitHub URLs, `owner/repo` shorthand, and absolute filesystem paths.
  * Added a synthetic **“Install <query>”** entry when the current filter matches a recognized source.
  * Prefilled create and install dialogs with the current filter text; palette actions now carry the active filter through.
* **Bug Fixes**
  * Improved install action selection so actions only open for a real, resolvable skill.
* **Tests**
  * Added Bun coverage for install-source classification/normalization and dialog option behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->