### PR TITLE
review: --no-ai fix + --explain-tier / --force-tier flags + manifest auto-discovery + column-aware schema.yml test-removal

### DIFF
--- a/packages/opencode/src/altimate/review/compiled.ts
+++ b/packages/opencode/src/altimate/review/compiled.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs"
 import path from "node:path"
 import YAML from "yaml"
+import { safeReadInside } from "./git"
 
 /**
  * Resolve dbt's COMPILED SQL for static analysis.
@@ -80,17 +81,9 @@ export function makeCompiledResolver(opts: CompiledResolverOptions) {
     const rel = prefix && (file === prefix || file.startsWith(prefix + "/")) ? file.slice(prefix.length + 1) : file
     const root = side === "new" ? headDir : baseDir
     const compiledRoot = path.join(opts.cwd, root, project)
-    // Containment check via realpath — matches makeContentResolver's
-    // symlink-safe read (coderabbit + cubic security review). A symlinked
-    // compiled artifact pointing outside `compiledRoot` is not read.
-    try {
-      const rootReal = await fs.realpath(compiledRoot)
-      const targetReal = await fs.realpath(path.join(compiledRoot, rel))
-      const sep = path.sep
-      if (targetReal !== rootReal && !targetReal.startsWith(rootReal + sep)) return undefined
-      return await fs.readFile(targetReal, "utf8")
-    } catch {
-      return undefined
-    }
+    // Shared realpath containment check — matches makeContentResolver's
+    // symlink-safe read so a future tweak to the containment logic can't
+    // leave one call site behind (cubic + kilo suggestion).
+    return await safeReadInside(compiledRoot, rel)
   }
 }

--- a/packages/opencode/src/altimate/review/compiled.ts
+++ b/packages/opencode/src/altimate/review/compiled.ts
@@ -36,12 +36,20 @@ export async function dbtProjectName(cwd: string): Promise<string | undefined> {
 }
 
 export interface CompiledResolverOptions {
+  /** dbt project root (the dir containing `dbt_project.yml`). */
   cwd: string
   projectName?: string
   /** Directory holding HEAD-side compiled SQL (relative to cwd). */
   headDir?: string
   /** Directory holding BASE-side compiled SQL (relative to cwd). */
   baseDir?: string
+  /** Prefix within the repo-relative file path that maps to `cwd`.
+   *  For a monorepo where the dbt project lives at `packages/dbt/`, callers
+   *  pass `pathPrefix: "packages/dbt"` so a repo-relative path like
+   *  `packages/dbt/models/foo.sql` resolves inside the dbt project root as
+   *  `models/foo.sql` before joining with `target/compiled/<project>/`.
+   *  Omit when `cwd` IS the repo root. */
+  pathPrefix?: string
 }
 
 /**
@@ -52,11 +60,26 @@ export function makeCompiledResolver(opts: CompiledResolverOptions) {
   const project = opts.projectName
   const headDir = opts.headDir ?? "target/compiled"
   const baseDir = opts.baseDir ?? "target-base/compiled"
+  // Normalise the prefix so both "" and "." mean "no prefix". Match against
+  // git-style forward slashes because `git diff --name-status` always emits
+  // POSIX separators regardless of platform. `path.relative()` on Windows
+  // returns backslashes, so callers passing that verbatim would produce a
+  // prefix that never matches — normalise here (codex R20 review HIGH).
+  const prefix =
+    opts.pathPrefix && opts.pathPrefix !== "."
+      ? opts.pathPrefix.replace(/\\/g, "/").replace(/\/+$/, "")
+      : ""
 
   return async (file: string, side: "old" | "new"): Promise<string | undefined> => {
     if (!project) return undefined
+    // When the dbt project sits inside a subdir of the repo, `file` (from
+    // `git diff --name-status`) is repo-root relative and always uses
+    // POSIX separators. Strip the mapped prefix so it becomes dbt-root
+    // relative before joining with `cwd` (which IS the dbt root). Without
+    // this the compiled resolver silently misses in monorepo layouts.
+    const rel = prefix && (file === prefix || file.startsWith(prefix + "/")) ? file.slice(prefix.length + 1) : file
     const root = side === "new" ? headDir : baseDir
-    const full = path.join(opts.cwd, root, project, file)
+    const full = path.join(opts.cwd, root, project, rel)
     try {
       return await fs.readFile(full, "utf8")
     } catch {

--- a/packages/opencode/src/altimate/review/compiled.ts
+++ b/packages/opencode/src/altimate/review/compiled.ts
@@ -79,9 +79,16 @@ export function makeCompiledResolver(opts: CompiledResolverOptions) {
     // this the compiled resolver silently misses in monorepo layouts.
     const rel = prefix && (file === prefix || file.startsWith(prefix + "/")) ? file.slice(prefix.length + 1) : file
     const root = side === "new" ? headDir : baseDir
-    const full = path.join(opts.cwd, root, project, rel)
+    const compiledRoot = path.join(opts.cwd, root, project)
+    // Containment check via realpath — matches makeContentResolver's
+    // symlink-safe read (coderabbit + cubic security review). A symlinked
+    // compiled artifact pointing outside `compiledRoot` is not read.
     try {
-      return await fs.readFile(full, "utf8")
+      const rootReal = await fs.realpath(compiledRoot)
+      const targetReal = await fs.realpath(path.join(compiledRoot, rel))
+      const sep = path.sep
+      if (targetReal !== rootReal && !targetReal.startsWith(rootReal + sep)) return undefined
+      return await fs.readFile(targetReal, "utf8")
     } catch {
       return undefined
     }

--- a/packages/opencode/src/altimate/review/dbt-patterns.ts
+++ b/packages/opencode/src/altimate/review/dbt-patterns.ts
@@ -1,4 +1,5 @@
 import path from "node:path"
+import YAML from "yaml"
 import { type Finding, type Severity, type ReviewCategory, makeFinding } from "./finding"
 import { type ChangedFile, classifyDbtFile } from "./diff-filter"
 import { type Rubric, clampSeverity, exclusionReason } from "./rubric"
@@ -790,162 +791,294 @@ export function detectModelPatterns(file: ChangedFile, newSql: string | undefine
  * Detect removal of `unique` / `not_null` / `relationships` tests in a schema.yml
  * diff — the guardrail that catches fan-out/dupes is the thing being deleted.
  */
