### PR TITLE
test(mcp): restore os.homedir spy after each test to prevent cross-file leak

### DIFF
--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -2,7 +2,7 @@ import path from "node:path"
 import { mkdtempSync } from "node:fs"
 import os, { tmpdir } from "node:os"
 import { pathToFileURL } from "node:url"
-import { expect, mock, beforeEach, spyOn } from "bun:test"
+import { expect, mock, beforeEach, afterEach, spyOn } from "bun:test"
 import { ListRootsRequestSchema, ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js"
 import { Cause, Effect, Exit } from "effect"
 import type { MCP as MCPNS } from "../../src/mcp/index"
@@ -255,6 +255,16 @@ beforeEach(() => {
   connectError = "Mock transport cannot connect"
   clientCreateCount = 0
   transportCloseCount = 0
+})
+
+// Restore all spies (including the `os.homedir` spy installed above) after
+// every test. Without this the spy persists past this file and pollutes any
+// downstream test in the same worker that calls `os.homedir()` — most
+// visibly the tilde/`$HOME`-expansion assertions in
+// `test/permission/next.test.ts`, which then see two different random
+// `mkdtempSync` paths within the same expect(). See issue #1042.
+afterEach(() => {
+  mock.restore()
 })
 
 // Import after mocks


### PR DESCRIPTION
### Issue for this PR

Closes #1042

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `beforeEach` in `packages/opencode/test/mcp/lifecycle.test.ts:250` installs `spyOn(os, "homedir").mockImplementation(...)` and returns a fresh `mkdtempSync(... "mcp-lifecycle-home-...")` on every call. There is no matching `afterEach` that restores the spy. When bun runs the full test suite, the spy persists past this file into any downstream file in the same worker process. The next test that calls `os.homedir()` gets a different random path per invocation — inside a single `expect().toEqual(...)` call, the value returned to the "actual" side and the value used to build the "expected" side can differ, and the assertion fails on paths that visibly contain the `mcp-lifecycle-home-` prefix from this file.

The most visible casualty is `test/permission/next.test.ts`, where 6 tilde / `$HOME`-expansion tests fail intermittently on CI:

```
error: expect(received).toEqual(expected)
[
  {
    "action": "allow",
-   "pattern": "/tmp/mcp-lifecycle-home-Zz7Y0f/projects/*",
+   "pattern": "/tmp/mcp-lifecycle-home-VvysFV/projects/*",
    "permission": "external_directory",
  }
]
```

The failure is file-order dependent — it passes in isolation and only surfaces when the full suite runs in the leaking order.

Fix: import `afterEach` from `bun:test` and add `afterEach(() => mock.restore())` right after the `beforeEach` block in `lifecycle.test.ts`. Blanket `mock.restore()` tears down the `os.homedir` spy (and any other spy installed during a test) between tests, so the mock cannot escape the file boundary. This matches the pattern already used elsewhere in the suite and keeps the fix a single import addition plus a 3-line hook.

### How did you verify your code works?

- `bun test test/mcp/lifecycle.test.ts` — 31 pass, 0 fail (fix's own file still green)
- `bun test test/permission/next.test.ts` — 80 pass, 0 fail (previously affected file green in isolation, same as before the fix)
- `bun test test/mcp/lifecycle.test.ts test/permission/next.test.ts` — 111 pass, 0 fail (both files together in one bun invocation — the shared-worker scenario that reproduced the leak)
- `bun run typecheck` — clean (exit 0)
- `bun run script/upstream/analyze.ts --markers --base origin/main --strict` — clean
- `bun run script/upstream/analyze.ts --branding` — 0 leaks

### Screenshots / recordings

_n/a — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flaky tests by restoring the os.homedir spy after each test in packages/opencode/test/mcp/lifecycle.test.ts. Adds afterEach(() => mock.restore()) from `bun:test` to stop cross-file leaks that broke tilde/$HOME expansion checks in test/permission/next.test.ts.

<sup>Written for commit fec5f6632a43b7a784653569e8871b76ef9c02d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/1043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by automatically restoring mocks after each test.
  * Prevented environment-related assertions from being affected by previous tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->