### PR TITLE
docs: document extension install-consent and auto-update settings

### DIFF
--- a/docs/docs/usage/ide.md
+++ b/docs/docs/usage/ide.md
@@ -45,6 +45,17 @@ This opens the Altimate Code chat panel where you can interact with altimate age
 
 The extension uses your existing `altimate-code.json` config. No additional IDE-specific configuration is required. Warehouse connections, LLM providers, permissions, and agent settings all carry over.
 
+### Extension settings
+
+The extension contributes these VS Code settings (Settings → search "altimate"):
+
+| Setting | Default | Description |
+|---|---|---|
+| `altimate.codeRequireConsent` | `false` | Ask before downloading and installing the altimate-code CLI. By default the extension installs the CLI automatically the first time chat opens. When enabled, chat shows an install prompt instead — nothing is downloaded until you confirm, and declining shows manual install instructions. |
+| `altimate.codeAutoUpdate` | `true` | Keep the CLI up to date automatically in the background. Checked at most once a day, and only runs when the CLI is already installed. |
+
+The extension installs the CLI natively: the release archive is fetched over HTTPS from [GitHub releases](https://github.com/AltimateAI/altimate-code/releases), verified against the release's `checksums.txt` (SHA-256), and placed in `~/.altimate/bin` — no shell scripts are executed and nothing outside your home directory is modified. Environments that prefer full control can enable `altimate.codeRequireConsent` via managed settings, or pre-install the CLI themselves (the extension uses any `altimate` found on `PATH` or in `~/.altimate/bin`).
+
 ## LLM Access
 
 You need an LLM to power the chat. Two options:


### PR DESCRIPTION
Documents the VS Code extension's install-related settings on the IDE page:

- **`altimate.codeRequireConsent`** (default `false`) — ask before downloading/installing the altimate-code CLI; declining shows manual install instructions. New setting shipping in AltimateAI/vscode-altimate-mcp-server#422.
- **`altimate.codeAutoUpdate`** (default `true`) — existing background auto-update setting, previously undocumented.

Also describes *how* the extension installs the CLI (HTTPS from GitHub releases, sha256-verified against `checksums.txt`, into `~/.altimate/bin`, no shell scripts) — the transparency detail security-conscious users ask about, and the pre-install/managed-settings escape hatches for controlled environments.

Note: this updates **docs.altimate.sh** (built from this repo). The help.altimate.ai copy of this page is maintained separately and gets the same section via an internal companion PR.

**Merge alongside** the extension release that ships #422 — the consent setting doesn't exist in published extensions yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SDUgAmfrsMTXpk7wDpbeu