-/** Walk a unified diff and, for each removed test-line, reconstruct which
- *  `(model, column)` context it belonged to on the OLD side. Uses hunk headers
- *  to reset line counters and tracks the nearest `- name:` header preceding
- *  each line. Yields `{ model, column, test }` tuples for every removed
- *  `unique | not_null | relationships` — including bare `- <test>` lines and
- *  block-form `- <test>:` lines (relationships with args). Round-18 G6. */
-function collectTestOccurrencesFromDiff(diff: string | undefined, side: "-" | "+"): Set<string> {
-  // Returned as a Set of canonical `${model}\x00${column}\x00${test}` keys so
-  // callers can compare removed vs added sets without re-parsing.
+/**
+ * Structural extraction of `(model, column?, test)` tuples from a parsed
+ * schema.yml document. Handles:
+ *  - Column-level tests under `models[*].columns[*].tests` / `.data_tests`
+ *  - Model-level tests directly under `models[*].tests` / `.data_tests`
+ *    (surrogate-key `unique`, etc. — no column)
+ *  - Sources (`sources[*].tables[*].(columns[*].)tests`) since dbt supports
+ *    the same test grammar there
+ *  - Snapshots (`snapshots[*].(columns[*].)tests`)
+ *  - Both bare (`- unique`) and block-form (`- relationships: {...}`)
+ *  - Both `tests` and `data_tests` (dbt 1.8+ alias)
+ *
+ * Returns a Set of canonical `${modelOrSource}\x00${column}\x00${test}` keys
+ * (column is empty string for model-level tests). Yields nothing when the
+ * document isn't shaped like a schema.yml.
+ */
+function extractTestOccurrences(doc: unknown): Set<string> {
   const out = new Set<string>()
-  if (!diff) return out
-  let currentModel = ""
-  let currentColumn = ""
-  // Track indentation depth of the CURRENT model/column so we can pop when we
-  // dedent past them. A `- name: X` at indent I claims all lines at indent > I.
-  let modelIndent = -1
-  let columnIndent = -1
-  const modelRe = /^(\s*)-\s*name:\s*([A-Za-z0-9_.\-]+)\s*$/
-  const testRe = /^(\s*)-\s*(unique|not_null|relationships)\b(?::)?/i
-  for (const raw of diff.split("\n")) {
-    // Diff hunk header — reset context; don't try to interpret hunk offsets.
-    if (raw.startsWith("@@")) {
-      currentModel = ""
-      currentColumn = ""
-      modelIndent = -1
-      columnIndent = -1
-      continue
-    }
-    // We consider both context and same-side lines for STRUCTURE (they define
-    // the model/column context) but only same-side lines for TEST detection.
-    let payload: string
-    let onOurSide: boolean
-    if (raw.startsWith(side)) {
-      // remove +/- prefix
-      payload = raw.slice(1)
-      onOurSide = true
-    } else if (raw.startsWith(side === "-" ? "+" : "-") || raw.startsWith("+++") || raw.startsWith("---")) {
-      // The other side's insertion/deletion — don't read structure from it,
-      // don't produce test occurrences from it.
-      continue
-    } else {
-      // Context line (leading space or none).
-      payload = raw.startsWith(" ") ? raw.slice(1) : raw
-      onOurSide = false
-    }
-    // Pop column/model when we've dedented past them.
-    const leadingWs = payload.match(/^(\s*)/)![1].length
-    // Only pop for non-empty payload lines (blank lines carry no indent info).
-    if (payload.trim()) {
-      if (columnIndent >= 0 && leadingWs <= columnIndent) {
-        currentColumn = ""
-        columnIndent = -1
-      }
-      if (modelIndent >= 0 && leadingWs <= modelIndent) {
-        currentModel = ""
-        modelIndent = -1
+  if (!doc || typeof doc !== "object") return out
+  const d = doc as Record<string, unknown>
+
+  const emitTests = (entity: string, column: string, tests: unknown): void => {
+    if (!Array.isArray(tests)) return
+    for (const t of tests) {
+      const name =
+        typeof t === "string"
+          ? t
+          : t && typeof t === "object"
+            ? Object.keys(t as Record<string, unknown>)[0]
+            : undefined
+      if (!name) continue
+      const n = name.toLowerCase()
+      // Restrict to the guardrail tests the detector cares about; a bespoke
+      // custom test being removed is not a signal at this level.
+      if (n === "unique" || n === "not_null" || n === "relationships") {
+        out.add(`${entity}\x00${column}\x00${n}`)
       }
     }
-    // Detect `- name: X` — could be either a model header or a column header;
-    // disambiguate by whether we already have a model in scope.
-    const nameMatch = payload.match(modelRe)
-    if (nameMatch) {
-      const wsLen = nameMatch[1].length
-      const name = nameMatch[2]
-      // If we have no model, or this header is at the same/less indent than
-      // the current model header, treat as a new model.
-      if (currentModel === "" || wsLen <= modelIndent) {
-        currentModel = name
-        modelIndent = wsLen
-        currentColumn = ""
-        columnIndent = -1
-      } else {
-        // Deeper than the model header → column of the current model.
-        currentColumn = name
-        columnIndent = wsLen
+  }
+
+  const walkEntityWithColumns = (entityName: string | undefined, node: unknown): void => {
+    if (!entityName || !node || typeof node !== "object") return
+    const n = node as Record<string, unknown>
+    // Model/source/snapshot-level tests: `tests:` or `data_tests:` right under the entity.
+    emitTests(entityName, "", n.tests)
+    emitTests(entityName, "", n.data_tests)
+    if (Array.isArray(n.columns)) {
+      for (const col of n.columns) {
+        if (!col || typeof col !== "object") continue
+        const c = col as Record<string, unknown>
+        const cname = typeof c.name === "string" ? c.name : undefined
+        if (!cname) continue
+        emitTests(entityName, cname, c.tests)
+        emitTests(entityName, cname, c.data_tests)
       }
-      continue
     }
-    // Detect a test on OUR side and within a column context.
-    if (onOurSide && currentModel && currentColumn) {
-      const t = payload.match(testRe)
-      if (t) {
-        const test = t[2].toLowerCase()
-        out.add(`${currentModel}\x00${currentColumn}\x00${test}`)
+  }
+
+  // `models:` — array of `{ name, columns?, tests? }`
+  if (Array.isArray(d.models)) {
+    for (const m of d.models) {
+      if (!m || typeof m !== "object") continue
+      const mm = m as Record<string, unknown>
+      const mname = typeof mm.name === "string" ? mm.name : undefined
+      walkEntityWithColumns(mname, mm)
+    }
+  }
+  // `snapshots:` — same shape as models
+  if (Array.isArray(d.snapshots)) {
+    for (const s of d.snapshots) {
+      if (!s || typeof s !== "object") continue
+      const ss = s as Record<string, unknown>
+      const sname = typeof ss.name === "string" ? ss.name : undefined
+      walkEntityWithColumns(sname, ss)
+    }
+  }
+  // `sources:` — `[{ name, tables: [{ name, columns?, tests? }] }]`
+  if (Array.isArray(d.sources)) {
+    for (const src of d.sources) {
+      if (!src || typeof src !== "object") continue
+      const srcObj = src as Record<string, unknown>
+      const srcName = typeof srcObj.name === "string" ? srcObj.name : undefined
+      if (!Array.isArray(srcObj.tables)) continue
+      for (const t of srcObj.tables) {
+        if (!t || typeof t !== "object") continue
+        const tt = t as Record<string, unknown>
+        const tname = typeof tt.name === "string" ? tt.name : undefined
+        const qualified = srcName && tname ? `${srcName}.${tname}` : tname || undefined
+        walkEntityWithColumns(qualified, tt)
       }
+    }
+  }
+  // `seeds:` — leaf entity, same test grammar
+  if (Array.isArray(d.seeds)) {
+    for (const s of d.seeds) {
+      if (!s || typeof s !== "object") continue
+      const ss = s as Record<string, unknown>
+      const sname = typeof ss.name === "string" ? ss.name : undefined
+      walkEntityWithColumns(sname, ss)
     }
   }
   return out
 }
 
-export function detectSchemaYmlPatterns(file: ChangedFile, rubric: Rubric): Finding[] {
+/**
+ * Fallback removed-test detector for callers that supply only the diff
+ * (no old/new content). Kept intentionally conservative: matches removed
+ * lines that look like `- unique | not_null | relationships`, subtracts any
+ * added line with the same trimmed text. Cannot distinguish "moved to
+ * another column" from "removed from this column" — that requires content.
+ * The old-string dedup false-negative on sibling columns is inherent to
+ * diff-only input; when structural content is available we use the
+ * structural path (`extractTestOccurrences` diff of old vs new).
+ */
+function fallbackRemovedTestLines(diff: string | undefined): string[] {
+  if (!diff) return []
+  const added: string[] = []
+  const removed: string[] = []
+  for (const raw of diff.split("\n")) {
+    if (raw.startsWith("+") && !raw.startsWith("+++")) added.push(raw.slice(1))
+    else if (raw.startsWith("-") && !raw.startsWith("---")) removed.push(raw.slice(1))
+  }
+  const testLine = /^\s*-\s*(unique|not_null|relationships)\b/i
+  const removedTests = removed.filter((l) => testLine.test(l))
+  const addedTrim = new Set(added.map((l) => l.trim()))
+  return removedTests.filter((l) => !addedTrim.has(l.trim()))
+}
+
+export interface SchemaYmlDetectContent {
+  oldContent?: string
+  newContent?: string
+}
+
+/**
+ * Detect removed data tests in a schema.yml diff.
+ *
+ * PREFERRED path (production, via orchestrator): pass full old/new content in
+ * `opts` — the detector parses both YAML documents, diffs by
+ * `(entity, column, test)` tuples, and emits one finding per genuine removal.
+ * This captures model-level tests (no column), sibling-column edge cases
+ * (unique removed from column X while column Y still declares it), quoted /
+ * commented YAML names, and any layout / indent style the parser accepts.
+ *
+ * FALLBACK path (callers that only have the raw diff, e.g. unit tests or
+ * pre-collected CI diffs without a content resolver): use the string-based
+ * removed-line detection preserved from the pre-R18 detector. It cannot
+ * tell "removed" from "moved to another column" for the same test type on
+ * a sibling column — that limitation is inherent to diff-only input.
+ */
+export function detectSchemaYmlPatterns(
+  file: ChangedFile,
+  rubric: Rubric,
+  opts: SchemaYmlDetectContent = {},
+): Finding[] {
   const kind = classifyDbtFile(file.path)
   if (kind !== "schema_yml" || file.status === "deleted") return []
 
-  // COLUMN-AWARE test-removal detection (G6 fix, Round 18). The previous
-  // string-set dedup collapsed `- unique` on ANY column into the "still
-  // present" bucket, hiding a genuine removal from column X whenever a
-  // sibling column Y still had `- unique`. This walks the diff with model/
-  // column context so a removal is only cancelled by re-appearance on the
-  // SAME `(model, column, test)` tuple.
-  const removedByCtx = collectTestOccurrencesFromDiff(file.diff, "-")
-  const addedByCtx = collectTestOccurrencesFromDiff(file.diff, "+")
-  const genuinelyRemoved: Array<{ model: string; column: string; test: string }> = []
-  for (const key of removedByCtx) {
-    if (addedByCtx.has(key)) continue
-    const [model, column, test] = key.split("\x00")
-    genuinelyRemoved.push({ model, column, test })
-  }
-  if (!genuinelyRemoved.length) return []
+  let removals: Array<{ model: string; column: string; test: string }> = []
+  let usedStructural = false
 
-  // Emit ONE finding per (column, test) removal for precision — customers
-  // can see exactly which guardrail was dropped, not just a total count.
+  // PREFERRED: structural YAML diff when we have both sides' content.
+  if (opts.newContent !== undefined) {
+    let oldDoc: unknown = undefined
+    let newDoc: unknown = undefined
+    try {
+      newDoc = YAML.parse(opts.newContent)
+    } catch {
+      newDoc = undefined
+    }
+    if (opts.oldContent !== undefined) {
+      try {
+        oldDoc = YAML.parse(opts.oldContent)
+      } catch {
+        oldDoc = undefined
+      }
+    }
+    // For an added file the "old" side is empty (nothing removed).
+    if (newDoc !== undefined && (opts.oldContent === undefined || oldDoc !== undefined)) {
+      const oldSet = extractTestOccurrences(oldDoc ?? {})
+      const newSet = extractTestOccurrences(newDoc)
+      for (const key of oldSet) {
+        if (newSet.has(key)) continue
+        const [model, column, test] = key.split("\x00")
+        removals.push({ model, column, test })
+      }
+      usedStructural = true
+    }
+  }
+
+  // FALLBACK: line-based detection for diff-only callers.
+  if (!usedStructural) {
+    const removedLines = fallbackRemovedTestLines(file.diff)
+    // Represent as unattributed tuples (model + column unknown) so the
+    // finding still surfaces with the correct severity but names the file
+    // rather than a specific column.
+    for (const l of removedLines) {
+      const m = /^\s*-\s*(unique|not_null|relationships)\b/i.exec(l)
+      if (!m) continue
+      removals.push({ model: "", column: "", test: m[1].toLowerCase() })
+    }
+    // Deduplicate identical (model, column, test) triples so the fallback
+    // path emits at most one finding per removed test-line pattern.
+    const seen = new Set<string>()
+    removals = removals.filter((r) => {
+      const k = `${r.model}\x00${r.column}\x00${r.test}`
+      if (seen.has(k)) return false
+      seen.add(k)
+      return true
+    })
+  }
+
+  if (!removals.length) return []
+
   const findings: Finding[] = []
   const seenModel = new Set<string>()
-  for (const r of genuinelyRemoved) {
+  const isMartLayer = /(^|\/)(marts?|reporting)\//.test(file.path)
+  const layerLabel = isMartLayer ? "mart-layer" : "declared"
+
+  for (const r of removals) {
     const isUniquenessSignal = r.test === "unique"
-    const notNullOnLikelyPK = r.test === "not_null" && /(_id$|^id$|_key$)/i.test(r.column)
+    const notNullOnLikelyPK =
+      r.test === "not_null" && !!r.column && /(_id$|^id$|_key$)/i.test(r.column)
     // Uniqueness OR not_null on an id/key column = warning (silent-dup / null-PK
     // risk); other not_null / relationships removals = suggestion.
     const sev: Severity = isUniquenessSignal || notNullOnLikelyPK ? "warning" : "suggestion"
-    // Detect layer from file path so the finding body doesn't misattribute
-    // (Codex-R18-review noted the previous copy said "mart-layer key" on
-    // every unique removal regardless of the schema.yml's actual layer).
-    const isMartLayer = /(^|\/)(marts?|reporting)\//.test(file.path)
-    const layerLabel = isMartLayer ? "mart-layer" : "declared"
-    const key = `${r.model}.${r.column}`
-    const isFirstForModel = !seenModel.has(r.model)
-    seenModel.add(r.model)
+
+    // Title / body vary based on whether structural attribution is available.
+    const attributed = !!r.model && !!r.column
+    const modelLevel = !!r.model && !r.column
+    const filename = file.path.split("/").pop()
+    const locKey = attributed ? `${r.model}.${r.column}` : modelLevel ? `${r.model} (model-level)` : "(unknown location)"
+    const title = attributed
+      ? `${filename}: ${r.test} test removed from ${locKey}`
+      : modelLevel
+        ? `${filename}: model-level ${r.test} test removed from \`${r.model}\``
+        : `${filename}: ${r.test} data test removed`
+
+    let bodyLead: string
+    if (attributed) {
+      bodyLead = `The \`${r.test}\` data test was removed from column \`${r.column}\` on model \`${r.model}\`. `
+    } else if (modelLevel) {
+      bodyLead = `A model-level \`${r.test}\` test was removed from \`${r.model}\`. `
+    } else {
+      bodyLead = `A \`${r.test}\` data test was removed from this schema file. `
+    }
+    let bodyRationale: string
+    if (isUniquenessSignal) {
+      bodyRationale =
+        `Removing a \`unique\` test on a ${layerLabel} key is how silent duplicate rows ship — ` +
+        `downstream joins fan out, aggregates double-count, and no test catches it. Restore ` +
+        `the test, or explicitly document why the grain no longer needs to be unique on this column.`
+    } else if (notNullOnLikelyPK) {
+      bodyRationale =
+        `Removing \`not_null\` on what looks like an identifier column (\`${r.column}\`) means nulls ` +
+        `will slip through into downstream joins and aggregates. Restore the test unless the column ` +
+        `is genuinely nullable now.`
+    } else {
+      bodyRationale =
+        `Removing an existing data test is a silent-regression risk. Confirm the test is genuinely ` +
+        `obsolete, not dropped to make CI green.`
+    }
+    const isFirstForModel = !!r.model && !seenModel.has(r.model)
+    if (r.model) seenModel.add(r.model)
+    const bodyTail =
+      isFirstForModel && removals.length > 1
+        ? `\n\n_This PR removes ${removals.length} data tests in total on model(s) ` +
+          `${[...new Set(removals.map((x) => x.model).filter(Boolean))].map((m) => `\`${m}\``).join(", ")}._`
+        : ""
+
     findings.push(
       makeFinding({
         severity: clampSeverity("test_coverage", sev, "high"),
         category: "test_coverage",
-        title: `${file.path.split("/").pop()}: ${r.test} test removed from ${key}`,
-        body:
-          `The \`${r.test}\` data test was removed from column \`${r.column}\` on model \`${r.model}\`. ` +
-          (isUniquenessSignal
-            ? `Removing a \`unique\` test on a ${layerLabel} key is how silent duplicate rows ship — ` +
-              `downstream joins fan out, aggregates double-count, and no test catches it. Restore ` +
-              `the test, or explicitly document why the grain no longer needs to be unique on this column.`
-            : notNullOnLikelyPK
-            ? `Removing \`not_null\` on what looks like an identifier column (\`${r.column}\`) means nulls ` +
-              `will slip through into downstream joins and aggregates. Restore the test unless the column ` +
-              `is genuinely nullable now.`
-            : `Removing an existing data test is a silent-regression risk. Confirm the test is genuinely ` +
-              `obsolete, not dropped to make CI green.`) +
-          (isFirstForModel && genuinelyRemoved.length > 1
-            ? `\n\n_This PR removes ${genuinelyRemoved.length} data tests in total on model(s) ` +
-              `${[...new Set(genuinelyRemoved.map((x) => x.model))].map((m) => `\`${m}\``).join(", ")}._`
-            : ""),
+        title,
+        body: bodyLead + bodyRationale + bodyTail,
         file: file.path,
         confidence: "high",
         evidence: {
           tool: "dbt-patterns",
-          result: { rule: "removed_tests", model: r.model, column: r.column, test: r.test },
+          result: {
+            rule: "removed_tests",
+            model: r.model || undefined,
+            column: r.column || undefined,
+            test: r.test,
+            attribution: attributed ? "column" : modelLevel ? "model-level" : "diff-only",
+          },
         },
-        ruleKey: `test_coverage:removed-tests:${r.model}.${r.column}.${r.test}`,
+        ruleKey: `test_coverage:removed-tests:${r.model || "?"}.${r.column || "?"}.${r.test}`,
       }),
     )
   }

--- a/packages/opencode/src/altimate/review/dbt-patterns.ts
+++ b/packages/opencode/src/altimate/review/dbt-patterns.ts
@@ -1,5 +1,6 @@
 import path from "node:path"
 import YAML from "yaml"
+import { Log } from "@/altimate/util/log"
 import { type Finding, type Severity, type ReviewCategory, makeFinding } from "./finding"
 import { type ChangedFile, classifyDbtFile } from "./diff-filter"
 import { type Rubric, clampSeverity, exclusionReason } from "./rubric"
@@ -948,27 +949,57 @@ export function detectSchemaYmlPatterns(
   const kind = classifyDbtFile(file.path)
   if (kind !== "schema_yml" || file.status === "deleted") return []
 
-  let removals: Array<{ model: string; column: string; test: string }> = []
+  const removals: Array<{ model: string; column: string; test: string }> = []
   let usedStructural = false
 
   // PREFERRED: structural YAML diff when we have both sides' content.
-  if (opts.newContent !== undefined) {
+  //
+  // "Added" file case (no `oldContent` supplied AND status marks the file as
+  // newly-added upstream) — the old side is empty, so there's nothing to
+  // remove; using the structural path with an empty old set is correct.
+  //
+  // "Modified but resolver returned undefined" case (`oldContent === undefined`
+  // for a file whose status is `modified` or `renamed`) — the resolver couldn't
+  // read the old side. Do NOT treat this as an added file (would silently drop
+  // real removals). Fall through to the diff-only fallback below.
+  const isAddedFile = file.status === "added"
+  const canUseStructural =
+    opts.newContent !== undefined &&
+    // For a real modification/rename we require both sides; without oldContent
+    // fall back to diff parsing so removals in the diff still surface.
+    (isAddedFile || opts.oldContent !== undefined)
+
+  if (canUseStructural) {
     let oldDoc: unknown = undefined
     let newDoc: unknown = undefined
     try {
-      newDoc = YAML.parse(opts.newContent)
-    } catch {
+      newDoc = YAML.parse(opts.newContent as string)
+    } catch (err) {
+      // Debug telemetry: YAML parsers can trip on Jinja injected into a
+      // schema.yml or on non-ASCII quirks; log so failures are diagnosable
+      // rather than silently demoting to the fallback path.
+      Log.create({ service: "review", tag: "detectSchemaYmlPatterns" }).warn(
+        `YAML.parse failed on new content of ${file.path}; falling back to diff-only detection`,
+        err instanceof Error ? { error: err.message } : undefined,
+      )
       newDoc = undefined
     }
     if (opts.oldContent !== undefined) {
       try {
         oldDoc = YAML.parse(opts.oldContent)
-      } catch {
+      } catch (err) {
+        Log.create({ service: "review", tag: "detectSchemaYmlPatterns" }).warn(
+          `YAML.parse failed on old content of ${file.path}; falling back to diff-only detection`,
+          err instanceof Error ? { error: err.message } : undefined,
+        )
         oldDoc = undefined
       }
     }
-    // For an added file the "old" side is empty (nothing removed).
-    if (newDoc !== undefined && (opts.oldContent === undefined || oldDoc !== undefined)) {
+    // Only commit to the structural path when we have a parseable new side
+    // AND (we're on an added file OR the old side also parsed). This preserves
+    // "unparseable old YAML" → fallback, not "structural with empty old = every
+    // removed test looks like a genuine removal".
+    if (newDoc !== undefined && (isAddedFile || oldDoc !== undefined)) {
       const oldSet = extractTestOccurrences(oldDoc ?? {})
       const newSet = extractTestOccurrences(newDoc)
       for (const key of oldSet) {
@@ -980,34 +1011,44 @@ export function detectSchemaYmlPatterns(
     }
   }
 
-  // FALLBACK: line-based detection for diff-only callers.
+  // FALLBACK: line-based detection for diff-only callers (unit tests, offline
+  // CI diffs) OR when the structural path couldn't parse both sides.
+  //
+  // No local deduplication: each entry in `removedLines` is already one match
+  // per raw removed line, and model/column are always empty on this path — a
+  // (model, column, test) dedup key would collapse to just `test` and silently
+  // merge distinct removals of the same test type on different columns.
+  //
+  // Downstream, `runReview` runs a global `dedupe` step that fingerprints
+  // findings by (category, file, model, column, ruleKey). Two fallback
+  // findings that share `file`, empty `model`, empty `column`, and a
+  // test-name-only `ruleKey` would still collapse there. We tag each fallback
+  // finding with a stable occurrence-index discriminator (`#0`, `#1`, …) so
+  // distinct removals in the same diff survive the global dedupe. The index
+  // is per-diff, not per-file-history — sufficient for one review pass and
+  // stable across dry-repeats of the same diff.
+  const fallbackDiscriminators: string[] = []
   if (!usedStructural) {
     const removedLines = fallbackRemovedTestLines(file.diff)
-    // Represent as unattributed tuples (model + column unknown) so the
-    // finding still surfaces with the correct severity but names the file
-    // rather than a specific column.
+    let idx = 0
     for (const l of removedLines) {
       const m = /^\s*-\s*(unique|not_null|relationships)\b/i.exec(l)
       if (!m) continue
       removals.push({ model: "", column: "", test: m[1].toLowerCase() })
+      fallbackDiscriminators.push(`#${idx++}`)
     }
-    // Deduplicate identical (model, column, test) triples so the fallback
-    // path emits at most one finding per removed test-line pattern.
-    const seen = new Set<string>()
-    removals = removals.filter((r) => {
-      const k = `${r.model}\x00${r.column}\x00${r.test}`
-      if (seen.has(k)) return false
-      seen.add(k)
-      return true
-    })
   }
 
   if (!removals.length) return []
 
   const findings: Finding[] = []
-  const seenModel = new Set<string>()
   const isMartLayer = /(^|\/)(marts?|reporting)\//.test(file.path)
   const layerLabel = isMartLayer ? "mart-layer" : "declared"
+  // Emit the "N removals across models A/B/C" summary line ONCE per file
+  // (on the first finding), not once per distinct model — otherwise a diff
+  // that removes tests from three models produces three copies of the same
+  // global summary. A single boolean guard is enough.
+  let summaryEmitted = false
 
   for (const r of removals) {
     const isUniquenessSignal = r.test === "unique"
@@ -1052,14 +1093,27 @@ export function detectSchemaYmlPatterns(
         `Removing an existing data test is a silent-regression risk. Confirm the test is genuinely ` +
         `obsolete, not dropped to make CI green.`
     }
-    const isFirstForModel = !!r.model && !seenModel.has(r.model)
-    if (r.model) seenModel.add(r.model)
-    const bodyTail =
-      isFirstForModel && removals.length > 1
-        ? `\n\n_This PR removes ${removals.length} data tests in total on model(s) ` +
-          `${[...new Set(removals.map((x) => x.model).filter(Boolean))].map((m) => `\`${m}\``).join(", ")}._`
-        : ""
+    // Emit the aggregate summary once per file, on the first finding, and
+    // only when there are multiple removals to summarise. Uses the file-scoped
+    // `summaryEmitted` flag rather than a per-model guard so a diff touching
+    // three models emits ONE summary, not three.
+    const shouldEmitSummary = !summaryEmitted && removals.length > 1
+    if (shouldEmitSummary) summaryEmitted = true
+    const distinctModels = [...new Set(removals.map((x) => x.model).filter(Boolean))]
+    const modelClause = distinctModels.length
+      ? ` on model(s) ${distinctModels.map((m) => `\`${m}\``).join(", ")}`
+      : ""
+    const bodyTail = shouldEmitSummary
+      ? `\n\n_This PR removes ${removals.length} data tests in total${modelClause}._`
+      : ""
 
+    // ruleKey feeds the finding fingerprint (finding.ts:107). For attributed
+    // (structural) findings, `(model.column.test)` is unique per removal in
+    // the file. For unattributed fallback findings, `(?.?.test)` collapses
+    // distinct removals of the same test type — we append the fallback
+    // discriminator so each removed line becomes a distinct finding
+    // downstream of the global dedupe.
+    const discriminator = attributed || modelLevel ? "" : `.${fallbackDiscriminators.shift() ?? "#?"}`
     findings.push(
       makeFinding({
         severity: clampSeverity("test_coverage", sev, "high"),
@@ -1078,7 +1132,7 @@ export function detectSchemaYmlPatterns(
             attribution: attributed ? "column" : modelLevel ? "model-level" : "diff-only",
           },
         },
-        ruleKey: `test_coverage:removed-tests:${r.model || "?"}.${r.column || "?"}.${r.test}`,
+        ruleKey: `test_coverage:removed-tests:${r.model || "?"}.${r.column || "?"}.${r.test}${discriminator}`,
       }),
     )
   }

--- a/packages/opencode/src/altimate/review/dbt-patterns.ts
+++ b/packages/opencode/src/altimate/review/dbt-patterns.ts
@@ -790,33 +790,159 @@ export function detectModelPatterns(file: ChangedFile, newSql: string | undefine
  * Detect removal of `unique` / `not_null` / `relationships` tests in a schema.yml
  * diff — the guardrail that catches fan-out/dupes is the thing being deleted.
  */
+/** Walk a unified diff and, for each removed test-line, reconstruct which
+ *  `(model, column)` context it belonged to on the OLD side. Uses hunk headers
+ *  to reset line counters and tracks the nearest `- name:` header preceding
+ *  each line. Yields `{ model, column, test }` tuples for every removed
+ *  `unique | not_null | relationships` — including bare `- <test>` lines and
+ *  block-form `- <test>:` lines (relationships with args). Round-18 G6. */
+function collectTestOccurrencesFromDiff(diff: string | undefined, side: "-" | "+"): Set<string> {
+  // Returned as a Set of canonical `${model}\x00${column}\x00${test}` keys so
+  // callers can compare removed vs added sets without re-parsing.
+  const out = new Set<string>()
+  if (!diff) return out
+  let currentModel = ""
+  let currentColumn = ""
+  // Track indentation depth of the CURRENT model/column so we can pop when we
+  // dedent past them. A `- name: X` at indent I claims all lines at indent > I.
+  let modelIndent = -1
+  let columnIndent = -1
+  const modelRe = /^(\s*)-\s*name:\s*([A-Za-z0-9_.\-]+)\s*$/
+  const testRe = /^(\s*)-\s*(unique|not_null|relationships)\b(?::)?/i
+  for (const raw of diff.split("\n")) {
+    // Diff hunk header — reset context; don't try to interpret hunk offsets.
+    if (raw.startsWith("@@")) {
+      currentModel = ""
+      currentColumn = ""
+      modelIndent = -1
+      columnIndent = -1
+      continue
+    }
+    // We consider both context and same-side lines for STRUCTURE (they define
+    // the model/column context) but only same-side lines for TEST detection.
+    let payload: string
+    let onOurSide: boolean
+    if (raw.startsWith(side)) {
+      // remove +/- prefix
+      payload = raw.slice(1)
+      onOurSide = true
+    } else if (raw.startsWith(side === "-" ? "+" : "-") || raw.startsWith("+++") || raw.startsWith("---")) {
+      // The other side's insertion/deletion — don't read structure from it,
+      // don't produce test occurrences from it.
+      continue
+    } else {
+      // Context line (leading space or none).
+      payload = raw.startsWith(" ") ? raw.slice(1) : raw
+      onOurSide = false
+    }
+    // Pop column/model when we've dedented past them.
+    const leadingWs = payload.match(/^(\s*)/)![1].length
+    // Only pop for non-empty payload lines (blank lines carry no indent info).
+    if (payload.trim()) {
+      if (columnIndent >= 0 && leadingWs <= columnIndent) {
+        currentColumn = ""
+        columnIndent = -1
+      }
+      if (modelIndent >= 0 && leadingWs <= modelIndent) {
+        currentModel = ""
+        modelIndent = -1
+      }
+    }
+    // Detect `- name: X` — could be either a model header or a column header;
+    // disambiguate by whether we already have a model in scope.
+    const nameMatch = payload.match(modelRe)
+    if (nameMatch) {
+      const wsLen = nameMatch[1].length
+      const name = nameMatch[2]
+      // If we have no model, or this header is at the same/less indent than
+      // the current model header, treat as a new model.
+      if (currentModel === "" || wsLen <= modelIndent) {
+        currentModel = name
+        modelIndent = wsLen
+        currentColumn = ""
+        columnIndent = -1
+      } else {
+        // Deeper than the model header → column of the current model.
+        currentColumn = name
+        columnIndent = wsLen
+      }
+      continue
+    }
+    // Detect a test on OUR side and within a column context.
+    if (onOurSide && currentModel && currentColumn) {
+      const t = payload.match(testRe)
+      if (t) {
+        const test = t[2].toLowerCase()
+        out.add(`${currentModel}\x00${currentColumn}\x00${test}`)
+      }
+    }
+  }
+  return out
+}
+
 export function detectSchemaYmlPatterns(file: ChangedFile, rubric: Rubric): Finding[] {
   const kind = classifyDbtFile(file.path)
   if (kind !== "schema_yml" || file.status === "deleted") return []
-  const { added, removed } = splitDiff(file.diff)
-  const removedTests = removed.filter((l) => /^\s*-\s*(unique|not_null|relationships)\b/i.test(l))
-  // A test still present (just moved) shouldn't fire.
-  const addedTests = new Set(added.map((l) => l.trim()))
-  const genuinelyRemoved = removedTests.filter((l) => !addedTests.has(l.trim()))
+
+  // COLUMN-AWARE test-removal detection (G6 fix, Round 18). The previous
+  // string-set dedup collapsed `- unique` on ANY column into the "still
+  // present" bucket, hiding a genuine removal from column X whenever a
+  // sibling column Y still had `- unique`. This walks the diff with model/
+  // column context so a removal is only cancelled by re-appearance on the
+  // SAME `(model, column, test)` tuple.
+  const removedByCtx = collectTestOccurrencesFromDiff(file.diff, "-")
+  const addedByCtx = collectTestOccurrencesFromDiff(file.diff, "+")
+  const genuinelyRemoved: Array<{ model: string; column: string; test: string }> = []
+  for (const key of removedByCtx) {
+    if (addedByCtx.has(key)) continue
+    const [model, column, test] = key.split("\x00")
+    genuinelyRemoved.push({ model, column, test })
+  }
   if (!genuinelyRemoved.length) return []
-  const removedUnique = genuinelyRemoved.some((l) => /\bunique\b/i.test(l))
-  const f = makeFinding({
-    severity: removedUnique ? "warning" : "suggestion",
-    category: "test_coverage",
-    title: `${file.path.split("/").pop()}: removed ${genuinelyRemoved.length} data test(s)`,
-    body:
-      "This change deletes `unique`/`not_null`/`relationships` test(s) — the guardrails that catch fan-out, duplicate, " +
-      "and broken-FK regressions. Removing a `unique` test on a grain key is how silent duplicate bugs ship. " +
-      "Confirm the test is genuinely obsolete, not removed to make CI green.",
-    file: file.path,
-    confidence: "high",
-    evidence: {
-      tool: "dbt-patterns",
-      result: { rule: "removed_tests", removed: genuinelyRemoved.map((l) => l.trim()) },
-    },
-    ruleKey: "test_coverage:removed-tests",
-  })
-  return [{ ...f, severity: clampSeverity(f.category, f.severity, f.confidence) }].filter(
-    (x) => !exclusionReason(x, rubric),
-  )
+
+  // Emit ONE finding per (column, test) removal for precision — customers
+  // can see exactly which guardrail was dropped, not just a total count.
+  const findings: Finding[] = []
+  const seenModel = new Set<string>()
+  for (const r of genuinelyRemoved) {
+    const isUniquenessSignal = r.test === "unique"
+    const notNullOnLikelyPK = r.test === "not_null" && /(_id$|^id$|_key$)/i.test(r.column)
+    // Uniqueness OR not_null on an id/key column = warning (silent-dup / null-PK
+    // risk); other not_null / relationships removals = suggestion.
+    const sev: Severity = isUniquenessSignal || notNullOnLikelyPK ? "warning" : "suggestion"
+    const key = `${r.model}.${r.column}`
+    const isFirstForModel = !seenModel.has(r.model)
+    seenModel.add(r.model)
+    findings.push(
+      makeFinding({
+        severity: clampSeverity("test_coverage", sev, "high"),
+        category: "test_coverage",
+        title: `${file.path.split("/").pop()}: ${r.test} test removed from ${key}`,
+        body:
+          `The \`${r.test}\` data test was removed from column \`${r.column}\` on model \`${r.model}\`. ` +
+          (isUniquenessSignal
+            ? `Removing a \`unique\` test on a mart-layer key is how silent duplicate rows ship — ` +
+              `downstream joins fan out, aggregates double-count, and no test catches it. Restore ` +
+              `the test, or explicitly document why the grain no longer needs to be unique on this column.`
+            : notNullOnLikelyPK
+            ? `Removing \`not_null\` on what looks like an identifier column (\`${r.column}\`) means nulls ` +
+              `will slip through into downstream joins and aggregates. Restore the test unless the column ` +
+              `is genuinely nullable now.`
+            : `Removing an existing data test is a silent-regression risk. Confirm the test is genuinely ` +
+              `obsolete, not dropped to make CI green.`) +
+          (isFirstForModel && genuinelyRemoved.length > 1
+            ? `\n\n_This PR removes ${genuinelyRemoved.length} data tests in total on model(s) ` +
+              `${[...new Set(genuinelyRemoved.map((x) => x.model))].map((m) => `\`${m}\``).join(", ")}._`
+            : ""),
+        file: file.path,
+        confidence: "high",
+        evidence: {
+          tool: "dbt-patterns",
+          result: { rule: "removed_tests", model: r.model, column: r.column, test: r.test },
+        },
+        ruleKey: `test_coverage:removed-tests:${r.model}.${r.column}.${r.test}`,
+      }),
+    )
+  }
+  return findings.filter((x) => !exclusionReason(x, rubric))
 }

--- a/packages/opencode/src/altimate/review/dbt-patterns.ts
+++ b/packages/opencode/src/altimate/review/dbt-patterns.ts
@@ -910,6 +910,11 @@ export function detectSchemaYmlPatterns(file: ChangedFile, rubric: Rubric): Find
     // Uniqueness OR not_null on an id/key column = warning (silent-dup / null-PK
     // risk); other not_null / relationships removals = suggestion.
     const sev: Severity = isUniquenessSignal || notNullOnLikelyPK ? "warning" : "suggestion"
+    // Detect layer from file path so the finding body doesn't misattribute
+    // (Codex-R18-review noted the previous copy said "mart-layer key" on
+    // every unique removal regardless of the schema.yml's actual layer).
+    const isMartLayer = /(^|\/)(marts?|reporting)\//.test(file.path)
+    const layerLabel = isMartLayer ? "mart-layer" : "declared"
     const key = `${r.model}.${r.column}`
     const isFirstForModel = !seenModel.has(r.model)
     seenModel.add(r.model)
@@ -921,7 +926,7 @@ export function detectSchemaYmlPatterns(file: ChangedFile, rubric: Rubric): Find
         body:
           `The \`${r.test}\` data test was removed from column \`${r.column}\` on model \`${r.model}\`. ` +
           (isUniquenessSignal
-            ? `Removing a \`unique\` test on a mart-layer key is how silent duplicate rows ship — ` +
+            ? `Removing a \`unique\` test on a ${layerLabel} key is how silent duplicate rows ship — ` +
               `downstream joins fan out, aggregates double-count, and no test catches it. Restore ` +
               `the test, or explicitly document why the grain no longer needs to be unique on this column.`
             : notNullOnLikelyPK

--- a/packages/opencode/src/altimate/review/dbt-patterns.ts
+++ b/packages/opencode/src/altimate/review/dbt-patterns.ts
@@ -827,7 +827,33 @@ function extractTestOccurrences(doc: unknown): Set<string> {
       // Restrict to the guardrail tests the detector cares about; a bespoke
       // custom test being removed is not a signal at this level.
       if (n === "unique" || n === "not_null" || n === "relationships") {
-        out.add(`${entity}\x00${column}\x00${n}`)
+        // PR #1027 consensus MINOR #4 — a column can carry MULTIPLE
+        // `relationships` tests pointing at different parents (e.g. one to
+        // dim_customers, one to legacy.dim_customers during a migration).
+        // Keying on `(entity, column, test)` alone collapses them into a
+        // single set entry, so dropping one silently doesn't surface.
+        // `unique` / `not_null` are single-instance semantically (a repeat is
+        // a no-op), so this discriminator only affects `relationships`.
+        // Block-form: `- relationships: {to: ..., field: ...}` → append the
+        // (to, field) tuple to the key. Bare string form: no discriminator
+        // (the block-form is the shape dbt requires for `relationships`
+        // anyway; a bare `- relationships` isn't a legal declaration).
+        let discriminator = ""
+        if (n === "relationships" && t && typeof t === "object") {
+          const args = (t as Record<string, unknown>)[name]
+          // dbt 1.9+ nests test args under `arguments:`; earlier versions
+          // put them at the top level of the test's value map.
+          const argsObj =
+            args && typeof args === "object" ? (args as Record<string, unknown>) : undefined
+          const nested =
+            argsObj?.arguments && typeof argsObj.arguments === "object"
+              ? (argsObj.arguments as Record<string, unknown>)
+              : undefined
+          const to = String((nested ?? argsObj)?.to ?? "")
+          const field = String((nested ?? argsObj)?.field ?? "")
+          if (to || field) discriminator = `\x01${to}\x02${field}`
+        }
+        out.add(`${entity}\x00${column}\x00${n}${discriminator}`)
       }
     }
   }
@@ -949,7 +975,15 @@ export function detectSchemaYmlPatterns(
   const kind = classifyDbtFile(file.path)
   if (kind !== "schema_yml") return []
 
-  const removals: Array<{ model: string; column: string; test: string }> = []
+  const removals: Array<{
+    model: string
+    column: string
+    test: string
+    /** Extra discriminator (e.g. `to:field` for a `relationships` test) so
+     *  multiple same-named tests on one column don't collapse via ruleKey.
+     *  Empty for `unique` / `not_null` and for fallback (diff-only) findings. */
+    testTag?: string
+  }> = []
   let usedStructural = false
 
   // Deleting a whole schema.yml removes every test declared in it — arguably
@@ -1022,8 +1056,17 @@ export function detectSchemaYmlPatterns(
       const newSet = extractTestOccurrences(isDeletedFile ? {} : newDoc)
       for (const key of oldSet) {
         if (newSet.has(key)) continue
-        const [model, column, test] = key.split("\x00")
-        removals.push({ model, column, test })
+        const [model, column, testField] = key.split("\x00")
+        // `testField` may carry a `\x01<to>\x02<field>` discriminator for
+        // `relationships` tests so multiple relationships on the same column
+        // don't collapse to one removal (MINOR #4). Strip it for display;
+        // retain the internal `\x02` separator in `testTag` for the ruleKey
+        // — a colon-joined form would collide when either arg contains `:`
+        // (e.g. `to='a:b'` vs `field='b:c'`, codex R20 review minor).
+        // ruleKey is hashed for fingerprinting; control chars survive.
+        const [test, tagPayload] = testField.split("\x01")
+        const testTag = tagPayload ?? ""
+        removals.push({ model, column, test, testTag })
       }
       usedStructural = true
     }
@@ -1130,7 +1173,12 @@ export function detectSchemaYmlPatterns(
       const modelClause = distinctModels.length
         ? ` on model(s) ${distinctModels.map((m) => `\`${m}\``).join(", ")}`
         : ""
-      bodyTail = `\n\n_This PR removes ${removals.length} data tests in total${modelClause}._`
+      // Scoped to THIS schema file — the removals loop counts the current
+      // file's removals only, not the PR's aggregate. Wording was previously
+      // "This PR removes N data tests in total" which misled reviewers on
+      // multi-file diffs (per PR #1027 consensus MINOR #3). A global-PR
+      // summary would need to move to orchestrate.ts.
+      bodyTail = `\n\n_This schema file drops ${removals.length} data tests${modelClause}._`
     }
 
     // ruleKey feeds the finding fingerprint (finding.ts:107). For attributed
@@ -1163,7 +1211,12 @@ export function detectSchemaYmlPatterns(
             attribution: attributed ? "column" : modelLevel ? "model-level" : "diff-only",
           },
         },
-        ruleKey: `test_coverage:removed-tests:${r.model || "?"}.${r.column || "?"}.${r.test}${discriminator}`,
+        // testTag suffix (`:to:field` for `relationships`) survives the global
+        // finding fingerprint dedupe so multiple relationships on the same
+        // column emit distinct findings (MINOR #4).
+        ruleKey: `test_coverage:removed-tests:${r.model || "?"}.${r.column || "?"}.${r.test}${
+          r.testTag ? `.${r.testTag}` : ""
+        }${discriminator}`,
       }),
     )
   }

--- a/packages/opencode/src/altimate/review/dbt-patterns.ts
+++ b/packages/opencode/src/altimate/review/dbt-patterns.ts
@@ -841,8 +841,8 @@ function extractTestOccurrences(doc: unknown): Set<string> {
         let discriminator = ""
         if (n === "relationships" && t && typeof t === "object") {
           const args = (t as Record<string, unknown>)[name]
-          // dbt 1.9+ nests test args under `arguments:`; earlier versions
-          // put them at the top level of the test's value map.
+          // dbt 1.10.5+ nests test args under `arguments:`; earlier versions
+          // put them at the top level of the test's value map (cubic-review P3).
           const argsObj =
             args && typeof args === "object" ? (args as Record<string, unknown>) : undefined
           const nested =

--- a/packages/opencode/src/altimate/review/dbt-patterns.ts
+++ b/packages/opencode/src/altimate/review/dbt-patterns.ts
@@ -1050,6 +1050,11 @@ export function detectSchemaYmlPatterns(
   // global summary. A single boolean guard is enough.
   let summaryEmitted = false
 
+  // Consumed in lock-step with the removals loop below (fallback path only).
+  // Using an index avoids `shift()`, which would be O(N) per call on the
+  // discriminator array — negligible on 2-3 removals but O(N²) on a large
+  // schema.yml PR that drops many tests.
+  let fallbackIdx = 0
   for (const r of removals) {
     const isUniquenessSignal = r.test === "unique"
     const notNullOnLikelyPK =
@@ -1096,16 +1101,19 @@ export function detectSchemaYmlPatterns(
     // Emit the aggregate summary once per file, on the first finding, and
     // only when there are multiple removals to summarise. Uses the file-scoped
     // `summaryEmitted` flag rather than a per-model guard so a diff touching
-    // three models emits ONE summary, not three.
+    // three models emits ONE summary, not three. Distinct-models computation
+    // is gated inside the branch so we don't pay for the Set/spread/map on
+    // every loop iteration when the summary won't be attached.
     const shouldEmitSummary = !summaryEmitted && removals.length > 1
-    if (shouldEmitSummary) summaryEmitted = true
-    const distinctModels = [...new Set(removals.map((x) => x.model).filter(Boolean))]
-    const modelClause = distinctModels.length
-      ? ` on model(s) ${distinctModels.map((m) => `\`${m}\``).join(", ")}`
-      : ""
-    const bodyTail = shouldEmitSummary
-      ? `\n\n_This PR removes ${removals.length} data tests in total${modelClause}._`
-      : ""
+    let bodyTail = ""
+    if (shouldEmitSummary) {
+      summaryEmitted = true
+      const distinctModels = [...new Set(removals.map((x) => x.model).filter(Boolean))]
+      const modelClause = distinctModels.length
+        ? ` on model(s) ${distinctModels.map((m) => `\`${m}\``).join(", ")}`
+        : ""
+      bodyTail = `\n\n_This PR removes ${removals.length} data tests in total${modelClause}._`
+    }
 
     // ruleKey feeds the finding fingerprint (finding.ts:107). For attributed
     // (structural) findings, `(model.column.test)` is unique per removal in
@@ -1113,7 +1121,7 @@ export function detectSchemaYmlPatterns(
     // distinct removals of the same test type — we append the fallback
     // discriminator so each removed line becomes a distinct finding
     // downstream of the global dedupe.
-    const discriminator = attributed || modelLevel ? "" : `.${fallbackDiscriminators.shift() ?? "#?"}`
+    const discriminator = attributed || modelLevel ? "" : `.${fallbackDiscriminators[fallbackIdx++] ?? "#?"}`
     findings.push(
       makeFinding({
         severity: clampSeverity("test_coverage", sev, "high"),

--- a/packages/opencode/src/altimate/review/dbt-patterns.ts
+++ b/packages/opencode/src/altimate/review/dbt-patterns.ts
@@ -947,10 +947,16 @@ export function detectSchemaYmlPatterns(
   opts: SchemaYmlDetectContent = {},
 ): Finding[] {
   const kind = classifyDbtFile(file.path)
-  if (kind !== "schema_yml" || file.status === "deleted") return []
+  if (kind !== "schema_yml") return []
 
   const removals: Array<{ model: string; column: string; test: string }> = []
   let usedStructural = false
+
+  // Deleting a whole schema.yml removes every test declared in it — arguably
+  // a bigger removal than dropping a single test. Treat the new side as empty
+  // and diff the old document against `{}` so every prior test surfaces as a
+  // removal (cubic-review P2). Requires `oldContent` from the caller.
+  const isDeletedFile = file.status === "deleted"
 
   // PREFERRED: structural YAML diff when we have both sides' content.
   //
@@ -958,31 +964,38 @@ export function detectSchemaYmlPatterns(
   // newly-added upstream) — the old side is empty, so there's nothing to
   // remove; using the structural path with an empty old set is correct.
   //
+  // "Deleted" file case — the new side is empty; use the structural path
+  // with an empty new set so every old test surfaces as a removal.
+  //
   // "Modified but resolver returned undefined" case (`oldContent === undefined`
   // for a file whose status is `modified` or `renamed`) — the resolver couldn't
   // read the old side. Do NOT treat this as an added file (would silently drop
   // real removals). Fall through to the diff-only fallback below.
   const isAddedFile = file.status === "added"
   const canUseStructural =
-    opts.newContent !== undefined &&
-    // For a real modification/rename we require both sides; without oldContent
-    // fall back to diff parsing so removals in the diff still surface.
-    (isAddedFile || opts.oldContent !== undefined)
+    (isDeletedFile
+      ? opts.oldContent !== undefined
+      : opts.newContent !== undefined &&
+        // For a real modification/rename we require both sides; without oldContent
+        // fall back to diff parsing so removals in the diff still surface.
+        (isAddedFile || opts.oldContent !== undefined))
 
   if (canUseStructural) {
     let oldDoc: unknown = undefined
     let newDoc: unknown = undefined
-    try {
-      newDoc = YAML.parse(opts.newContent as string)
-    } catch (err) {
-      // Debug telemetry: YAML parsers can trip on Jinja injected into a
-      // schema.yml or on non-ASCII quirks; log so failures are diagnosable
-      // rather than silently demoting to the fallback path.
-      Log.create({ service: "review", tag: "detectSchemaYmlPatterns" }).warn(
-        `YAML.parse failed on new content of ${file.path}; falling back to diff-only detection`,
-        err instanceof Error ? { error: err.message } : undefined,
-      )
-      newDoc = undefined
+    if (opts.newContent !== undefined) {
+      try {
+        newDoc = YAML.parse(opts.newContent)
+      } catch (err) {
+        // Debug telemetry: YAML parsers can trip on Jinja injected into a
+        // schema.yml or on non-ASCII quirks; log so failures are diagnosable
+        // rather than silently demoting to the fallback path.
+        Log.create({ service: "review", tag: "detectSchemaYmlPatterns" }).warn(
+          `YAML.parse failed on new content of ${file.path}; falling back to diff-only detection`,
+          err instanceof Error ? { error: err.message } : undefined,
+        )
+        newDoc = undefined
+      }
     }
     if (opts.oldContent !== undefined) {
       try {
@@ -995,13 +1008,18 @@ export function detectSchemaYmlPatterns(
         oldDoc = undefined
       }
     }
-    // Only commit to the structural path when we have a parseable new side
-    // AND (we're on an added file OR the old side also parsed). This preserves
-    // "unparseable old YAML" → fallback, not "structural with empty old = every
-    // removed test looks like a genuine removal".
-    if (newDoc !== undefined && (isAddedFile || oldDoc !== undefined)) {
+    // Only commit to the structural path when the appropriate sides parsed:
+    //  - deleted → old must parse; new is treated as `{}`
+    //  - added   → new must parse; old is treated as `{}`
+    //  - modified/renamed → both must parse
+    // This preserves "unparseable YAML" → fallback rather than
+    // "structural with empty side = every test looks removed/added".
+    const canCommit = isDeletedFile
+      ? oldDoc !== undefined
+      : newDoc !== undefined && (isAddedFile || oldDoc !== undefined)
+    if (canCommit) {
       const oldSet = extractTestOccurrences(oldDoc ?? {})
-      const newSet = extractTestOccurrences(newDoc)
+      const newSet = extractTestOccurrences(isDeletedFile ? {} : newDoc)
       for (const key of oldSet) {
         if (newSet.has(key)) continue
         const [model, column, test] = key.split("\x00")
@@ -1129,6 +1147,11 @@ export function detectSchemaYmlPatterns(
         title,
         body: bodyLead + bodyRationale + bodyTail,
         file: file.path,
+        // Surface the extracted attribution on the top-level Finding so
+        // downstream consumers (dedupe, formatting, telemetry) see it —
+        // not just inside `evidence.result` (cubic-review P3).
+        model: r.model || undefined,
+        column: r.column || undefined,
         confidence: "high",
         evidence: {
           tool: "dbt-patterns",

--- a/packages/opencode/src/altimate/review/diff-filter.ts
+++ b/packages/opencode/src/altimate/review/diff-filter.ts
@@ -61,7 +61,11 @@ export function classifyDbtFile(path: string): DbtFileKind {
   const isYaml = p.endsWith(".yml") || p.endsWith(".yaml")
   if (/(^|\/)(dbt_project|profiles|packages|dependencies)\.ya?ml$/.test(p)) return "project_config"
   if (/(^|\/)macros\//.test(p)) return "macro"
-  if (/(^|\/)snapshots\//.test(p)) return "snapshot"
+  // Snapshots split by extension: `.sql` files are snapshot definitions
+  // (tier-forcing, catalog-scoped), YAML property files under `snapshots/`
+  // are schema files (declared tests + column metadata) and should route to
+  // `schema_yml` so the test-removal detector runs on them.
+  if (/(^|\/)snapshots\//.test(p) && p.endsWith(".sql")) return "snapshot"
   if (/(^|\/)seeds\//.test(p) && p.endsWith(".csv")) return "seed"
   if (/(^|\/)tests\//.test(p) && p.endsWith(".sql")) return "test"
   if (/(^|\/)analyses\//.test(p)) return "analysis"

--- a/packages/opencode/src/altimate/review/format.ts
+++ b/packages/opencode/src/altimate/review/format.ts
@@ -28,7 +28,8 @@ export function verdictHeadline(env: VerdictEnvelope): string {
     [critical && `${critical} critical`, warning && `${warning} warning`, suggestion && `${suggestion} suggestion`]
       .filter(Boolean)
       .join(", ") || "no findings"
-  return `${VERDICT_LABEL[env.verdict]} — ${counts} (${env.tier} tier)`
+  const tierLabel = env.tierForced ? `${env.tier} tier — forced (was ${env.tierClassified})` : `${env.tier} tier`
+  return `${VERDICT_LABEL[env.verdict]} — ${counts} (${tierLabel})`
 }
 
 /** Full PR/MR summary comment body (markdown), prefixed with the dedup marker. */
@@ -39,6 +40,16 @@ export function renderSummary(env: VerdictEnvelope): string {
     lines.push(
       "> ⚙️ **Lint-only run** — no dbt manifest/warehouse was available, so lineage, equivalence and",
       "> data-impact checks were skipped. Wire `manifest_path` (and optionally warehouse creds) for the full verdict.",
+      "",
+    )
+  }
+
+  // G1 (Round 18) — surface classifier reasons when --explain-tier populated
+  // them, so a customer can see why the review ran at this tier. Also surfaces
+  // when --force-tier bypassed the classifier (tierReasons is auto-populated).
+  if (env.tierReasons && env.tierReasons.length) {
+    lines.push(
+      `> 🧭 **Tier: ${env.tier}** — ${env.tierReasons.map((r) => `\`${r}\``).join(", ")}`,
       "",
     )
   }

--- a/packages/opencode/src/altimate/review/format.ts
+++ b/packages/opencode/src/altimate/review/format.ts
@@ -57,7 +57,21 @@ export function renderSummary(env: VerdictEnvelope): string {
   // the signed envelope's tierReasons[]; the summary shows the first 8.
   if (env.tierReasons && env.tierReasons.length) {
     const RENDER_CAP = 8
-    const shown = env.tierReasons.slice(0, RENDER_CAP).map((r) => `\`${r}\``).join(", ")
+    // Pick an inline-code-span fence longer than any backtick run inside `r`
+    // so a path like `packages/…/foo`bar`.sql` cannot terminate the span
+    // (cubic-review P3).
+    const shown = env.tierReasons
+      .slice(0, RENDER_CAP)
+      .map((r) => {
+        const runs = r.match(/`+/g)
+        const maxRun = runs ? Math.max(...runs.map((run) => run.length)) : 0
+        const fence = "`".repeat(maxRun + 1)
+        // If the reason itself starts/ends with a backtick, pad with a space so
+        // the leading/trailing backtick isn't glued to the fence.
+        const pad = /^`|`$/.test(r) ? " " : ""
+        return `${fence}${pad}${r}${pad}${fence}`
+      })
+      .join(", ")
     const overflow =
       env.tierReasons.length > RENDER_CAP
         ? ` (+${env.tierReasons.length - RENDER_CAP} more in verdict envelope)`

--- a/packages/opencode/src/altimate/review/format.ts
+++ b/packages/opencode/src/altimate/review/format.ts
@@ -28,7 +28,11 @@ export function verdictHeadline(env: VerdictEnvelope): string {
     [critical && `${critical} critical`, warning && `${warning} warning`, suggestion && `${suggestion} suggestion`]
       .filter(Boolean)
       .join(", ") || "no findings"
-  const tierLabel = env.tierForced ? `${env.tier} tier — forced (was ${env.tierClassified})` : `${env.tier} tier`
+  // tierClassified is optional in the schema — guard against externally-built
+  // envelopes that mark tierForced without threading the original classification.
+  const tierLabel = env.tierForced
+    ? `${env.tier} tier — forced (was ${env.tierClassified ?? "unknown"})`
+    : `${env.tier} tier`
   return `${VERDICT_LABEL[env.verdict]} — ${counts} (${tierLabel})`
 }
 
@@ -47,11 +51,18 @@ export function renderSummary(env: VerdictEnvelope): string {
   // G1 (Round 18) — surface classifier reasons when --explain-tier populated
   // them, so a customer can see why the review ran at this tier. Also surfaces
   // when --force-tier bypassed the classifier (tierReasons is auto-populated).
+  // Truncate the rendered summary on very large diffs: classifyPR appends one
+  // reason per file forcing FULL tier (e.g. every touched schema.yml or every
+  // PII column), which bloats the comment on wide PRs. The full list stays in
+  // the signed envelope's tierReasons[]; the summary shows the first 8.
   if (env.tierReasons && env.tierReasons.length) {
-    lines.push(
-      `> 🧭 **Tier: ${env.tier}** — ${env.tierReasons.map((r) => `\`${r}\``).join(", ")}`,
-      "",
-    )
+    const RENDER_CAP = 8
+    const shown = env.tierReasons.slice(0, RENDER_CAP).map((r) => `\`${r}\``).join(", ")
+    const overflow =
+      env.tierReasons.length > RENDER_CAP
+        ? ` (+${env.tierReasons.length - RENDER_CAP} more in verdict envelope)`
+        : ""
+    lines.push(`> 🧭 **Tier: ${env.tier}** — ${shown}${overflow}`, "")
   }
 
   if (!env.findings.length) {

--- a/packages/opencode/src/altimate/review/git.ts
+++ b/packages/opencode/src/altimate/review/git.ts
@@ -63,11 +63,17 @@ export async function collectChangedFiles(opts: CollectOptions): Promise<Changed
 }
 
 /** Read the given file only when its realpath sits inside the resolved root.
- *  Blocks the "tracked symlink escapes the repo" class of attack — e.g. a
+ *  Blocks the "tracked symlink escapes the root" class of attack — e.g. a
  *  `models/evil.sql → /etc/passwd` symlink that would otherwise leak external
  *  files into the review pipeline (coderabbit + cubic security review).
- *  Returns undefined when the target escapes, is missing, or realpath fails. */
-async function safeReadInside(root: string, rel: string): Promise<string | undefined> {
+ *  Returns undefined when the target escapes, is missing, or realpath fails.
+ *
+ *  Exported for the compiled-SQL resolver in compiled.ts so both content
+ *  paths go through the same containment check — cubic + kilo suggested
+ *  extracting the shared helper so a future security tweak (Windows
+ *  case-sensitivity, trailing separator) can't leave one call site
+ *  behind. */
+export async function safeReadInside(root: string, rel: string): Promise<string | undefined> {
   try {
     // Realpath both sides so a symlink IN the repo, or a repo checked out
     // under a symlinked path (`/var` → `/private/var` on macOS), still

--- a/packages/opencode/src/altimate/review/git.ts
+++ b/packages/opencode/src/altimate/review/git.ts
@@ -62,6 +62,29 @@ export async function collectChangedFiles(opts: CollectOptions): Promise<Changed
   )
 }
 
+/** Read the given file only when its realpath sits inside the resolved root.
+ *  Blocks the "tracked symlink escapes the repo" class of attack — e.g. a
+ *  `models/evil.sql → /etc/passwd` symlink that would otherwise leak external
+ *  files into the review pipeline (coderabbit + cubic security review).
+ *  Returns undefined when the target escapes, is missing, or realpath fails. */
+async function safeReadInside(root: string, rel: string): Promise<string | undefined> {
+  try {
+    // Realpath both sides so a symlink IN the repo, or a repo checked out
+    // under a symlinked path (`/var` → `/private/var` on macOS), still
+    // compares apples to apples. Missing realpath calls on the target fail
+    // fast into the catch (no read attempted).
+    const rootReal = await fs.realpath(root)
+    const targetReal = await fs.realpath(path.join(root, rel))
+    // Ensure `targetReal` is inside `rootReal` using a separator-aware
+    // startsWith check so `/repo-backup` doesn't count as inside `/repo`.
+    const sep = path.sep
+    if (targetReal !== rootReal && !targetReal.startsWith(rootReal + sep)) return undefined
+    return await fs.readFile(targetReal, "utf8")
+  } catch {
+    return undefined
+  }
+}
+
 /** Build a getContent(path, side) resolver over git refs / the working tree.
  *  `renames` maps a new path → its old path so the "old" side of a renamed file
  *  resolves from where it actually lived at `base` (not the post-rename path).
@@ -84,9 +107,10 @@ export function makeContentResolver(opts: CollectOptions & { renames?: Map<strin
       // returning undefined and silently demoting downstream detectors to
       // the diff-only fallback. Root at the resolved git top-level when
       // supplied by the caller; fall back to `opts.cwd` when we couldn't
-      // resolve it (non-git or bare-repo contexts).
+      // resolve it (non-git or bare-repo contexts). Reads are containment-
+      // checked (symlink-safe) — see safeReadInside.
       const root = opts.gitRoot ?? opts.cwd
-      return await fs.readFile(path.join(root, file), "utf8")
+      return await safeReadInside(root, file)
     } catch {
       return undefined
     }
@@ -95,11 +119,15 @@ export function makeContentResolver(opts: CollectOptions & { renames?: Map<strin
 
 /** Resolve the repository top-level (`git rev-parse --show-toplevel`).
  *  Used to root working-tree FS reads and existence checks at the repo root
- *  regardless of the caller's cwd. Returns undefined outside a git repo. */
+ *  regardless of the caller's cwd. Returns undefined outside a git repo.
+ *  Strips only the git-emitted terminator (`\r\n` or `\n`) rather than
+ *  `trim()` — a path with legitimate leading/trailing whitespace stays
+ *  intact (cubic-review P3). */
 export async function gitRepoRoot(cwd: string): Promise<string | undefined> {
   try {
     const out = await git(["rev-parse", "--show-toplevel"], cwd)
-    return out.trim() || undefined
+    const root = out.replace(/[\r\n]+$/, "")
+    return root || undefined
   } catch {
     return undefined
   }

--- a/packages/opencode/src/altimate/review/git.ts
+++ b/packages/opencode/src/altimate/review/git.ts
@@ -64,8 +64,11 @@ export async function collectChangedFiles(opts: CollectOptions): Promise<Changed
 
 /** Build a getContent(path, side) resolver over git refs / the working tree.
  *  `renames` maps a new path → its old path so the "old" side of a renamed file
- *  resolves from where it actually lived at `base` (not the post-rename path). */
-export function makeContentResolver(opts: CollectOptions & { renames?: Map<string, string> }) {
+ *  resolves from where it actually lived at `base` (not the post-rename path).
+ *  `gitRoot` is the repository top-level (from `git rev-parse --show-toplevel`).
+ *  When omitted, working-tree reads fall back to `opts.cwd`, which is only
+ *  correct when the CLI is invoked from the repo root. */
+export function makeContentResolver(opts: CollectOptions & { renames?: Map<string, string>; gitRoot?: string }) {
   return async (file: string, side: "old" | "new"): Promise<string | undefined> => {
     try {
       if (side === "old") {
@@ -75,10 +78,30 @@ export function makeContentResolver(opts: CollectOptions & { renames?: Map<strin
       if (opts.head) {
         return await git(["show", `${opts.head}:${file}`], opts.cwd)
       }
-      return await fs.readFile(path.join(opts.cwd, file), "utf8")
+      // File paths from `git diff --name-status` are repo-root relative,
+      // NOT `opts.cwd` relative. When the CLI is invoked from a subdirectory
+      // the naive `path.join(opts.cwd, file)` double-joins and fails ENOENT,
+      // returning undefined and silently demoting downstream detectors to
+      // the diff-only fallback. Root at the resolved git top-level when
+      // supplied by the caller; fall back to `opts.cwd` when we couldn't
+      // resolve it (non-git or bare-repo contexts).
+      const root = opts.gitRoot ?? opts.cwd
+      return await fs.readFile(path.join(root, file), "utf8")
     } catch {
       return undefined
     }
+  }
+}
+
+/** Resolve the repository top-level (`git rev-parse --show-toplevel`).
+ *  Used to root working-tree FS reads and existence checks at the repo root
+ *  regardless of the caller's cwd. Returns undefined outside a git repo. */
+export async function gitRepoRoot(cwd: string): Promise<string | undefined> {
+  try {
+    const out = await git(["rev-parse", "--show-toplevel"], cwd)
+    return out.trim() || undefined
+  } catch {
+    return undefined
   }
 }
 

--- a/packages/opencode/src/altimate/review/orchestrate.ts
+++ b/packages/opencode/src/altimate/review/orchestrate.ts
@@ -190,6 +190,10 @@ export interface OrchestrateInput {
   /** PR metadata passed to the AI reviewer for intent checking. */
   prTitle?: string
   prBody?: string
+  /** G1 — attach the classifier's reason list to the envelope. */
+  explainTier?: boolean
+  /** G2 — override the classifier's tier decision. Envelope carries tierForced:true. */
+  forceTier?: "trivial" | "lite" | "full"
 }
 
 /** Derive the dbt model name from a model file path. */
@@ -1088,14 +1092,24 @@ export async function runReview(input: OrchestrateInput): Promise<VerdictEnvelop
   // A run is degraded when model files exist but none resolved against a manifest.
   const runDegraded = modelFiles.length > 0 ? !anyManifest : reviewable.length === 0
 
-  const tier = classifyPR(reviewable, {
+  const tierResult = classifyPR(reviewable, {
     blastRadiusOf: (p) => {
       const c = ctxByPath.get(p)
       return c ? c.impact.directCount + c.impact.transitiveCount : 0
     },
     touchesPiiOf: (f) => (ctxByPath.get(f.path)?.pii.length ?? 0) > 0,
     isComplexOf: (f) => ctxByPath.get(f.path)?.complex ?? false,
-  }).tier
+  })
+  const classifiedTier = tierResult.tier
+  // G2 — --force-tier overrides the classifier. Envelope records both the forced
+  // tier and the original classification so audits can see the bypass; the
+  // reasons list gets a leading "forced" marker so downstream doesn't confuse
+  // the forced tier for a natural one.
+  const tier = input.forceTier ?? classifiedTier
+  const tierForced = input.forceTier !== undefined && input.forceTier !== classifiedTier
+  const tierReasons = tierForced
+    ? [`forced via --force-tier (classifier said ${classifiedTier})`, ...tierResult.reasons]
+    : tierResult.reasons
 
   const lanes = new Set(input.config.reviewers.length ? input.config.reviewers : TIER_LANES[tier])
 
@@ -1349,6 +1363,9 @@ export async function runReview(input: OrchestrateInput): Promise<VerdictEnvelop
     manifestHash: input.manifestHash,
     generatedAt: input.generatedAt,
     degraded,
+    tierReasons: input.explainTier || tierForced ? tierReasons : undefined,
+    tierForced: tierForced ? true : undefined,
+    tierClassified: tierForced ? classifiedTier : undefined,
   })
   return signEnvelope(envelope)
 }

--- a/packages/opencode/src/altimate/review/orchestrate.ts
+++ b/packages/opencode/src/altimate/review/orchestrate.ts
@@ -1217,8 +1217,19 @@ export async function runReview(input: OrchestrateInput): Promise<VerdictEnvelop
 
   // schema.yml-level detectors (test removal) — run on changed YAML files
   // regardless of tier, since deleting a guardrail test is always worth flagging.
+  // Pass old + new content when available so the detector diffs structural YAML
+  // (per-(entity, column, test) tuples) instead of walking the unified diff
+  // (which loses context when the model header is outside the -U3 window and
+  // silently drops sibling-column edge cases). Falls back to diff-only line
+  // detection when a content resolver isn't wired (e.g. unit-test callers).
   for (const file of reviewable) {
-    if (file.kind === "schema_yml") all.push(detectSchemaYmlPatterns(file, input.rubric))
+    if (file.kind !== "schema_yml") continue
+    const oldRef = file.oldPath ?? file.path
+    const [oldContent, newContent] = await Promise.all([
+      file.status === "modified" ? getContent?.(oldRef, "old") : Promise.resolve(undefined),
+      file.status !== "deleted" ? getContent?.(file.path, "new") : Promise.resolve(undefined),
+    ])
+    all.push(detectSchemaYmlPatterns(file, input.rubric, { oldContent, newContent }))
   }
 
   // Architectural dedup: the regex `dbt-patterns`/`rule-catalog` layer is a

--- a/packages/opencode/src/altimate/review/orchestrate.ts
+++ b/packages/opencode/src/altimate/review/orchestrate.ts
@@ -1101,14 +1101,21 @@ export async function runReview(input: OrchestrateInput): Promise<VerdictEnvelop
     isComplexOf: (f) => ctxByPath.get(f.path)?.complex ?? false,
   })
   const classifiedTier = tierResult.tier
-  // G2 — --force-tier overrides the classifier. Envelope records both the forced
-  // tier and the original classification so audits can see the bypass; the
-  // reasons list gets a leading "forced" marker so downstream doesn't confuse
-  // the forced tier for a natural one.
+  // G2 — --force-tier overrides the classifier. Envelope records both the
+  // forced tier and the original classification whenever the flag is passed
+  // (regardless of whether the forced value happens to match the classifier),
+  // so audits can see the bypass every time the flag was used. The reasons
+  // list gets a leading "forced" marker so downstream doesn't confuse the
+  // forced tier for a natural one. Codex-R18-review fix — the earlier
+  // `!== classifiedTier` gate silently hid the bypass when the forced tier
+  // matched the classifier's result.
   const tier = input.forceTier ?? classifiedTier
-  const tierForced = input.forceTier !== undefined && input.forceTier !== classifiedTier
+  const tierForced = input.forceTier !== undefined
   const tierReasons = tierForced
-    ? [`forced via --force-tier (classifier said ${classifiedTier})`, ...tierResult.reasons]
+    ? [
+        `forced via --force-tier=${input.forceTier} (classifier said ${classifiedTier})`,
+        ...tierResult.reasons,
+      ]
     : tierResult.reasons
 
   const lanes = new Set(input.config.reviewers.length ? input.config.reviewers : TIER_LANES[tier])

--- a/packages/opencode/src/altimate/review/orchestrate.ts
+++ b/packages/opencode/src/altimate/review/orchestrate.ts
@@ -1230,14 +1230,19 @@ export async function runReview(input: OrchestrateInput): Promise<VerdictEnvelop
   //
   // Fetches run in parallel across schema files (a schema-heavy PR could touch
   // dozens of yml files; serial `git show` per file adds up).
-  const schemaFiles = reviewable.filter((f) => f.kind === "schema_yml")
+  //
+  // DELETED schema files are filtered upfront because `detectSchemaYmlPatterns`
+  // early-returns `[]` for `status === "deleted"` anyway; not filtering here
+  // would trigger an unnecessary `getContent(oldRef, "old")` fetch (a git-show
+  // round-trip) whose result is thrown away by the detector.
+  const schemaFiles = reviewable.filter((f) => f.kind === "schema_yml" && f.status !== "deleted")
   if (schemaFiles.length) {
     const schemaFindingSets = await Promise.all(
       schemaFiles.map(async (file) => {
         const oldRef = file.oldPath ?? file.path
         const [oldContent, newContent] = await Promise.all([
           file.status !== "added" ? getContent?.(oldRef, "old") : Promise.resolve(undefined),
-          file.status !== "deleted" ? getContent?.(file.path, "new") : Promise.resolve(undefined),
+          getContent?.(file.path, "new"),
         ])
         return detectSchemaYmlPatterns(file, input.rubric, { oldContent, newContent })
       }),

--- a/packages/opencode/src/altimate/review/orchestrate.ts
+++ b/packages/opencode/src/altimate/review/orchestrate.ts
@@ -1223,26 +1223,27 @@ export async function runReview(input: OrchestrateInput): Promise<VerdictEnvelop
   // silently drops sibling-column edge cases). Falls back to diff-only line
   // detection when a content resolver isn't wired (e.g. unit-test callers).
   //
-  // `oldContent` is fetched for anything that has an old side — MODIFIED and
-  // RENAMED. A schema.yml being renamed (e.g. moved to a new subdir) that
-  // also drops a `unique`/`not_null` guardrail must still surface as a finding;
-  // the earlier `status === "modified"` gate silently skipped renames.
+  // `oldContent` is fetched for anything that has an old side — MODIFIED,
+  // RENAMED, and DELETED. A schema.yml being renamed (e.g. moved to a new
+  // subdir) that also drops a `unique`/`not_null` guardrail must still surface
+  // as a finding; the earlier `status === "modified"` gate silently skipped
+  // renames. A whole schema.yml being DELETED removes every test declared in
+  // it — an even bigger removal — so the detector runs against `oldContent`
+  // vs an empty new document (cubic-review P2).
+  //
+  // `newContent` fetch is skipped for deleted files (nothing at HEAD to read;
+  // git-show would fail).
   //
   // Fetches run in parallel across schema files (a schema-heavy PR could touch
   // dozens of yml files; serial `git show` per file adds up).
-  //
-  // DELETED schema files are filtered upfront because `detectSchemaYmlPatterns`
-  // early-returns `[]` for `status === "deleted"` anyway; not filtering here
-  // would trigger an unnecessary `getContent(oldRef, "old")` fetch (a git-show
-  // round-trip) whose result is thrown away by the detector.
-  const schemaFiles = reviewable.filter((f) => f.kind === "schema_yml" && f.status !== "deleted")
+  const schemaFiles = reviewable.filter((f) => f.kind === "schema_yml")
   if (schemaFiles.length) {
     const schemaFindingSets = await Promise.all(
       schemaFiles.map(async (file) => {
         const oldRef = file.oldPath ?? file.path
         const [oldContent, newContent] = await Promise.all([
           file.status !== "added" ? getContent?.(oldRef, "old") : Promise.resolve(undefined),
-          getContent?.(file.path, "new"),
+          file.status !== "deleted" ? getContent?.(file.path, "new") : Promise.resolve(undefined),
         ])
         return detectSchemaYmlPatterns(file, input.rubric, { oldContent, newContent })
       }),

--- a/packages/opencode/src/altimate/review/orchestrate.ts
+++ b/packages/opencode/src/altimate/review/orchestrate.ts
@@ -1222,14 +1222,27 @@ export async function runReview(input: OrchestrateInput): Promise<VerdictEnvelop
   // (which loses context when the model header is outside the -U3 window and
   // silently drops sibling-column edge cases). Falls back to diff-only line
   // detection when a content resolver isn't wired (e.g. unit-test callers).
-  for (const file of reviewable) {
-    if (file.kind !== "schema_yml") continue
-    const oldRef = file.oldPath ?? file.path
-    const [oldContent, newContent] = await Promise.all([
-      file.status === "modified" ? getContent?.(oldRef, "old") : Promise.resolve(undefined),
-      file.status !== "deleted" ? getContent?.(file.path, "new") : Promise.resolve(undefined),
-    ])
-    all.push(detectSchemaYmlPatterns(file, input.rubric, { oldContent, newContent }))
+  //
+  // `oldContent` is fetched for anything that has an old side — MODIFIED and
+  // RENAMED. A schema.yml being renamed (e.g. moved to a new subdir) that
+  // also drops a `unique`/`not_null` guardrail must still surface as a finding;
+  // the earlier `status === "modified"` gate silently skipped renames.
+  //
+  // Fetches run in parallel across schema files (a schema-heavy PR could touch
+  // dozens of yml files; serial `git show` per file adds up).
+  const schemaFiles = reviewable.filter((f) => f.kind === "schema_yml")
+  if (schemaFiles.length) {
+    const schemaFindingSets = await Promise.all(
+      schemaFiles.map(async (file) => {
+        const oldRef = file.oldPath ?? file.path
+        const [oldContent, newContent] = await Promise.all([
+          file.status !== "added" ? getContent?.(oldRef, "old") : Promise.resolve(undefined),
+          file.status !== "deleted" ? getContent?.(file.path, "new") : Promise.resolve(undefined),
+        ])
+        return detectSchemaYmlPatterns(file, input.rubric, { oldContent, newContent })
+      }),
+    )
+    for (const findings of schemaFindingSets) all.push(findings)
   }
 
   // Architectural dedup: the regex `dbt-patterns`/`rule-catalog` layer is a

--- a/packages/opencode/src/altimate/review/run.ts
+++ b/packages/opencode/src/altimate/review/run.ts
@@ -1,5 +1,5 @@
 import path from "node:path"
-import { readFile } from "node:fs/promises"
+import { readFile, stat, access } from "node:fs/promises"
 import { loadReviewConfig, resolveRubric } from "./config"
 import type { Severity } from "./finding"
 import { collectChangedFiles, makeContentResolver, defaultBaseRef, manifestHash } from "./git"
@@ -42,6 +42,11 @@ export interface ReviewPullRequestOptions {
   /** PR metadata for the AI reviewer's intent check. */
   prTitle?: string
   prBody?: string
+  /** G1 — surface the tier classifier's reasons on the verdict envelope. */
+  explainTier?: boolean
+  /** G2 — [EXPERIMENTAL] bypass the tier classifier with the supplied tier.
+   *  Envelope carries `tierForced: true` when used. Debug / bench only. */
+  forceTier?: "trivial" | "lite" | "full"
 }
 
 /** dbt adapter_type → core SQL dialect. Mostly identity; a few aliases. */
@@ -73,6 +78,68 @@ async function detectDialect(manifestAbs: string): Promise<string | undefined> {
   }
 }
 
+/**
+ * G3 (Round 18) — walk upward from `cwd` looking for a dbt project, then check
+ * for the compiled `target/manifest.json` next to it. Emits an absolute path
+ * only when the manifest exists AND the file is under the dbt project's parent
+ * (defensive against relative escapes and stale manifests from unrelated
+ * projects on the same filesystem). Returns undefined when nothing matches.
+ *
+ * We DO NOT re-run `dbt compile` here — that could touch a real warehouse or
+ * consume credentials. The customer is still responsible for a compiled
+ * artifact; we just find it when they compiled but didn't pass `--manifest`.
+ */
+async function autoDiscoverManifest(cwd: string): Promise<{ path: string; projectRoot: string } | undefined> {
+  let dir = path.resolve(cwd)
+  const root = path.parse(dir).root
+  // Walk up looking for dbt_project.yml so the manifest we auto-discover is
+  // demonstrably tied to a dbt project (never `target/manifest.json` from an
+  // unrelated cwd, e.g. Airflow's `target/`).
+  while (true) {
+    for (const fn of ["dbt_project.yml", "dbt_project.yaml"]) {
+      try {
+        await access(path.join(dir, fn))
+        const candidate = path.join(dir, "target", "manifest.json")
+        try {
+          await access(candidate)
+          return { path: candidate, projectRoot: dir }
+        } catch {
+          return undefined // dbt project found but not compiled — respect that
+        }
+      } catch {
+        /* keep walking */
+      }
+    }
+    if (dir === root) return undefined
+    dir = path.dirname(dir)
+  }
+}
+
+/** Warn to stderr when the manifest looks stale relative to changed files. */
+async function warnIfStale(manifestAbs: string, changedPaths: string[], cwd: string): Promise<void> {
+  try {
+    const manifestMtime = (await stat(manifestAbs)).mtimeMs
+    for (const rel of changedPaths) {
+      // Only compare against tracked, on-disk model files (schema.yml or SQL)
+      const abs = path.isAbsolute(rel) ? rel : path.join(cwd, rel)
+      try {
+        const changedMtime = (await stat(abs)).mtimeMs
+        if (changedMtime > manifestMtime) {
+          process.stderr.write(
+            `⚠️  manifest ${manifestAbs} appears stale — ${rel} was modified after the manifest was written. ` +
+              `Re-run \`dbt compile\` (or \`dbt build\`) to refresh before reviewing.\n`,
+          )
+          return
+        }
+      } catch {
+        /* file not on disk (e.g. removed by the change) — skip */
+      }
+    }
+  } catch {
+    /* manifest unreadable → detectDialect will have already returned undefined */
+  }
+}
+
 export async function reviewPullRequest(opts: ReviewPullRequestOptions): Promise<VerdictEnvelope> {
   const config = await loadReviewConfig(opts.cwd)
   if (opts.manifestPath) config.manifestPath = opts.manifestPath
@@ -97,9 +164,37 @@ export async function reviewPullRequest(opts: ReviewPullRequestOptions): Promise
   // Resolve the manifest against the PROJECT being reviewed (cwd), not the
   // binary's process.cwd() — otherwise a relative path silently misses when the
   // CLI is invoked from elsewhere, degrading every review to lint-only.
-  const manifestAbs = path.isAbsolute(config.manifestPath)
+  let manifestAbs = path.isAbsolute(config.manifestPath)
     ? config.manifestPath
     : path.join(opts.cwd, config.manifestPath)
+  // G3 (Round 18) — auto-discovery when the caller didn't pass `--manifest` and
+  // the config-relative resolve above doesn't point at an existing file. Walk
+  // upward for the dbt project root and use its `target/manifest.json`. Explicit
+  // `--manifest` always wins (see run.ts opts.manifestPath override at the top).
+  if (!opts.manifestPath) {
+    let manifestExists = false
+    try {
+      await access(manifestAbs)
+      manifestExists = true
+    } catch {
+      /* fall through to auto-discovery */
+    }
+    if (!manifestExists) {
+      const discovered = await autoDiscoverManifest(opts.cwd)
+      if (discovered) {
+        manifestAbs = discovered.path
+        process.stderr.write(
+          `ℹ️  auto-discovered dbt manifest at ${discovered.path} ` +
+            `(dbt project root: ${discovered.projectRoot}). Pass --manifest to override.\n`,
+        )
+      }
+    }
+  }
+  // Freshness check: warn (don't fail) when the manifest predates changed files.
+  // Skip when we're diffing against the working tree (mtime signal is noisy
+  // during active edits) — only warn when the caller explicitly pinned a head
+  // ref, which is the CI / bench shape where a stale manifest is a real risk.
+  if (opts.head) await warnIfStale(manifestAbs, changedFiles.map((f) => f.path), opts.cwd)
 
   // Resolve the SQL dialect: explicit config wins; otherwise auto-detect from
   // the dbt manifest's `adapter_type` (so a BigQuery/Redshift project isn't
@@ -135,5 +230,7 @@ export async function reviewPullRequest(opts: ReviewPullRequestOptions): Promise
     aiReview: opts.noAi || config.ai === false ? undefined : runAiReview,
     prTitle: opts.prTitle,
     prBody: opts.prBody,
+    explainTier: opts.explainTier,
+    forceTier: opts.forceTier,
   })
 }

--- a/packages/opencode/src/altimate/review/run.ts
+++ b/packages/opencode/src/altimate/review/run.ts
@@ -118,12 +118,26 @@ async function autoDiscoverManifest(cwd: string): Promise<{ path: string; projec
   }
 }
 
-/** Warn to stderr when the manifest looks stale relative to changed files. */
+/** Warn to stderr when the manifest looks stale relative to changed files.
+ *  Only considers dbt-relevant files (SQL, YAML, Python models, seed CSV,
+ *  docs markdown) — changes to `README.md` at repo root, `.github/`,
+ *  `package.json`, etc. don't affect whether the compiled manifest is still
+ *  valid, so their mtimes shouldn't trigger a stale warning. */
+/** Exported for tests — see review-run-stale.test.ts. */
+export function isManifestAffecting(rel: string): boolean {
+  // dbt source directories — code (sql/py), schema (yml), seeds (csv), and
+  // docs blocks (md files under models/ / snapshots/ / analyses/ / etc.).
+  if (/(^|\/)(models|seeds|snapshots|macros|tests|analyses)\/.*\.(sql|py|yml|yaml|csv|md)$/i.test(rel)) return true
+  // Top-level dbt project config files.
+  if (/(^|\/)(dbt_project|packages|profiles|dependencies)\.ya?ml$/i.test(rel)) return true
+  return false
+}
+
 async function warnIfStale(manifestAbs: string, changedPaths: string[], cwd: string): Promise<void> {
   try {
     const manifestMtime = (await stat(manifestAbs)).mtimeMs
     for (const rel of changedPaths) {
-      // Only compare against tracked, on-disk model files (schema.yml or SQL)
+      if (!isManifestAffecting(rel)) continue
       const abs = path.isAbsolute(rel) ? rel : path.join(cwd, rel)
       try {
         const changedMtime = (await stat(abs)).mtimeMs

--- a/packages/opencode/src/altimate/review/run.ts
+++ b/packages/opencode/src/altimate/review/run.ts
@@ -79,15 +79,18 @@ async function detectDialect(manifestAbs: string): Promise<string | undefined> {
 }
 
 /**
- * G3 (Round 18) — walk upward from `cwd` looking for a dbt project, then check
- * for the compiled `target/manifest.json` next to it. Emits an absolute path
- * only when the manifest exists AND the file is under the dbt project's parent
- * (defensive against relative escapes and stale manifests from unrelated
- * projects on the same filesystem). Returns undefined when nothing matches.
+ * G3 (Round 18) — walk upward from `cwd` looking for the nearest
+ * `dbt_project.yml`; if found, return the adjacent `target/manifest.json`
+ * (when it exists). Anchored on `dbt_project.yml` so we never pick up a
+ * `target/` from an unrelated tool (e.g. an Airflow project) that happens
+ * to live above us on the filesystem.
  *
  * We DO NOT re-run `dbt compile` here — that could touch a real warehouse or
- * consume credentials. The customer is still responsible for a compiled
- * artifact; we just find it when they compiled but didn't pass `--manifest`.
+ * consume credentials. The customer is still responsible for compiling; we
+ * just find the existing artifact when they didn't pass `--manifest`.
+ *
+ * Returns undefined when no dbt project is found upward, or when the found
+ * project has no compiled manifest.
  */
 async function autoDiscoverManifest(cwd: string): Promise<{ path: string; projectRoot: string } | undefined> {
   let dir = path.resolve(cwd)
@@ -167,6 +170,12 @@ export async function reviewPullRequest(opts: ReviewPullRequestOptions): Promise
   let manifestAbs = path.isAbsolute(config.manifestPath)
     ? config.manifestPath
     : path.join(opts.cwd, config.manifestPath)
+  // The "effective dbt project root" for downstream lookups (dbtProjectName,
+  // compiled-SQL resolver). Starts as opts.cwd — G3 auto-discovery updates it
+  // when it finds a dbt_project.yml in an ancestor directory, so the compiled
+  // resolver and project-name lookups target the discovered project rather
+  // than the CLI's working directory (which may be a subdir).
+  let dbtRoot = opts.cwd
   // G3 (Round 18) — auto-discovery when the caller didn't pass `--manifest` and
   // the config-relative resolve above doesn't point at an existing file. Walk
   // upward for the dbt project root and use its `target/manifest.json`. Explicit
@@ -183,6 +192,7 @@ export async function reviewPullRequest(opts: ReviewPullRequestOptions): Promise
       const discovered = await autoDiscoverManifest(opts.cwd)
       if (discovered) {
         manifestAbs = discovered.path
+        dbtRoot = discovered.projectRoot
         process.stderr.write(
           `ℹ️  auto-discovered dbt manifest at ${discovered.path} ` +
             `(dbt project root: ${discovered.projectRoot}). Pass --manifest to override.\n`,
@@ -212,8 +222,11 @@ export async function reviewPullRequest(opts: ReviewPullRequestOptions): Promise
 
   // Prefer dbt's COMPILED SQL (target/compiled) for the engine lanes — the clean
   // approach (Datafold/Recce/Fusion all render-then-analyze rather than parse Jinja).
-  const projectName = await dbtProjectName(opts.cwd)
-  const getCompiled = opts.getContent ? undefined : makeCompiledResolver({ cwd: opts.cwd, projectName })
+  // Use `dbtRoot` (the discovered project root when G3 auto-discovery fired,
+  // else opts.cwd) so a subdir invocation still finds `target/compiled/…`
+  // next to the discovered manifest instead of falling back to raw Jinja.
+  const projectName = await dbtProjectName(dbtRoot)
+  const getCompiled = opts.getContent ? undefined : makeCompiledResolver({ cwd: dbtRoot, projectName })
 
   return runReview({
     changedFiles,

--- a/packages/opencode/src/altimate/review/run.ts
+++ b/packages/opencode/src/altimate/review/run.ts
@@ -2,7 +2,7 @@ import path from "node:path"
 import { readFile, stat, access } from "node:fs/promises"
 import { loadReviewConfig, resolveRubric } from "./config"
 import type { Severity } from "./finding"
-import { collectChangedFiles, makeContentResolver, defaultBaseRef, manifestHash } from "./git"
+import { collectChangedFiles, makeContentResolver, defaultBaseRef, gitRepoRoot, manifestHash } from "./git"
 import { makeCompiledResolver, dbtProjectName } from "./compiled"
 import { buildCatalogSchemaContext } from "./schema-context"
 import { createDispatcherRunner } from "./runner"
@@ -93,12 +93,12 @@ async function detectDialect(manifestAbs: string): Promise<string | undefined> {
  * project has no compiled manifest.
  */
 async function autoDiscoverManifest(cwd: string): Promise<{ path: string; projectRoot: string } | undefined> {
-  let dir = path.resolve(cwd)
-  const root = path.parse(dir).root
   // Walk up looking for dbt_project.yml so the manifest we auto-discover is
   // demonstrably tied to a dbt project (never `target/manifest.json` from an
-  // unrelated cwd, e.g. Airflow's `target/`).
-  while (true) {
+  // unrelated cwd, e.g. Airflow's `target/`). `path.dirname(root) === root`
+  // on every platform, so once we reach the filesystem root the next step
+  // is a fixed point — exit at that point (NIT #6 tidy from consensus review).
+  for (let dir = path.resolve(cwd); ; dir = path.dirname(dir)) {
     for (const fn of ["dbt_project.yml", "dbt_project.yaml"]) {
       try {
         await access(path.join(dir, fn))
@@ -113,8 +113,7 @@ async function autoDiscoverManifest(cwd: string): Promise<{ path: string; projec
         /* keep walking */
       }
     }
-    if (dir === root) return undefined
-    dir = path.dirname(dir)
+    if (path.dirname(dir) === dir) return undefined
   }
 }
 
@@ -133,12 +132,16 @@ export function isManifestAffecting(rel: string): boolean {
   return false
 }
 
-async function warnIfStale(manifestAbs: string, changedPaths: string[], cwd: string): Promise<void> {
+async function warnIfStale(manifestAbs: string, changedPaths: string[], fsRoot: string): Promise<void> {
   try {
     const manifestMtime = (await stat(manifestAbs)).mtimeMs
     for (const rel of changedPaths) {
       if (!isManifestAffecting(rel)) continue
-      const abs = path.isAbsolute(rel) ? rel : path.join(cwd, rel)
+      // `changedPaths` are repo-root relative (from `git diff --name-status`),
+      // so root at the git top-level rather than the caller's cwd. When the
+      // CLI is invoked from a subdir the naive path.join(cwd, rel) points at
+      // a non-existent path and the stale check silently no-ops.
+      const abs = path.isAbsolute(rel) ? rel : path.join(fsRoot, rel)
       try {
         const changedMtime = (await stat(abs)).mtimeMs
         if (changedMtime > manifestMtime) {
@@ -171,12 +174,19 @@ export async function reviewPullRequest(opts: ReviewPullRequestOptions): Promise
   const needGit = !opts.changedFiles || !opts.getContent
   const base = opts.base ?? (needGit ? await defaultBaseRef(opts.cwd) : "")
   const changedFiles = opts.changedFiles ?? (await collectChangedFiles({ base, head: opts.head, cwd: opts.cwd }))
+  // Resolve the repo top-level once; used to root working-tree FS reads, the
+  // stale-manifest existence check, and the compiled-SQL resolver's path
+  // mapping. Falls back to opts.cwd when we couldn't resolve it (non-git or
+  // bare-repo contexts) — safe for the repo-root-invoked case but not helpful
+  // in the subdir-invocation case that this addresses.
+  const gitRoot = (await gitRepoRoot(opts.cwd)) ?? opts.cwd
   // Map renamed files → their old path so getContent resolves the "old" side
   // from where the file lived at `base`.
   const renames = new Map(
     changedFiles.filter((f) => f.status === "renamed" && f.oldPath).map((f) => [f.path, f.oldPath as string]),
   )
-  const getContent = opts.getContent ?? makeContentResolver({ base, head: opts.head, cwd: opts.cwd, renames })
+  const getContent =
+    opts.getContent ?? makeContentResolver({ base, head: opts.head, cwd: opts.cwd, renames, gitRoot })
 
   // Resolve the manifest against the PROJECT being reviewed (cwd), not the
   // binary's process.cwd() — otherwise a relative path silently misses when the
@@ -218,7 +228,7 @@ export async function reviewPullRequest(opts: ReviewPullRequestOptions): Promise
   // Skip when we're diffing against the working tree (mtime signal is noisy
   // during active edits) — only warn when the caller explicitly pinned a head
   // ref, which is the CI / bench shape where a stale manifest is a real risk.
-  if (opts.head) await warnIfStale(manifestAbs, changedFiles.map((f) => f.path), opts.cwd)
+  if (opts.head) await warnIfStale(manifestAbs, changedFiles.map((f) => f.path), gitRoot)
 
   // Resolve the SQL dialect: explicit config wins; otherwise auto-detect from
   // the dbt manifest's `adapter_type` (so a BigQuery/Redshift project isn't
@@ -240,7 +250,13 @@ export async function reviewPullRequest(opts: ReviewPullRequestOptions): Promise
   // else opts.cwd) so a subdir invocation still finds `target/compiled/…`
   // next to the discovered manifest instead of falling back to raw Jinja.
   const projectName = await dbtProjectName(dbtRoot)
-  const getCompiled = opts.getContent ? undefined : makeCompiledResolver({ cwd: dbtRoot, projectName })
+  // Repo-relative file paths need the git-root → dbt-root prefix stripped
+  // so `packages/dbt/models/foo.sql` resolves to `models/foo.sql` inside the
+  // dbt project. `path.relative` returns "" when dbtRoot === gitRoot (the
+  // repo-root-invoked case) — makeCompiledResolver's `pathPrefix` treats
+  // that as a no-op.
+  const pathPrefix = path.relative(gitRoot, dbtRoot)
+  const getCompiled = opts.getContent ? undefined : makeCompiledResolver({ cwd: dbtRoot, projectName, pathPrefix })
 
   return runReview({
     changedFiles,

--- a/packages/opencode/src/altimate/review/run.ts
+++ b/packages/opencode/src/altimate/review/run.ts
@@ -107,7 +107,14 @@ async function autoDiscoverManifest(cwd: string): Promise<{ path: string; projec
           await access(candidate)
           return { path: candidate, projectRoot: dir }
         } catch {
-          return undefined // dbt project found but not compiled — respect that
+          // dbt project found at this dir but no compiled artifact. Do
+          // NOT walk further — a grandparent's `target/manifest.json`
+          // belongs to that grandparent's project, not to this one, and
+          // reviewing against it would compile the wrong DAG. Deliberate:
+          // "found a project, it just hasn't been compiled" — silent
+          // fallback to a sibling project would surprise the caller
+          // (altimate-harness-bot review, PR #1027 run.ts:114).
+          return undefined
         }
       } catch {
         /* keep walking */
@@ -117,21 +124,31 @@ async function autoDiscoverManifest(cwd: string): Promise<{ path: string; projec
   }
 }
 
-/** Warn to stderr when the manifest looks stale relative to changed files.
- *  Only considers dbt-relevant files (SQL, YAML, Python models, seed CSV,
- *  docs markdown) — changes to `README.md` at repo root, `.github/`,
- *  `package.json`, etc. don't affect whether the compiled manifest is still
- *  valid, so their mtimes shouldn't trigger a stale warning. */
-/** Exported for tests — see review-run-stale.test.ts. */
+/** Whether a repo-relative path is one whose modification could invalidate
+ *  the compiled manifest — dbt source (SQL, YAML, Python models, seed CSV,
+ *  docs markdown blocks) or top-level dbt config. `README.md` at repo root,
+ *  `.github/`, `package.json`, etc. are excluded so their mtimes don't
+ *  trigger a stale warning. Exported for tests — see review-run-stale.test.ts.
+ *  Referenced by `warnIfStale`. */
 export function isManifestAffecting(rel: string): boolean {
-  // dbt source directories — code (sql/py), schema (yml), seeds (csv), and
-  // docs blocks (md files under models/ / snapshots/ / analyses/ / etc.).
-  if (/(^|\/)(models|seeds|snapshots|macros|tests|analyses)\/.*\.(sql|py|yml|yaml|csv|md)$/i.test(rel)) return true
+  // Code / schema / seed CSV live under any dbt source directory.
+  if (/(^|\/)(models|seeds|snapshots|macros|tests|analyses)\/.*\.(sql|py|yml|yaml|csv)$/i.test(rel)) return true
+  // dbt docs blocks (`.md`) are only manifest-affecting under `models/` and
+  // `analyses/` — where `{% docs %}` blocks are canonically parsed. A
+  // `macros/README.md` / `tests/README.md` / `seeds/README.md` is package
+  // documentation, not manifest input (altimate-harness-bot review,
+  // PR #1027 run.ts:133).
+  if (/(^|\/)(models|analyses)\/.*\.md$/i.test(rel)) return true
   // Top-level dbt project config files.
   if (/(^|\/)(dbt_project|packages|profiles|dependencies)\.ya?ml$/i.test(rel)) return true
   return false
 }
 
+/** Warn to stderr when the manifest looks stale relative to changed files.
+ *  Compares the manifest's mtime against every change-affecting path (per
+ *  `isManifestAffecting`); a single change newer than the manifest is
+ *  enough to fire the warning once and return. Non-fatal — the review
+ *  proceeds against the (possibly stale) manifest. */
 async function warnIfStale(manifestAbs: string, changedPaths: string[], fsRoot: string): Promise<void> {
   try {
     const manifestMtime = (await stat(manifestAbs)).mtimeMs

--- a/packages/opencode/src/altimate/review/run.ts
+++ b/packages/opencode/src/altimate/review/run.ts
@@ -1,5 +1,5 @@
 import path from "node:path"
-import { readFile, stat, access } from "node:fs/promises"
+import { readFile, realpath, stat, access } from "node:fs/promises"
 import { loadReviewConfig, resolveRubric } from "./config"
 import type { Severity } from "./finding"
 import { collectChangedFiles, makeContentResolver, defaultBaseRef, gitRepoRoot, manifestHash } from "./git"
@@ -255,8 +255,27 @@ export async function reviewPullRequest(opts: ReviewPullRequestOptions): Promise
   // dbt project. `path.relative` returns "" when dbtRoot === gitRoot (the
   // repo-root-invoked case) — makeCompiledResolver's `pathPrefix` treats
   // that as a no-op.
-  const pathPrefix = path.relative(gitRoot, dbtRoot)
-  const getCompiled = opts.getContent ? undefined : makeCompiledResolver({ cwd: dbtRoot, projectName, pathPrefix })
+  //
+  // Canonicalise both roots via `fs.realpath` before computing the relative
+  // path. `gitRoot` from `git rev-parse --show-toplevel` is already
+  // symlink-resolved; `dbtRoot` is not, so on macOS (`/var` → `/private/var`)
+  // or any other symlinked-parent layout the `path.relative` result was a
+  // meaningless climb path (`../../var/...`) that never matched incoming
+  // repo-relative paths, and compiled SQL was silently missed
+  // (cubic-review P2 + kilo suggestion). Falls back gracefully when the
+  // realpath call fails (e.g. path deleted mid-run).
+  let gitRootReal = gitRoot
+  let dbtRootReal = dbtRoot
+  try {
+    gitRootReal = await realpath(gitRoot)
+    dbtRootReal = await realpath(dbtRoot)
+  } catch {
+    /* keep original values on realpath failure */
+  }
+  const pathPrefix = path.relative(gitRootReal, dbtRootReal)
+  const getCompiled = opts.getContent
+    ? undefined
+    : makeCompiledResolver({ cwd: dbtRootReal, projectName, pathPrefix })
 
   return runReview({
     changedFiles,

--- a/packages/opencode/src/altimate/review/verdict.ts
+++ b/packages/opencode/src/altimate/review/verdict.ts
@@ -122,6 +122,32 @@ export const VerdictEnvelope = z.object({
     .optional(),
   /** HMAC-SHA256 over the canonical body (added by signEnvelope). */
   signature: z.string().optional(),
+}).superRefine((env, ctx) => {
+  // G2 audit invariant — enforced at the envelope boundary so a hand-built
+  // envelope (bypassing runReview) can't sign inconsistent forced-tier
+  // metadata. When --force-tier is used, BOTH tierForced=true AND
+  // tierClassified must be present (per PR #1027 consensus MINOR #2).
+  const hasForced = env.tierForced === true
+  const hasClassified = env.tierClassified !== undefined
+  if (hasForced !== hasClassified) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        "tierForced and tierClassified must both be present or both absent: " +
+        `tierForced=${env.tierForced}, tierClassified=${env.tierClassified ?? "undefined"}`,
+      path: ["tierForced"],
+    })
+  }
+  // tierForced: false is not a legitimate state — the flag records
+  // "was --force-tier used?" as a positive marker; false is indistinguishable
+  // from a natural (unforced) run and only adds noise to the canonical body.
+  if (env.tierForced === false) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "tierForced must be true or undefined, not false",
+      path: ["tierForced"],
+    })
+  }
 })
 export type VerdictEnvelope = z.infer<typeof VerdictEnvelope>
 

--- a/packages/opencode/src/altimate/review/verdict.ts
+++ b/packages/opencode/src/altimate/review/verdict.ts
@@ -92,6 +92,13 @@ export const VerdictEnvelope = z.object({
   idealVerdict: Verdict,
   mode: ReviewMode,
   tier: RiskTier,
+  /** G1 — reasons the classifier assigned this tier (only when --explain-tier). */
+  tierReasons: z.array(z.string()).optional(),
+  /** G2 — true when --force-tier bypassed the classifier. Included in signature so
+   *  a tampered envelope claiming natural tier can't fake a forced run. */
+  tierForced: z.boolean().optional(),
+  /** The classifier's original tier before --force-tier overrode it (G2). */
+  tierClassified: RiskTier.optional(),
   findings: z.array(Finding),
   summary: z.object({
     critical: z.number().int().nonnegative(),
@@ -127,6 +134,12 @@ export interface BuildEnvelopeInput {
   manifestHash?: string
   generatedAt?: string
   degraded?: boolean
+  /** G1 — classifier reasons for the tier (only surfaced when explainTier=true). */
+  tierReasons?: string[]
+  /** G2 — set when --force-tier was applied. */
+  tierForced?: boolean
+  /** G2 — classifier's original tier before the force override. */
+  tierClassified?: RiskTier
 }
 
 function summarize(findings: Finding[], degraded: boolean): VerdictEnvelope["summary"] {
@@ -147,6 +160,9 @@ export function buildEnvelope(input: BuildEnvelopeInput): VerdictEnvelope {
     idealVerdict: ideal,
     mode: input.mode,
     tier: input.tier,
+    tierReasons: input.tierReasons,
+    tierForced: input.tierForced,
+    tierClassified: input.tierClassified,
     findings: input.findings,
     summary: summarize(input.findings, degraded),
     engine: EngineVersions.parse(input.engine ?? {}),

--- a/packages/opencode/src/cli/cmd/review.ts
+++ b/packages/opencode/src/cli/cmd/review.ts
@@ -22,9 +22,15 @@ export const ReviewCommand = cmd({
   describe: "review dbt/SQL changes and emit a signed verdict (APPROVE/COMMENT/REQUEST_CHANGES)",
   builder: (yargs) =>
     yargs
+      // Disable yargs' `--no-<option>` auto-negation for this command. Without this,
+      // yargs interprets bare `--no-ai` as "set option `ai` to false" — which is
+      // NOT a declared option, so the command silently falls into the help path
+      // (exit 0, no review runs). With `boolean-negation: false`, `--no-ai` binds
+      // to the declared `noAi` boolean flag as authored. B1 fix, Round 18.
+      .parserConfiguration({ "boolean-negation": false })
       .option("base", { type: "string", describe: "base git ref (default: merge-base with origin/main)" })
       .option("head", { type: "string", describe: "head git ref (default: working tree)" })
-      .option("manifest", { type: "string", describe: "path to dbt manifest.json" })
+      .option("manifest", { type: "string", describe: "path to dbt manifest.json (auto-discovered under target/ when omitted)" })
       .option("mode", {
         type: "string",
         choices: ["comment", "gate"] as const,
@@ -47,9 +53,25 @@ export const ReviewCommand = cmd({
         default: false,
         describe: "disable the advisory LLM reviewer lane (no model calls / cost)",
       })
+      .option("explain-tier", {
+        type: "boolean",
+        default: false,
+        describe: "emit tierReasons[] in the verdict envelope explaining the tier classification",
+      })
+      .option("force-tier", {
+        type: "string",
+        choices: ["trivial", "lite", "full"] as const,
+        describe: "[EXPERIMENTAL / bench debug] override the tier classifier — verdict envelope carries tierForced: true",
+      })
       .option("cwd", { type: "string", describe: "project directory (default: current dir)" }),
   async handler(args) {
     const cwd = (args.cwd as string) || process.cwd()
+    if (args.forceTier) {
+      process.stderr.write(
+        `⚠️  --force-tier=${args.forceTier} is EXPERIMENTAL (bench / debug only). ` +
+          `Classifier bypassed; verdict envelope will carry tierForced: true.\n`,
+      )
+    }
     await bootstrap(cwd, async () => {
       const env = await reviewPullRequest({
         cwd,
@@ -58,11 +80,11 @@ export const ReviewCommand = cmd({
         manifestPath: args.manifest as string | undefined,
         mode: args.mode as ReviewMode | undefined,
         severityThreshold: args.severity as Severity | undefined,
-        // The flag is registered as `--no-ai`, so yargs sets `args.noAi`. No `ai`
-        // option is declared, so `--ai=false` is NOT a supported CLI flag; the
-        // `args.ai === false` check only covers programmatic callers that pass
-        // `ai: false` directly.
+        // With `boolean-negation: false` above, `--no-ai` binds to `noAi` and
+        // the historical `--ai=false` programmatic path stays supported.
         noAi: args.noAi === true || args.ai === false,
+        explainTier: args.explainTier === true,
+        forceTier: args.forceTier as "trivial" | "lite" | "full" | undefined,
       })
 
       if (args.output) await fs.writeFile(args.output as string, JSON.stringify(env, null, 2))

--- a/packages/opencode/test/altimate/review-ci.test.ts
+++ b/packages/opencode/test/altimate/review-ci.test.ts
@@ -19,6 +19,43 @@ describe("review CLI command", () => {
     expect(ReviewCommand.command).toBe("review")
     expect(typeof ReviewCommand.handler).toBe("function")
   })
+
+  test("boolean-negation:false does not break other declared boolean flags (PR #1027 consensus MINOR #5)", async () => {
+    // The B1 fix disables yargs' `--no-<option>` auto-negation on the review
+    // command via `parserConfiguration({ "boolean-negation": false })`, so
+    // `--no-ai` binds to the declared `noAi` boolean. That setting is
+    // command-global — if a future boolean flag is added, its `--no-<flag>`
+    // form silently changes shape. This regression asserts every currently
+    // declared boolean parses to the expected type + default.
+    const yargsMod = await import("yargs")
+    // Build the command's yargs builder in isolation (no execution) and
+    // check the parsed argv shape for each boolean flag's on/off/default
+    // forms. Uses parseAsync so the whole builder chain runs.
+    const buildBase = () => (ReviewCommand.builder as any)(yargsMod.default([]).exitProcess(false).help(false))
+    const parse = async (args: string[]) => {
+      const parsed = await buildBase().parseAsync(args)
+      return parsed
+    }
+
+    const flags: Array<{ name: string; long: string; camel: string; default?: boolean }> = [
+      { name: "json", long: "--json", camel: "json", default: false },
+      { name: "post", long: "--post", camel: "post", default: false },
+      { name: "no-ai", long: "--no-ai", camel: "noAi", default: false },
+      { name: "explain-tier", long: "--explain-tier", camel: "explainTier", default: false },
+    ]
+
+    for (const f of flags) {
+      // Default (flag absent).
+      const defaultParsed = await parse([])
+      expect((defaultParsed as any)[f.camel]).toBe(f.default ?? false)
+      // Bare form flips to true (the whole point of B1).
+      const bareParsed = await parse([f.long])
+      expect((bareParsed as any)[f.camel]).toBe(true)
+      // Explicit `=false` still works.
+      const explicitFalse = await parse([`${f.long}=false`])
+      expect((explicitFalse as any)[f.camel]).toBe(false)
+    }
+  })
 })
 
 describe("resolveGitHubTarget", () => {

--- a/packages/opencode/test/altimate/review-dbt-patterns.test.ts
+++ b/packages/opencode/test/altimate/review-dbt-patterns.test.ts
@@ -235,6 +235,133 @@ models:
     expect(evResult.attribution).toBe("model-level")
   })
 
+  test("schema.yml (structural): dropping BOTH of two relationships on one column emits TWO findings (PR #1027 consensus MINOR #4)", () => {
+    // Regression: with `(entity, column, test)` keying alone, two
+    // `relationships` tests on the same column collapsed to a single set
+    // entry — dropping both produced ONE finding, and dropping either one
+    // in isolation produced ZERO (because the surviving one still matched
+    // the collapsed key). The extractor now discriminates by (to, field)
+    // so distinct relationships on one column stay distinct.
+    const oldContent = `version: 2
+models:
+  - name: orders
+    columns:
+      - name: customer_id
+        tests:
+          - relationships:
+              to: ref('customers')
+              field: customer_id
+          - relationships:
+              to: ref('legacy_customers')
+              field: id
+`
+    const newContent = `version: 2
+models:
+  - name: orders
+    columns:
+      - name: customer_id
+        tests: []
+`
+    const f = detectSchemaYmlPatterns(
+      { path: "models/schema.yml", status: "modified", diff: undefined },
+      DEFAULT_RUBRIC,
+      { oldContent, newContent },
+    )
+    // Both relationships removals surface separately.
+    expect(f.length).toBe(2)
+    // Distinct fingerprint ids so the global dedupe keeps them.
+    expect(new Set(f.map((x) => x.id)).size).toBe(2)
+    // Display copy stays clean — no raw discriminator control chars leak.
+    for (const finding of f) {
+      expect(finding.title).toContain("relationships")
+      expect(finding.title).not.toContain("\x01")
+      expect(finding.title).not.toContain("\x02")
+      expect(finding.body).not.toContain("\x01")
+      expect(finding.body).not.toContain("\x02")
+    }
+  })
+
+  test("schema.yml (structural): relationships discriminator survives colons in `to`/`field` args (codex round-5 minor)", () => {
+    // Codex flagged that a `:`-joined discriminator would collide when
+    // either arg contains `:` (e.g. `to='a:b', field='c'` vs `to='a',
+    // field='b:c'`). Discriminator now retains the internal `\x02`
+    // separator inside ruleKey (hashed, not displayed) so distinct
+    // (to, field) tuples never share a fingerprint.
+    const oldContent = `version: 2
+models:
+  - name: orders
+    columns:
+      - name: customer_id
+        tests:
+          - relationships:
+              to: "ref('a:b')"
+              field: c
+          - relationships:
+              to: ref('a')
+              field: "b:c"
+`
+    const newContent = `version: 2
+models:
+  - name: orders
+    columns:
+      - name: customer_id
+        tests: []
+`
+    const f = detectSchemaYmlPatterns(
+      { path: "models/schema.yml", status: "modified", diff: undefined },
+      DEFAULT_RUBRIC,
+      { oldContent, newContent },
+    )
+    // Two distinct removals, distinct fingerprints (would collide on a
+    // colon-joined tag).
+    expect(f.length).toBe(2)
+    expect(new Set(f.map((x) => x.id)).size).toBe(2)
+    // Display copy still stripped of raw control chars.
+    for (const finding of f) {
+      expect(finding.title).not.toContain("\x01")
+      expect(finding.body).not.toContain("\x02")
+    }
+  })
+
+  test("schema.yml (structural): dropping ONE of TWO relationships on one column surfaces (PR #1027 consensus MINOR #4 companion)", () => {
+    // Companion regression: with pre-fix keying, dropping one relationship
+    // while keeping the other left the collapsed key still in newSet, so
+    // no removal was reported. Now the (to, field) discriminator makes the
+    // dropped one distinct — a finding surfaces.
+    const oldContent = `version: 2
+models:
+  - name: orders
+    columns:
+      - name: customer_id
+        tests:
+          - relationships:
+              to: ref('customers')
+              field: customer_id
+          - relationships:
+              to: ref('legacy_customers')
+              field: id
+`
+    const newContent = `version: 2
+models:
+  - name: orders
+    columns:
+      - name: customer_id
+        tests:
+          - relationships:
+              to: ref('customers')
+              field: customer_id
+`
+    const f = detectSchemaYmlPatterns(
+      { path: "models/schema.yml", status: "modified", diff: undefined },
+      DEFAULT_RUBRIC,
+      { oldContent, newContent },
+    )
+    expect(f.length).toBe(1)
+    expect(f[0].title).toContain("relationships")
+    expect(f[0].title).not.toContain("\x01")
+    expect(f[0].body).not.toContain("\x01")
+  })
+
   test("schema.yml (structural): block-form relationships removal is detected", () => {
     const oldContent = `version: 2
 models:
@@ -539,12 +666,18 @@ models:
       { oldContent, newContent },
     )
     expect(f.length).toBe(2)
-    // Only ONE finding body should contain the "removes N data tests in total"
-    // aggregate summary line; the other should be plain.
-    const summaryCount = f.filter((x) => (x.body || "").includes("data tests in total")).length
+    // Only ONE finding body should contain the aggregate "N data tests"
+    // summary line; the other should be plain. Wording is per-schema-file
+    // scoped (PR #1027 consensus MINOR #3): "This schema file drops N data
+    // tests" so reviewers don't misread it as a PR-wide total on multi-file
+    // diffs.
+    const summaryCount = f.filter((x) => (x.body || "").includes("This schema file drops")).length
     expect(summaryCount).toBe(1)
+    const withSummary = f.find((x) => (x.body || "").includes("This schema file drops"))!
+    // Explicitly reject the old ambiguous PR-wide wording.
+    expect(withSummary.body).not.toContain("This PR removes")
+    expect(withSummary.body).not.toContain("in total")
     // And the mentioned model list should include BOTH models it touched.
-    const withSummary = f.find((x) => (x.body || "").includes("data tests in total"))!
     expect(withSummary.body).toContain("`customers`")
     expect(withSummary.body).toContain("`orders`")
   })

--- a/packages/opencode/test/altimate/review-dbt-patterns.test.ts
+++ b/packages/opencode/test/altimate/review-dbt-patterns.test.ts
@@ -158,6 +158,193 @@ describe("dbt-patterns detectors", () => {
     expect(f.length).toBe(0)
   })
 
+  // ------------------------------------------------------------------------
+  // Post-R18 review follow-ups: structural YAML path + sibling-column edge case
+  // + model-level tests + fallback shape. The rewritten detector prefers full
+  // old/new file content; these tests validate both paths.
+  // ------------------------------------------------------------------------
+
+  test("schema.yml (structural): unique removed from one column while sibling keeps it → 1 finding on the affected column", () => {
+    const oldContent = `version: 2
+models:
+  - name: customers
+    columns:
+      - name: customer_id
+        tests: [unique, not_null]
+      - name: email
+        tests: [not_null]
+  - name: orders
+    columns:
+      - name: order_id
+        tests: [unique, not_null]
+`
+    const newContent = `version: 2
+models:
+  - name: customers
+    columns:
+      - name: customer_id
+        tests: []
+      - name: email
+        tests: [not_null]
+  - name: orders
+    columns:
+      - name: order_id
+        tests: [unique, not_null]
+`
+    const f = detectSchemaYmlPatterns(
+      { path: "models/marts/_models.yml", status: "modified", diff: undefined },
+      DEFAULT_RUBRIC,
+      { oldContent, newContent },
+    )
+    // 2 removals on customers.customer_id (unique + not_null), 0 on orders/email
+    expect(f.length).toBe(2)
+    expect(has(f, "test_coverage", "warning")).toBe(true)
+    // At least one finding names customers.customer_id specifically
+    expect(f.some((x) => (x.title || "").includes("customers.customer_id"))).toBe(true)
+    // No finding attributed to orders.order_id (sibling still has `unique`)
+    expect(f.some((x) => (x.title || "").includes("orders.order_id"))).toBe(false)
+  })
+
+  test("schema.yml (structural): model-level unique test removed → 1 finding with model-level attribution", () => {
+    const oldContent = `version: 2
+models:
+  - name: customers
+    tests:
+      - unique
+    columns:
+      - name: customer_id
+`
+    const newContent = `version: 2
+models:
+  - name: customers
+    columns:
+      - name: customer_id
+`
+    const f = detectSchemaYmlPatterns(
+      { path: "models/marts/_models.yml", status: "modified", diff: undefined },
+      DEFAULT_RUBRIC,
+      { oldContent, newContent },
+    )
+    expect(f.length).toBe(1)
+    expect(f[0].category).toBe("test_coverage")
+    expect(f[0].severity).toBe("warning")
+    expect((f[0].title || "").includes("model-level")).toBe(true)
+    // Attribution flag in evidence lets downstream see it wasn't column-scoped
+    const evResult = (f[0].evidence?.result || {}) as Record<string, unknown>
+    expect(evResult.attribution).toBe("model-level")
+  })
+
+  test("schema.yml (structural): block-form relationships removal is detected", () => {
+    const oldContent = `version: 2
+models:
+  - name: orders
+    columns:
+      - name: customer_id
+        tests:
+          - relationships:
+              to: ref('customers')
+              field: customer_id
+`
+    const newContent = `version: 2
+models:
+  - name: orders
+    columns:
+      - name: customer_id
+        tests: []
+`
+    const f = detectSchemaYmlPatterns(
+      { path: "models/schema.yml", status: "modified", diff: undefined },
+      DEFAULT_RUBRIC,
+      { oldContent, newContent },
+    )
+    expect(f.length).toBe(1)
+    expect((f[0].title || "").includes("relationships")).toBe(true)
+  })
+
+  test("schema.yml (structural): data_tests (dbt 1.8+ alias) is recognized", () => {
+    const oldContent = `version: 2
+models:
+  - name: customers
+    columns:
+      - name: customer_id
+        data_tests: [unique, not_null]
+`
+    const newContent = `version: 2
+models:
+  - name: customers
+    columns:
+      - name: customer_id
+        data_tests: []
+`
+    const f = detectSchemaYmlPatterns(
+      { path: "models/schema.yml", status: "modified", diff: undefined },
+      DEFAULT_RUBRIC,
+      { oldContent, newContent },
+    )
+    expect(f.length).toBe(2)
+  })
+
+  test("schema.yml (structural): source column test removal is detected", () => {
+    const oldContent = `version: 2
+sources:
+  - name: raw
+    tables:
+      - name: users
+        columns:
+          - name: id
+            tests: [unique, not_null]
+`
+    const newContent = `version: 2
+sources:
+  - name: raw
+    tables:
+      - name: users
+        columns:
+          - name: id
+            tests: []
+`
+    const f = detectSchemaYmlPatterns(
+      { path: "models/sources.yml", status: "modified", diff: undefined },
+      DEFAULT_RUBRIC,
+      { oldContent, newContent },
+    )
+    expect(f.length).toBe(2)
+    // Source table gets qualified as `source.table` in the model field
+    expect(f.some((x) => (x.title || "").includes("raw.users.id"))).toBe(true)
+  })
+
+  test("schema.yml (structural): added file (no oldContent) surfaces no removal findings", () => {
+    const newContent = `version: 2
+models:
+  - name: customers
+    columns:
+      - name: customer_id
+        tests: [unique, not_null]
+`
+    const f = detectSchemaYmlPatterns(
+      { path: "models/schema.yml", status: "modified", diff: undefined },
+      DEFAULT_RUBRIC,
+      { oldContent: undefined, newContent },
+    )
+    expect(f.length).toBe(0)
+  })
+
+  test("schema.yml (fallback): diff-only path still surfaces removal (existing test's shape)", () => {
+    // Exercises the fallback line-based detection when the orchestrator can't
+    // supply file content (e.g. offline CI diffs).
+    const f = detectSchemaYmlPatterns(
+      {
+        path: "models/marts/_models.yml",
+        status: "modified",
+        diff: "-          - unique\n-          - not_null",
+      },
+      DEFAULT_RUBRIC,
+    )
+    // At least one test_coverage finding surfaces so a customer isn't blind to
+    // removed guardrails just because the content resolver wasn't wired.
+    expect(has(f, "test_coverage")).toBe(true)
+  })
+
   test("benign additive column produces NO dbt-pattern finding (precision)", () => {
     const sql = `select id, upper(status) as status_upper from {{ ref('x') }}`
     const f = detectModelPatterns(

--- a/packages/opencode/test/altimate/review-dbt-patterns.test.ts
+++ b/packages/opencode/test/altimate/review-dbt-patterns.test.ts
@@ -549,6 +549,107 @@ models:
     expect(withSummary.body).toContain("`orders`")
   })
 
+  test("deleted schema.yml: every prior test surfaces as a removal finding (cubic-review P2)", () => {
+    // Regression: deleting a whole schema.yml removes every test declared in
+    // it — arguably a bigger removal than dropping a single test. Previously
+    // the detector early-returned `[]` for `status === "deleted"`, so the
+    // deletion went unnoticed. Now the detector diffs the old document against
+    // an empty new document.
+    const oldContent = `version: 2
+models:
+  - name: customers
+    columns:
+      - name: customer_id
+        tests: [unique, not_null]
+      - name: email
+        tests: [not_null]
+  - name: orders
+    columns:
+      - name: order_id
+        tests: [unique]
+`
+    const f = detectSchemaYmlPatterns(
+      { path: "models/marts/_models.yml", status: "deleted", diff: undefined },
+      DEFAULT_RUBRIC,
+      // Only oldContent is available for a deleted file; newContent is undefined
+      // because git-show at HEAD would fail.
+      { oldContent, newContent: undefined },
+    )
+    // 4 removals: customers.customer_id.unique, customers.customer_id.not_null,
+    // customers.email.not_null, orders.order_id.unique
+    expect(f.length).toBe(4)
+    expect(has(f, "test_coverage", "warning")).toBe(true)
+    // Structured attribution surfaces on the top-level Finding, not just in
+    // evidence.result (cubic-review P3).
+    const byModel = f.filter((x) => x.model === "customers")
+    expect(byModel.length).toBe(3)
+    const byColumn = f.filter((x) => x.column === "email")
+    expect(byColumn.length).toBe(1)
+  })
+
+  test("deleted schema.yml without oldContent: no findings (safe degrade)", () => {
+    // Without the old side, we can't know what tests to flag as removed.
+    // The detector should degrade to `[]` rather than fabricating findings.
+    const f = detectSchemaYmlPatterns(
+      { path: "models/marts/_models.yml", status: "deleted", diff: undefined },
+      DEFAULT_RUBRIC,
+      { oldContent: undefined, newContent: undefined },
+    )
+    expect(f.length).toBe(0)
+  })
+
+  test("deleted schema.yml with unparsable oldContent + deletion diff → fallback surfaces removals", () => {
+    // Structural path can't commit (old YAML fails to parse), so the diff-only
+    // fallback runs. Confirms: unparsable-old → fallback, not silent drop.
+    const oldContent = `version: 2
+models:
+  - name: customers
+    columns:
+      - name: customer_id
+        tests:
+          - not_null   # <-- unterminated block below causes parse failure
+    tests: [
+`
+    // Diff uses the block-list shape the fallback regex targets
+    // (`-      - unique` / `-      - not_null`).
+    const diff = `--- a/models/marts/_models.yml
++++ /dev/null
+@@ -1,8 +0,0 @@
+-version: 2
+-models:
+-  - name: customers
+-    columns:
+-      - name: customer_id
+-        tests:
+-          - unique
+-          - not_null
+`
+    const f = detectSchemaYmlPatterns(
+      { path: "models/marts/_models.yml", status: "deleted", diff },
+      DEFAULT_RUBRIC,
+      { oldContent, newContent: undefined },
+    )
+    // Diff-only fallback picks up the removed `- unique` and `- not_null`
+    // lines, so we still emit at least one removal finding rather than silently
+    // dropping when the structural path couldn't commit.
+    expect(f.length).toBeGreaterThan(0)
+    expect(has(f, "test_coverage", "warning")).toBe(true)
+  })
+
+  test("deleted empty schema.yml: no fabricated findings (locks in precision)", () => {
+    // Old side parses cleanly but declares no tests. Ensures the structural
+    // loop doesn't fabricate findings when oldSet is empty.
+    const oldContent = `version: 2
+models: []
+`
+    const f = detectSchemaYmlPatterns(
+      { path: "models/marts/_models.yml", status: "deleted", diff: undefined },
+      DEFAULT_RUBRIC,
+      { oldContent, newContent: undefined },
+    )
+    expect(f.length).toBe(0)
+  })
+
   test("benign additive column produces NO dbt-pattern finding (precision)", () => {
     const sql = `select id, upper(status) as status_upper from {{ ref('x') }}`
     const f = detectModelPatterns(

--- a/packages/opencode/test/altimate/review-dbt-patterns.test.ts
+++ b/packages/opencode/test/altimate/review-dbt-patterns.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_RUBRIC,
   type ChangedFile,
 } from "../../src/altimate/review"
+import { dedupe } from "../../src/altimate/review/finding"
 
 // Build a modified-model ChangedFile from a new-SQL body + a synthetic diff
 // where the given lines are "added" (prefixed with +).
@@ -313,7 +314,7 @@ sources:
     expect(f.some((x) => (x.title || "").includes("raw.users.id"))).toBe(true)
   })
 
-  test("schema.yml (structural): added file (no oldContent) surfaces no removal findings", () => {
+  test("schema.yml (structural): added file (status=added, no oldContent) surfaces no removal findings", () => {
     const newContent = `version: 2
 models:
   - name: customers
@@ -322,11 +323,60 @@ models:
         tests: [unique, not_null]
 `
     const f = detectSchemaYmlPatterns(
-      { path: "models/schema.yml", status: "modified", diff: undefined },
+      { path: "models/schema.yml", status: "added", diff: undefined },
       DEFAULT_RUBRIC,
       { oldContent: undefined, newContent },
     )
     expect(f.length).toBe(0)
+  })
+
+  test("schema.yml (structural): renamed file with removed test still surfaces finding", () => {
+    // Regression guard: earlier code only fetched oldContent when
+    // status === "modified", so a rename that also dropped a guardrail test
+    // silently bypassed the detector.
+    const oldContent = `version: 2
+models:
+  - name: customers
+    columns:
+      - name: customer_id
+        tests: [unique, not_null]
+`
+    const newContent = `version: 2
+models:
+  - name: customers
+    columns:
+      - name: customer_id
+        tests: []
+`
+    const f = detectSchemaYmlPatterns(
+      {
+        path: "models/marts/_models.yml",
+        status: "renamed",
+        oldPath: "models/_models.yml",
+        diff: undefined,
+      },
+      DEFAULT_RUBRIC,
+      { oldContent, newContent },
+    )
+    expect(f.length).toBe(2)
+    expect(has(f, "test_coverage", "warning")).toBe(true)
+  })
+
+  test("schema.yml (structural): modified file with oldContent=undefined falls back to diff detection", () => {
+    // When the content resolver couldn't read the old side (e.g. transient
+    // git failure) on a MODIFIED file, we must NOT treat the situation as
+    // "added file, nothing removed" — the diff still contains real removed
+    // lines. Fall back to line-based detection instead of silently dropping.
+    const f = detectSchemaYmlPatterns(
+      {
+        path: "models/marts/_models.yml",
+        status: "modified",
+        diff: "-          - unique\n-          - not_null",
+      },
+      DEFAULT_RUBRIC,
+      { oldContent: undefined, newContent: "version: 2\nmodels: []\n" },
+    )
+    expect(has(f, "test_coverage")).toBe(true)
   })
 
   test("schema.yml (fallback): diff-only path still surfaces removal (existing test's shape)", () => {
@@ -343,6 +393,160 @@ models:
     // At least one test_coverage finding surfaces so a customer isn't blind to
     // removed guardrails just because the content resolver wasn't wired.
     expect(has(f, "test_coverage")).toBe(true)
+  })
+
+  test("schema.yml (fallback): distinct removals of same test type on different columns each surface", () => {
+    // Regression guard for the earlier dedup bug: (model="", column="", test)
+    // key reduced to just `test` and silently collapsed distinct removals of
+    // the same test type on different columns. The fallback path now emits
+    // one finding per removed test-line.
+    const f = detectSchemaYmlPatterns(
+      {
+        path: "models/marts/_models.yml",
+        status: "modified",
+        // Two `- unique` removed lines representing two different columns
+        // losing the `unique` test in the same PR.
+        diff: "-          - unique\n-          - not_null\n-          - unique\n-          - not_null",
+      },
+      DEFAULT_RUBRIC,
+    )
+    // 4 removed test-lines → 4 findings (fallback preserves per-line detail).
+    expect(f.length).toBe(4)
+    expect(has(f, "test_coverage", "warning")).toBe(true)
+  })
+
+  test("schema.yml (fallback): distinct removals survive the global fingerprint dedupe", () => {
+    // Integration-shape guard: the detector-level test above returns 4
+    // findings, but `runReview` runs a global `dedupe(findings)` step that
+    // fingerprints by (category, file, model, column, ruleKey). If ruleKey
+    // only varies by test-name for the fallback path, two `- unique`
+    // removals share a fingerprint and get merged post-detector. This test
+    // pipes the detector's output through `dedupe` to prove distinct
+    // removals actually reach the user.
+    const f = detectSchemaYmlPatterns(
+      {
+        path: "models/marts/_models.yml",
+        status: "modified",
+        diff: "-          - unique\n-          - not_null\n-          - unique\n-          - not_null",
+      },
+      DEFAULT_RUBRIC,
+    )
+    const deduped = dedupe(f)
+    expect(deduped.length).toBe(4)
+    // All 4 must be test_coverage findings; `unique` removals are `warning`,
+    // and fallback `not_null` (no column attribution) is `suggestion` because
+    // we can't tell if it was on an id/key column.
+    expect(deduped.every((x) => x.category === "test_coverage")).toBe(true)
+    // The 4 fingerprints must be distinct (was the exact regression: without
+    // an occurrence-index discriminator in ruleKey, the two `- unique` and
+    // two `- not_null` removals collapse to 2 findings after dedupe).
+    expect(new Set(deduped.map((x) => x.id)).size).toBe(4)
+    // 2 `- unique` (warning) + 2 `- not_null` (suggestion) — the exact split.
+    expect(deduped.filter((x) => x.severity === "warning").length).toBe(2)
+    expect(deduped.filter((x) => x.severity === "suggestion").length).toBe(2)
+  })
+
+  test("schema.yml (structural): distinct column removals also survive global dedupe", () => {
+    // Structural attribution provides (model.column.test) uniqueness natively,
+    // but the guard is worth codifying so future rule-key changes don't
+    // silently regress into the fingerprint-collision failure mode.
+    const oldContent = `version: 2
+models:
+  - name: customers
+    columns:
+      - name: customer_id
+        tests: [unique]
+      - name: email
+        tests: [unique]
+`
+    const newContent = `version: 2
+models:
+  - name: customers
+    columns:
+      - name: customer_id
+        tests: []
+      - name: email
+        tests: []
+`
+    const f = detectSchemaYmlPatterns(
+      { path: "models/marts/_models.yml", status: "modified", diff: undefined },
+      DEFAULT_RUBRIC,
+      { oldContent, newContent },
+    )
+    const deduped = dedupe(f)
+    expect(deduped.length).toBe(2)
+    expect(new Set(deduped.map((x) => x.id)).size).toBe(2)
+  })
+
+  test("snapshot yml property file (structural): removed test surfaces finding", () => {
+    // Regression: snapshot YAML property files were previously classified as
+    // `snapshot` kind (blocking the `schema_yml` gate in the orchestrator).
+    // Now `.yml` files under snapshots/ classify as `schema_yml` while `.sql`
+    // snapshots stay `snapshot` (tier-forcing catalog rules unchanged).
+    const oldContent = `version: 2
+snapshots:
+  - name: orders_snapshot
+    columns:
+      - name: order_id
+        tests: [unique, not_null]
+`
+    const newContent = `version: 2
+snapshots:
+  - name: orders_snapshot
+    columns:
+      - name: order_id
+        tests: []
+`
+    const f = detectSchemaYmlPatterns(
+      { path: "snapshots/orders_snapshot.yml", status: "modified", diff: undefined },
+      DEFAULT_RUBRIC,
+      { oldContent, newContent },
+    )
+    expect(f.length).toBe(2)
+    expect(has(f, "test_coverage", "warning")).toBe(true)
+  })
+
+  test("schema.yml summary: multi-model removals emit ONE aggregate summary line", () => {
+    // Regression guard: the aggregate "This PR removes N tests total on
+    // model(s) X, Y" summary was previously appended once per model, so a
+    // diff touching two models produced two copies of the same summary in
+    // separate findings. Now emitted once per FILE on the first finding.
+    const oldContent = `version: 2
+models:
+  - name: customers
+    columns:
+      - name: customer_id
+        tests: [unique]
+  - name: orders
+    columns:
+      - name: order_id
+        tests: [unique]
+`
+    const newContent = `version: 2
+models:
+  - name: customers
+    columns:
+      - name: customer_id
+        tests: []
+  - name: orders
+    columns:
+      - name: order_id
+        tests: []
+`
+    const f = detectSchemaYmlPatterns(
+      { path: "models/schema.yml", status: "modified", diff: undefined },
+      DEFAULT_RUBRIC,
+      { oldContent, newContent },
+    )
+    expect(f.length).toBe(2)
+    // Only ONE finding body should contain the "removes N data tests in total"
+    // aggregate summary line; the other should be plain.
+    const summaryCount = f.filter((x) => (x.body || "").includes("data tests in total")).length
+    expect(summaryCount).toBe(1)
+    // And the mentioned model list should include BOTH models it touched.
+    const withSummary = f.find((x) => (x.body || "").includes("data tests in total"))!
+    expect(withSummary.body).toContain("`customers`")
+    expect(withSummary.body).toContain("`orders`")
   })
 
   test("benign additive column produces NO dbt-pattern finding (precision)", () => {

--- a/packages/opencode/test/altimate/review-run-stale.test.ts
+++ b/packages/opencode/test/altimate/review-run-stale.test.ts
@@ -16,7 +16,8 @@ describe("isManifestAffecting", () => {
     "models/staging/stg_orders.sql",
     "models/schema.yml",
     "models/marts/_models.yml",
-    "models/customers.md", // dbt docs block
+    "models/customers.md", // dbt docs block under models/
+    "analyses/gross_margin.md", // dbt docs block under analyses/
     "seeds/lookup.csv",
     "snapshots/orders_snapshot.sql",
     "snapshots/orders_snapshot.yml",
@@ -45,6 +46,14 @@ describe("isManifestAffecting", () => {
     "target/manifest.json", // the manifest itself
     "target/compiled/foo.sql", // compiled artifacts
     "tests/e2e/setup.ts",
+    // dbt docs blocks are canonically parsed only from `models/` and
+    // `analyses/`. README.md files elsewhere under dbt directories are
+    // package documentation, not manifest input (altimate-harness-bot
+    // review, PR #1027 run.ts:133).
+    "macros/README.md",
+    "tests/README.md",
+    "seeds/README.md",
+    "snapshots/README.md",
   ])("rejects: %s", (rel) => {
     expect(isManifestAffecting(rel)).toBe(false)
   })

--- a/packages/opencode/test/altimate/review-run-stale.test.ts
+++ b/packages/opencode/test/altimate/review-run-stale.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from "bun:test"
+import { isManifestAffecting } from "../../src/altimate/review/run"
+
+/**
+ * Guards on `warnIfStale`'s changed-file filter. The stale warning gates on a
+ * changed file having an mtime newer than the manifest; iterating every path
+ * in the diff (including README.md, package.json, .github/*) triggered
+ * false-positive warnings on unrelated repo activity. The filter admits only
+ * dbt-relevant paths.
+ */
+describe("isManifestAffecting", () => {
+  // ADMITTED — these should trigger a stale-manifest warning when newer than
+  // the compiled manifest.
+  test.each([
+    "models/marts/customers.sql",
+    "models/staging/stg_orders.sql",
+    "models/schema.yml",
+    "models/marts/_models.yml",
+    "models/customers.md", // dbt docs block
+    "seeds/lookup.csv",
+    "snapshots/orders_snapshot.sql",
+    "snapshots/orders_snapshot.yml",
+    "macros/generate_schema_name.sql",
+    "tests/singular/no_orphan_orders.sql",
+    "analyses/gross_margin.sql",
+    "dbt_project.yml",
+    "packages.yml",
+    "profiles.yml",
+    "dependencies.yml",
+  ])("admits: %s", (rel) => {
+    expect(isManifestAffecting(rel)).toBe(true)
+  })
+
+  // REJECTED — these should NOT trigger a stale-manifest warning because
+  // touching them doesn't invalidate the compiled dbt manifest.
+  test.each([
+    "README.md",
+    "CHANGELOG.md",
+    "package.json",
+    ".github/workflows/ci.yml",
+    ".gitignore",
+    "docs/README.md",
+    "Dockerfile",
+    "scripts/deploy.sh",
+    "target/manifest.json", // the manifest itself
+    "target/compiled/foo.sql", // compiled artifacts
+    "tests/e2e/setup.ts",
+  ])("rejects: %s", (rel) => {
+    expect(isManifestAffecting(rel)).toBe(false)
+  })
+})

--- a/packages/opencode/test/altimate/review-subdir-invocation.test.ts
+++ b/packages/opencode/test/altimate/review-subdir-invocation.test.ts
@@ -154,6 +154,73 @@ describe("R20: subdir-invocation content resolution (PR #1027 consensus MAJOR)",
     expect(content).toBe("-- compiled via backslash prefix\n")
   })
 
+  test("makeContentResolver refuses to read a repo file whose realpath escapes the git root (bot-review security)", async () => {
+    // coderabbit + cubic P2 — a tracked symlink that points outside the
+    // repo (e.g. `models/evil.sql → /etc/passwd`) would otherwise be
+    // followed and leak external content into the review pipeline. The
+    // containment check via realpath rejects any target whose resolved
+    // path is not inside the resolved repo root.
+    const { root } = await mkTempRepo()
+    // Create a target outside the repo, then a symlink inside the repo
+    // pointing to it.
+    const outside = await fs.mkdtemp(path.join(tmpdir(), "outside-repo-"))
+    const secret = path.join(outside, "secret.sql")
+    await fs.writeFile(secret, "SECRET CONTENT\n")
+    const evilPath = path.join(root, "packages", "dbt", "models", "marts", "evil.sql")
+    await fs.symlink(secret, evilPath)
+
+    const resolver = makeContentResolver({ base: "HEAD", cwd: root, gitRoot: root })
+    // Reading the symlink target must be refused (returns undefined) —
+    // it must NOT leak the secret file contents.
+    const content = await resolver("packages/dbt/models/marts/evil.sql", "new")
+    expect(content).toBeUndefined()
+
+    // Sanity: a regular tracked file inside the repo is still readable.
+    const good = await resolver("packages/dbt/models/marts/customers.sql", "new")
+    expect(good).toBe("-- customers content\n")
+  })
+
+  test("gitRepoRoot preserves legitimate leading/trailing spaces in the path (bot-review P3)", async () => {
+    // cubic P3 — `.trim()` on the git output stripped path characters
+    // (leading spaces are legitimate on macOS temp dirs like `/private/…`
+    // and on Windows). Now we strip only the git-emitted `\r?\n`
+    // terminator. Simulate a git output with only a newline terminator and
+    // no path whitespace — the result must equal the pre-terminator body.
+    // (Building an actual repo at a whitespace path is filesystem-touchy
+    // across platforms; this test exercises the string handling
+    // behaviorally via the actual git output.)
+    const { root } = await mkTempRepo()
+    const r = await gitRepoRoot(root)
+    // Verify the returned value doesn't have trailing newline chars.
+    expect(r?.endsWith("\n")).toBe(false)
+    expect(r?.endsWith("\r")).toBe(false)
+    // And that r is still a valid path (matches real repo).
+    expect(await fs.realpath(r!)).toBe(await fs.realpath(root))
+  })
+
+  test("makeCompiledResolver refuses a compiled symlink escaping the compiled root (bot-review security)", async () => {
+    // Same containment check applied to compiled SQL lookup — a symlinked
+    // compiled artifact pointing outside `target/compiled/<project>/`
+    // must not be read.
+    const { root } = await mkTempRepo()
+    const dbtRoot = path.join(root, "packages", "dbt")
+    const project = "acme"
+    const compiledDir = path.join(dbtRoot, "target", "compiled", project, "models", "marts")
+    await fs.mkdir(compiledDir, { recursive: true })
+    const outside = await fs.mkdtemp(path.join(tmpdir(), "outside-compiled-"))
+    const secret = path.join(outside, "secret.sql")
+    await fs.writeFile(secret, "COMPILED SECRET\n")
+    await fs.symlink(secret, path.join(compiledDir, "evil.sql"))
+
+    const resolver = makeCompiledResolver({
+      cwd: dbtRoot,
+      projectName: project,
+      pathPrefix: "packages/dbt",
+    })
+    const content = await resolver("packages/dbt/models/marts/evil.sql", "new")
+    expect(content).toBeUndefined()
+  })
+
   test("makeCompiledResolver pathPrefix accepts '.' as a no-op alias", async () => {
     // `path.relative(root, root)` returns "" — treat "" and "." as
     // equivalent to "no prefix" so callers don't need branching logic.

--- a/packages/opencode/test/altimate/review-subdir-invocation.test.ts
+++ b/packages/opencode/test/altimate/review-subdir-invocation.test.ts
@@ -1,0 +1,168 @@
+import { describe, test, expect } from "bun:test"
+import { promises as fs } from "node:fs"
+import path from "node:path"
+import { tmpdir } from "node:os"
+import { execFile } from "node:child_process"
+import { promisify } from "node:util"
+import { gitRepoRoot, makeContentResolver } from "../../src/altimate/review/git"
+import { makeCompiledResolver } from "../../src/altimate/review/compiled"
+
+const exec = promisify(execFile)
+
+/**
+ * Regression coverage for the subdir-invocation content-resolution MAJOR
+ * (PR #1027 consensus review, finding 1). The three affected code paths —
+ * `makeContentResolver` working-tree read, `warnIfStale` file existence check,
+ * and `makeCompiledResolver` compiled-SQL lookup — all previously joined
+ * repo-relative paths (from `git diff --name-status`) with the caller's
+ * `opts.cwd`, silently ENOENT-ing when the CLI was invoked from a subdir.
+ *
+ * These tests build a small git repo in a temp dir, invoke resolvers from a
+ * subdir, and assert content is still found via the resolved git top-level.
+ */
+
+async function mkTempRepo(): Promise<{ root: string; sub: string }> {
+  const root = await fs.mkdtemp(path.join(tmpdir(), "review-subdir-invocation-"))
+  const sub = path.join(root, "packages", "dbt")
+  await fs.mkdir(sub, { recursive: true })
+  await fs.mkdir(path.join(sub, "models", "marts"), { recursive: true })
+  await fs.writeFile(path.join(sub, "models", "marts", "customers.sql"), "-- customers content\n")
+  await exec("git", ["init", "-q"], { cwd: root })
+  await exec("git", ["config", "user.email", "t@test"], { cwd: root })
+  await exec("git", ["config", "user.name", "t"], { cwd: root })
+  await exec("git", ["add", "."], { cwd: root })
+  await exec("git", ["commit", "-qm", "seed"], { cwd: root })
+  return { root, sub }
+}
+
+describe("R20: subdir-invocation content resolution (PR #1027 consensus MAJOR)", () => {
+  test("gitRepoRoot resolves the same top-level from repo root and from a subdir", async () => {
+    const { root, sub } = await mkTempRepo()
+    const fromRoot = await gitRepoRoot(root)
+    const fromSub = await gitRepoRoot(sub)
+    // `git rev-parse --show-toplevel` may emit a path with a `/private` prefix
+    // on macOS (symlink resolution); compare via realpath so the test is
+    // portable across platforms.
+    expect(await fs.realpath(fromRoot!)).toBe(await fs.realpath(root))
+    expect(await fs.realpath(fromSub!)).toBe(await fs.realpath(root))
+  })
+
+  test("gitRepoRoot returns undefined outside a git repo", async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), "not-a-repo-"))
+    const r = await gitRepoRoot(dir)
+    expect(r).toBeUndefined()
+  })
+
+  test("makeContentResolver working-tree branch reads via gitRoot when invoked from subdir", async () => {
+    const { root, sub } = await mkTempRepo()
+    // Simulating the CI-side path where a caller invokes the review from a
+    // subdir (`sub`). The gitRoot option lets working-tree reads use the
+    // resolved top-level.
+    const resolver = makeContentResolver({ base: "HEAD", cwd: sub, gitRoot: root })
+    const content = await resolver("packages/dbt/models/marts/customers.sql", "new")
+    expect(content).toBe("-- customers content\n")
+  })
+
+  test("makeContentResolver without gitRoot falls back to opts.cwd (legacy behavior)", async () => {
+    // When gitRoot is omitted, working-tree reads join with opts.cwd. When
+    // the CLI is invoked from the repo root this is correct; from a subdir
+    // it silently ENOENTs. Regression guard: the fallback path is
+    // exercised (returns undefined without throwing) so the legacy call
+    // sites still work.
+    const { root, sub } = await mkTempRepo()
+    const resolver = makeContentResolver({ base: "HEAD", cwd: sub })
+    // Subdir cwd + repo-relative file = path-doubling → ENOENT → undefined.
+    const missing = await resolver("packages/dbt/models/marts/customers.sql", "new")
+    expect(missing).toBeUndefined()
+    // From the repo root the same file is found (baseline check).
+    const found = await makeContentResolver({ base: "HEAD", cwd: root })(
+      "packages/dbt/models/marts/customers.sql",
+      "new",
+    )
+    expect(found).toBe("-- customers content\n")
+  })
+
+  test("makeCompiledResolver strips the git-root → dbt-root pathPrefix", async () => {
+    // Simulate a monorepo where dbt lives at packages/dbt/ and compiled SQL
+    // is written by `dbt compile` to packages/dbt/target/compiled/<project>/.
+    // File paths from `git diff --name-status` are repo-root relative
+    // (packages/dbt/models/marts/foo.sql). Without prefix-stripping the
+    // resolver looks for target/compiled/<project>/packages/dbt/models/…
+    // (wrong: nested duplication) and misses the compiled artifact.
+    const { root } = await mkTempRepo()
+    const dbtRoot = path.join(root, "packages", "dbt")
+    const project = "acme"
+    const compiledPath = path.join(dbtRoot, "target", "compiled", project, "models", "marts", "customers.sql")
+    await fs.mkdir(path.dirname(compiledPath), { recursive: true })
+    await fs.writeFile(compiledPath, "-- compiled customers\n")
+
+    const resolver = makeCompiledResolver({
+      cwd: dbtRoot,
+      projectName: project,
+      pathPrefix: "packages/dbt",
+    })
+    const content = await resolver("packages/dbt/models/marts/customers.sql", "new")
+    expect(content).toBe("-- compiled customers\n")
+  })
+
+  test("makeCompiledResolver pathPrefix is a no-op when unset (repo-root-invoked case)", async () => {
+    const { root } = await mkTempRepo()
+    const project = "acme"
+    const compiledPath = path.join(root, "target", "compiled", project, "models", "marts", "customers.sql")
+    await fs.mkdir(path.dirname(compiledPath), { recursive: true })
+    await fs.writeFile(compiledPath, "-- compiled at root\n")
+
+    const resolver = makeCompiledResolver({ cwd: root, projectName: project })
+    const content = await resolver("models/marts/customers.sql", "new")
+    expect(content).toBe("-- compiled at root\n")
+  })
+
+  test("makeCompiledResolver pathPrefix does NOT strip when path doesn't start with prefix", async () => {
+    // Precision guard: a file outside the prefixed subtree must remain
+    // untouched. Repo-relative `docs/foo.md` with prefix `packages/dbt`
+    // → still `docs/foo.md` (no lookup match, returns undefined).
+    const { root } = await mkTempRepo()
+    const resolver = makeCompiledResolver({
+      cwd: path.join(root, "packages", "dbt"),
+      projectName: "acme",
+      pathPrefix: "packages/dbt",
+    })
+    const content = await resolver("docs/foo.md", "new")
+    expect(content).toBeUndefined()
+  })
+
+  test("makeCompiledResolver pathPrefix normalises Windows backslashes to forward slashes (codex round-5 HIGH)", async () => {
+    // `path.relative()` on Windows returns `packages\dbt` while git diff paths
+    // are always POSIX-separated. If the resolver didn't normalise the prefix,
+    // no repo-relative file path would match it and compiled SQL would be
+    // silently missed on Windows monorepos.
+    const { root } = await mkTempRepo()
+    const dbtRoot = path.join(root, "packages", "dbt")
+    const project = "acme"
+    const compiledPath = path.join(dbtRoot, "target", "compiled", project, "models", "customers.sql")
+    await fs.mkdir(path.dirname(compiledPath), { recursive: true })
+    await fs.writeFile(compiledPath, "-- compiled via backslash prefix\n")
+
+    // Simulate the Windows caller: pathPrefix contains `\` separators; the
+    // repo-relative file path from `git diff` still uses `/`.
+    const resolver = makeCompiledResolver({
+      cwd: dbtRoot,
+      projectName: project,
+      pathPrefix: "packages\\dbt",
+    })
+    const content = await resolver("packages/dbt/models/customers.sql", "new")
+    expect(content).toBe("-- compiled via backslash prefix\n")
+  })
+
+  test("makeCompiledResolver pathPrefix accepts '.' as a no-op alias", async () => {
+    // `path.relative(root, root)` returns "" — treat "" and "." as
+    // equivalent to "no prefix" so callers don't need branching logic.
+    const { root } = await mkTempRepo()
+    const project = "acme"
+    const compiledPath = path.join(root, "target", "compiled", project, "models", "customers.sql")
+    await fs.mkdir(path.dirname(compiledPath), { recursive: true })
+    await fs.writeFile(compiledPath, "-- via dot prefix\n")
+    const resolver = makeCompiledResolver({ cwd: root, projectName: project, pathPrefix: "." })
+    expect(await resolver("models/customers.sql", "new")).toBe("-- via dot prefix\n")
+  })
+})

--- a/packages/opencode/test/altimate/review.test.ts
+++ b/packages/opencode/test/altimate/review.test.ts
@@ -1881,6 +1881,42 @@ describe("orchestrate", () => {
     expect(env.summary.degraded).toBe(true)
   })
 
+  test("renderSummary escapes backticks in tierReasons (cubic-review P3)", async () => {
+    // Regression: a fixed single-backtick fence around each tier reason meant a
+    // path like `weird`path`.sql` would terminate the code span mid-way and
+    // inject Markdown into the summary. Fence now sizes to max(backtick-run)+1
+    // and pads leading/trailing backticks with a space.
+    const env = buildEnvelope({
+      findings: [],
+      tier: "full",
+      mode: "comment",
+      generatedAt: "2026-05-29T00:00:00Z",
+      tierReasons: [
+        "models/x.sql", // plain path — one-backtick fence still fine
+        "path with `single` inside", // needs 2-backtick fence
+        "path with ``double`` inside", // needs 3-backtick fence
+        "`starts-with-backtick",
+        "ends-with-backtick`",
+        "`both-ends`", // both leading + trailing backticks — symmetric padding
+      ],
+    })
+    const summary = renderSummary(env)
+    // Sanity: the tier line exists
+    expect(summary).toContain("Tier: full")
+    // A path with `single` inside must be wrapped by a fence longer than the
+    // longest backtick run inside it. Two-backtick fence sees `single` as a
+    // single-backtick run inside the code span → renders correctly.
+    expect(summary).toContain("``path with `single` inside``")
+    // Three-backtick fence for two-backtick run inside.
+    expect(summary).toContain("```path with ``double`` inside```")
+    // Leading/trailing backticks get space padding so the fence doesn't fuse
+    // with the reason text.
+    expect(summary).toContain("`` `starts-with-backtick ``")
+    expect(summary).toContain("`` ends-with-backtick` ``")
+    // Both ends have backticks — same single pad wraps both sides symmetrically.
+    expect(summary).toContain("`` `both-ends` ``")
+  })
+
   test("renderSummary + inlineComments produce marker + structured output", async () => {
     const env = buildEnvelope({
       findings: [

--- a/packages/opencode/test/altimate/review.test.ts
+++ b/packages/opencode/test/altimate/review.test.ts
@@ -297,6 +297,85 @@ describe("verdict", () => {
     expect(notForced.tierClassified).toBeUndefined()
   })
 
+  test("envelope schema rejects inconsistent tierForced / tierClassified (PR #1027 consensus MINOR #2)", async () => {
+    // Direct-parse invariants at the envelope boundary. `runReview` never
+    // builds an inconsistent envelope, but a hand-built envelope with
+    // `tierForced: true` and no `tierClassified` (or vice versa) is a
+    // silent audit-metadata break — the signed body claims a bypass but
+    // records no origin tier, or vice versa. The zod `superRefine`
+    // makes both states unparseable and unsignable.
+    const { VerdictEnvelope: EnvelopeSchema } = await import("../../src/altimate/review/verdict")
+
+    const goodBothPresent = EnvelopeSchema.safeParse({
+      version: "1",
+      verdict: "APPROVE",
+      idealVerdict: "APPROVE",
+      mode: "comment",
+      tier: "full",
+      tierForced: true,
+      tierClassified: "trivial",
+      findings: [],
+      summary: { critical: 0, warning: 0, suggestion: 0, degraded: false },
+      engine: { reviewer: "test/1" },
+    })
+    expect(goodBothPresent.success).toBe(true)
+
+    const goodBothAbsent = EnvelopeSchema.safeParse({
+      version: "1",
+      verdict: "APPROVE",
+      idealVerdict: "APPROVE",
+      mode: "comment",
+      tier: "lite",
+      findings: [],
+      summary: { critical: 0, warning: 0, suggestion: 0, degraded: false },
+      engine: { reviewer: "test/1" },
+    })
+    expect(goodBothAbsent.success).toBe(true)
+
+    const badForcedOnly = EnvelopeSchema.safeParse({
+      version: "1",
+      verdict: "APPROVE",
+      idealVerdict: "APPROVE",
+      mode: "comment",
+      tier: "full",
+      tierForced: true,
+      // tierClassified missing — inconsistent audit metadata
+      findings: [],
+      summary: { critical: 0, warning: 0, suggestion: 0, degraded: false },
+      engine: { reviewer: "test/1" },
+    })
+    expect(badForcedOnly.success).toBe(false)
+
+    const badClassifiedOnly = EnvelopeSchema.safeParse({
+      version: "1",
+      verdict: "APPROVE",
+      idealVerdict: "APPROVE",
+      mode: "comment",
+      tier: "full",
+      // tierForced missing but tierClassified claims an origin
+      tierClassified: "trivial",
+      findings: [],
+      summary: { critical: 0, warning: 0, suggestion: 0, degraded: false },
+      engine: { reviewer: "test/1" },
+    })
+    expect(badClassifiedOnly.success).toBe(false)
+
+    const badForcedFalse = EnvelopeSchema.safeParse({
+      version: "1",
+      verdict: "APPROVE",
+      idealVerdict: "APPROVE",
+      mode: "comment",
+      tier: "lite",
+      // `tierForced: false` is not a legitimate state — the marker exists to
+      // record forced runs; unforced runs must omit it entirely.
+      tierForced: false,
+      findings: [],
+      summary: { critical: 0, warning: 0, suggestion: 0, degraded: false },
+      engine: { reviewer: "test/1" },
+    })
+    expect(badForcedFalse.success).toBe(false)
+  })
+
   test("tierForced + tierClassified are covered by the signature (tampering detected)", () => {
     // Confirms the audit fields live inside the signed canonical body — a
     // tampered envelope claiming a natural tier when a bypass ran can't slip

--- a/packages/opencode/test/altimate/review.test.ts
+++ b/packages/opencode/test/altimate/review.test.ts
@@ -265,6 +265,59 @@ describe("verdict", () => {
     expect(verifyEnvelope(tampered, "test-key")).toBe(false)
   })
 
+  test("--force-tier audit fields are set whenever the flag is passed (even when forced == classified)", () => {
+    // Simulates orchestrate.ts's audit-envelope construction for the two
+    // --force-tier cases. Ensures we never silently bypass the audit trail
+    // just because the forced value happens to match the classifier's tier.
+    // Regression guard for the post-R18 review finding.
+    const withForcedDifferent = buildEnvelope({
+      findings: [],
+      tier: "full",
+      mode: "comment",
+      tierForced: true,
+      tierClassified: "trivial",
+      tierReasons: ["forced via --force-tier=full (classifier said trivial)"],
+    })
+    expect(withForcedDifferent.tierForced).toBe(true)
+    expect(withForcedDifferent.tierClassified).toBe("trivial")
+
+    const withForcedSame = buildEnvelope({
+      findings: [],
+      tier: "full",
+      mode: "comment",
+      tierForced: true,
+      tierClassified: "full",
+      tierReasons: ["forced via --force-tier=full (classifier said full)"],
+    })
+    expect(withForcedSame.tierForced).toBe(true)
+    expect(withForcedSame.tierClassified).toBe("full")
+
+    const notForced = buildEnvelope({ findings: [], tier: "lite", mode: "comment" })
+    expect(notForced.tierForced).toBeUndefined()
+    expect(notForced.tierClassified).toBeUndefined()
+  })
+
+  test("tierForced + tierClassified are covered by the signature (tampering detected)", () => {
+    // Confirms the audit fields live inside the signed canonical body — a
+    // tampered envelope claiming a natural tier when a bypass ran can't slip
+    // past verifyEnvelope.
+    const signed = signEnvelope(
+      buildEnvelope({
+        findings: [],
+        tier: "full",
+        mode: "comment",
+        tierForced: true,
+        tierClassified: "trivial",
+        tierReasons: ["forced via --force-tier=full (classifier said trivial)"],
+        generatedAt: "2026-05-29T00:00:00Z",
+      }),
+      "k",
+    )
+    expect(verifyEnvelope(signed, "k")).toBe(true)
+    const strippedForce = { ...signed, tierForced: undefined, tierClassified: undefined, tierReasons: undefined }
+    expect(verifyEnvelope(strippedForce, "k")).toBe(false)
+  })
+
   test("tampering a NESTED finding field is detected (signature covers findings)", () => {
     const f = makeFinding({
       severity: "warning",

--- a/packages/opencode/test/altimate/review.test.ts
+++ b/packages/opencode/test/altimate/review.test.ts
@@ -366,6 +366,10 @@ describe("diff-filter", () => {
     expect(classifyDbtFile("models/marts/_marts.yml")).toBe("schema_yml")
     expect(classifyDbtFile("macros/x.sql")).toBe("macro")
     expect(classifyDbtFile("snapshots/s.sql")).toBe("snapshot")
+    // Snapshot YAML property files carry column/test declarations and route
+    // to the schema_yml detector, not the snapshot catalog rules.
+    expect(classifyDbtFile("snapshots/orders_snapshot.yml")).toBe("schema_yml")
+    expect(classifyDbtFile("snapshots/orders_snapshot.yaml")).toBe("schema_yml")
     expect(classifyDbtFile("seeds/c.csv")).toBe("seed")
     expect(classifyDbtFile("dbt_project.yml")).toBe("project_config")
     expect(classifyDbtFile("models/marts/m.py")).toBe("python_model")

--- a/packages/opencode/test/cli/tui/command.test.ts
+++ b/packages/opencode/test/cli/tui/command.test.ts
@@ -7,8 +7,11 @@ describe("tui command", () => {
   test("resolves network options through the config-aware resolver", async () => {
     const source = await tuiCommandSource()
 
-    expect(source).toContain('import { withNetworkOptions, resolveNetworkOptions } from "@/cli/network"')
-    expect(source).toContain('import { AppRuntime } from "@/effect/app-runtime"')
+    // Assertions use regex (not string literals) so Bun's transpiler doesn't
+    // statically resolve `@/cli/network` into `file:///…/network.ts` in the
+    // expected value — a CI-only cache quirk that inverts the comparison.
+    expect(source).toMatch(/import \{ withNetworkOptions, resolveNetworkOptions \} from "@\/cli\/network"/)
+    expect(source).toMatch(/import \{ AppRuntime \} from "@\/effect\/app-runtime"/)
     expect(source).toContain("await AppRuntime.runPromise(resolveNetworkOptions(args))")
     expect(source).not.toContain("resolveNetworkOptionsNoConfig(args)")
   })


### PR DESCRIPTION
## Summary

Improvements to `altimate-code review` covering two bug fixes and four observability / recall features that share the same code surface. Filed against `packages/opencode/src/{cli/cmd/review.ts, altimate/review/*.ts}`.

## Bug fixes

Both are reproducible against `main` and closed by this PR:

- **#1025** — bare `--no-ai <other-flag>` triggers the yargs help path and exits 0 without running the review. Fix: `.parserConfiguration({ "boolean-negation": false })` on the review command's yargs builder, so `--no-ai` binds to the declared `noAi` option as authored. `--no-ai=true` / `--no-ai=false` continue to work for programmatic parity.
- **#1026** — `detectSchemaYmlPatterns` compared removed and added test lines as raw trimmed strings, so a genuine removal from one column was silently cancelled by an unrelated re-add on a sibling column (yaml re-serialization emits the same `- unique` / `- not_null` lines for other columns still declaring those tests). Fix: `collectTestOccurrencesFromDiff` in `dbt-patterns.ts` walks the unified diff with model/column context via nearest preceding `- name: X` header (resets on hunk boundaries), keys removals by `(model, column, test)`, and only cancels on a same-tuple re-add. Emits one finding per removed `(model, column, test)` triple, with severity elevated to `warning` for `unique` removals and for `not_null` on id/key columns. Body text detects layer from file path (`marts?/reporting` → "mart-layer key", else "declared key") so the copy doesn't mislabel non-mart schema files.

## Feature enhancements bundled with the fixes

Four additions in the same code surface, small enough to review alongside the bug fixes rather than as their own PRs:

- **`--explain-tier`** — new boolean flag. When set, the verdict envelope carries `tierReasons: string[]` (the risk classifier's reasons for the tier decision) and the human-readable summary prints a `🧭 **Tier: X** — <reasons>` line. Read-only — doesn't change tier classification or verdicts. Envelope field is optional (absent when the flag is off), so existing verdicts remain byte-equivalent.

- **`--force-tier <trivial|lite|full>`** — new experimental flag for bench and debug work. Overrides the tier classifier with the supplied tier. Guardrails:
  - Prints an `⚠️  --force-tier=X is EXPERIMENTAL (bench / debug only). Classifier bypassed; verdict envelope will carry tierForced: true.` warning to stderr on every use.
  - Verdict envelope carries `tierForced: true` and `tierClassified: <original>` whenever the flag is passed, regardless of whether the forced value matches the classifier's decision. (An earlier iteration of this change guarded that flag on `input.forceTier !== classifiedTier`, which meant `--force-tier=full` on a naturally-`full` PR silently bypassed the audit envelope. Corrected in the same branch — every use of the flag is now recorded.)
  - Verdict headline renders as `<tier> tier — forced (was <classified>)`.
  - `tierReasons` is always populated when the flag is used, with a leading `forced via --force-tier=X (classifier said Y)` marker so downstream can't confuse the forced tier for a natural one.
  - Not a default-visible feature. Documented as EXPERIMENTAL in the yargs `describe`; the stderr banner ensures no one uses it in CI without noticing.

- **Manifest auto-discovery** — before, `--manifest <path>` had to be explicit; otherwise the CLI used the config-relative default `target/manifest.json`, which silently missed when `cwd` wasn't the dbt project root, degrading every such review to lint-only. Now:
  1. If `--manifest` isn't explicit AND the config-relative path doesn't exist, walk UP from `cwd` looking for `dbt_project.yml`. Use the adjacent `target/manifest.json` when it exists.
  2. Log discovery to stderr (`ℹ️  auto-discovered dbt manifest at ...`) so users see which manifest the review used.
  3. Never auto-discover a manifest from a directory without a dbt project — a `target/` from an unrelated tool never gets picked up.
  4. Freshness warning: when `--head` is set (CI shape) AND any changed file has an mtime newer than the manifest, print `⚠️  manifest ... appears stale` to stderr. Skipped for working-tree diffs (mtime noise during active edits would spam warnings).

  Explicit `--manifest <path>` always wins. Auto-discovery is only attempted when the caller was silent AND the config default is absent.

- **Verdict envelope** — three new optional fields added to `VerdictEnvelope` in `verdict.ts`, all included in the signed canonical body so tampering is detectable:
  - `tierReasons?: string[]` (from `--explain-tier`)
  - `tierForced?: boolean` (from `--force-tier`)
  - `tierClassified?: RiskTier` (from `--force-tier` — original tier before the override)

  All are optional and absent when the corresponding flag is off, so existing verdicts remain byte-equivalent to before.

## Testing

Verified locally on synthetic scenarios:

- Bare `--no-ai` now runs the review (verifies bug fix for #1025).
- `--no-ai=true` and `--no-ai=false` continue to work.
- `--explain-tier` populates `tierReasons` on both `trivial` and `full` verdicts.
- `--force-tier=full` on a naturally-`full` PR sets `tierForced: true` and `tierClassified: "full"` on the envelope + emits the stderr warning + the leading `forced via` reason. `--force-tier=lite` on a naturally-`full` PR overrides tier to `lite` and records `tierClassified: "full"`.
- Manifest auto-discovery: finds `target/manifest.json` when invoked from a subdirectory containing `dbt_project.yml` upward; declines to use a `target/manifest.json` from a directory that has no `dbt_project.yml` (verified against a plain non-dbt git repo).
- schema.yml test-removal: reproducer for #1026 (remove `unique`+`not_null` from one column while sibling columns still have them) now surfaces two `warning`-severity findings, one per removed `(column, test)` tuple. Layer-aware body renders "declared key" for a top-level `models/schema.yml` and "mart-layer key" for a `models/marts/schema.yml`.
- Envelope signature still round-trips through `verifyEnvelope` for both flag-on and flag-off shapes.

## Test plan

- [ ] Bare `--no-ai` runs the review (repro from #1025 no longer occurs)
- [ ] `--no-ai=true` / `--no-ai=false` behavior unchanged
- [ ] `--explain-tier` produces `tierReasons` in JSON output; envelope signature verifies
- [ ] `--force-tier` prints EXPERIMENTAL warning to stderr; envelope carries `tierForced: true` + `tierClassified: <original>` even when forced tier matches classifier
- [ ] Manifest auto-discovery finds `target/manifest.json` from subdir; explicit `--manifest` still wins; auto-discovery declines outside a dbt project
- [ ] Freshness warning fires when a changed file's mtime > manifest mtime AND `--head` is set; silent otherwise
- [ ] schema.yml test-removal reproducer for #1026 now emits per-`(column, test)` findings
- [ ] Existing verdicts (no new flags) are byte-equivalent to `main`

Closes #1025.
Closes #1026.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes bare `--no-ai` runs, hardens file reads against symlink escapes with a shared `safeReadInside` helper, upgrades schema.yml test‑removal to a structural YAML diff (incl. deleted/renamed files), auto‑discovers the dbt manifest, and makes subdir/monorepo invocations resolve compiled SQL and working‑tree files correctly. Closes #1025 and #1026.

- **Bug Fixes**
  - CLI: bare `--no-ai` now runs instead of falling into help.
  - Security: working‑tree and compiled‑SQL reads reject targets that realpath outside the repo/project (blocks tracked‑symlink escapes) and now share the centralized `safeReadInside` helper.
  - schema.yml: structural diff across models/sources/snapshots/seeds with `tests`/`data_tests`; handles deleted and renamed files; model‑level and column‑level attribution; per‑removal findings; elevated severity for `unique` and `not_null` on likely key columns; multiple `relationships` on one column are distinct; snapshot property files under `snapshots/*.yml` now route here; safe diff‑only fallback with per‑occurrence tags; emits the per‑file summary once with clearer “This schema file drops …” wording.
  - Tier display/audit: headline shows “forced (was X)” with an “unknown” fallback when `tierClassified` is missing; envelope schema enforces `tierForced` ↔ `tierClassified` consistency and rejects `tierForced: false`; backtick‑safe, capped tier reason rendering.
  - Stale‑manifest warning filters to dbt‑relevant paths and only treats `.md` under `models/` or `analyses/` as manifest‑affecting to avoid false positives.
  - Subdir/monorepo invocation: working‑tree reads root at the git repo top‑level; compiled SQL resolver uses the dbt project realpath and strips the repo→project path prefix (Windows‑ and symlink‑safe), so files like `packages/dbt/models/...` resolve under the discovered dbt project.

- **New Features**
  - `--explain-tier`: attaches `tierReasons[]` to the envelope and prints a capped tier line in the summary.
  - `--force-tier <trivial|lite|full>` (experimental): overrides the classifier with a stderr warning; envelope records `tierForced: true` and `tierClassified`; reasons start with a “forced via …” marker; headline shows “forced (was X)”.
  - Manifest auto‑discovery: when `--manifest` is omitted and the config default is missing, walks up to the nearest `dbt_project.yml` and uses its `target/manifest.json`; logs the chosen path; never picks a manifest outside a dbt project; warns if stale when `--head` is set; routes compiled SQL resolution and project name to the discovered project root. Explicit `--manifest` always wins.
  - Verdict envelope: adds optional `tierReasons`, `tierForced`, and `tierClassified` (all signed). Backwards compatible when flags aren’t used.

<sup>Written for commit 69553ed9ddc8980aac46006b9c8dfa0f6f420a2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/1027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--explain-tier` to include tier reasoning in the verdict and enrich the summary when reasons are available.
  - Added experimental `--force-tier` to override tier selection and record forced-tier auditing metadata.
  - Auto-discovers the nearest dbt manifest when not provided, and warns if it may be stale.

- **Bug Fixes**
  - Improved `schema.yml` guardrail removal detection with YAML-aware attribution (including `data_tests`), plus a safe diff-only fallback.
  - Fixed CLI boolean parsing for `--no-ai`.
  - Corrected snapshot classification under `snapshots/` (now handles non-`.sql` snapshot YAML files).

- **Tests**
  - Expanded coverage for tier rendering/forcing, schema-yml attribution, manifest staleness, and subdirectory invocation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[AI-7915]: https://altimateai.atlassian.net/browse/AI-7915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AI-7709]: https://altimateai.atlassian.net/browse/AI-7709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AI-7883]: https://altimateai.atlassian.net/browse/AI-7883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AI-7884]: https://altimateai.atlassian.net/browse/AI-7884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AI-7885]: https://altimateai.atlassian.net/browse/AI-7885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AI-7886]: https://altimateai.atlassian.net/browse/AI-7886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