### PR TITLE
feat: [AI-8138] /datamates picker + onboarding banner

### DIFF
--- a/packages/opencode/src/altimate/datamate-config.ts
+++ b/packages/opencode/src/altimate/datamate-config.ts
@@ -56,12 +56,16 @@ export async function readWiredDatamates(projectRootDir: string): Promise<WiredD
   for (const configPath of configPaths) {
     for (const name of await listMcpInConfig(configPath)) {
       if (name !== DATAMATE_KEY && !name.startsWith("datamate-")) continue
+      const entry = await readMcpEntryFromDisk(name, configPath)
+      // A disabled entry is not wired — a stale `datamate` key with `enabled: false` must not
+      // flip the dialog into gateway mode or claim an active datamate.
+      if (entry && typeof entry === "object" && (entry as { enabled?: unknown }).enabled === false) continue
       if (!serverNames.includes(name)) serverNames.push(name)
       if (name === DATAMATE_KEY) {
         gateway = true
         continue
       }
-      const id = datamateIdFromEntry(await readMcpEntryFromDisk(name, configPath))
+      const id = datamateIdFromEntry(entry)
       if (id) ids.add(id)
     }
   }

--- a/packages/opencode/src/altimate/datamate-config.ts
+++ b/packages/opencode/src/altimate/datamate-config.ts
@@ -1,0 +1,70 @@
+// Config-level reads for datamate MCP entries.
+//
+// Deliberately free of `MCP` and `Instance` imports so this module is safe to load from the TUI
+// main thread as well as the server: the TUI runs the plugin host in-process while the server
+// lives in a Worker (cli/cmd/tui.ts), so TUI-side code has no Effect/Instance runtime and must
+// not pull one in. Live wiring (MCP.add/connect) lives in ./datamate-connect.ts, server-only.
+import { Global } from "../global"
+import { findAllConfigPaths, listMcpInConfig, readMcpEntryFromDisk } from "../mcp/config"
+import { DATAMATE_KEY } from "./datamate-transport"
+
+/** Standalone-mode MCP server names are `datamate-<slug>`; the shared gateway is DATAMATE_KEY. */
+export function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+}
+
+export type WiredDatamates = {
+  /**
+   * Datamate ids that are identifiable from config. Only the standalone/cloud transport records
+   * one (as the `x-datamate-id` header), so this is empty in gateway mode.
+   */
+  ids: Set<string>
+  /** Datamate MCP server names found in config, across project and global files. */
+  serverNames: string[]
+  /**
+   * True when the shared `datamate` gateway server is wired. The gateway serves every datamate
+   * through one connection, so no single datamate id can be recovered from it.
+   */
+  gateway: boolean
+}
+
+/** The `x-datamate-id` header AltimateApi.buildMcpConfig writes on the cloud transport. */
+function datamateIdFromEntry(entry: unknown): string | undefined {
+  if (!entry || typeof entry !== "object") return undefined
+  const headers = (entry as { headers?: unknown }).headers
+  if (!headers || typeof headers !== "object") return undefined
+  const id = (headers as Record<string, unknown>)["x-datamate-id"]
+  return typeof id === "string" && id.length > 0 ? id : undefined
+}
+
+/**
+ * Read which datamates are wired as MCP servers, from the project and global config files.
+ *
+ * Reads config only — it does not glob for IDE `mcp.json` files (readDatamateTransportFromIde
+ * scans the whole worktree) and does not consult live MCP status, so it is cheap enough to call
+ * on every dialog open.
+ */
+export async function readWiredDatamates(projectRootDir: string): Promise<WiredDatamates> {
+  const ids = new Set<string>()
+  const serverNames: string[] = []
+  let gateway = false
+
+  const configPaths = await findAllConfigPaths(projectRootDir, Global.Path.config)
+  for (const configPath of configPaths) {
+    for (const name of await listMcpInConfig(configPath)) {
+      if (name !== DATAMATE_KEY && !name.startsWith("datamate-")) continue
+      if (!serverNames.includes(name)) serverNames.push(name)
+      if (name === DATAMATE_KEY) {
+        gateway = true
+        continue
+      }
+      const id = datamateIdFromEntry(await readMcpEntryFromDisk(name, configPath))
+      if (id) ids.add(id)
+    }
+  }
+
+  return { ids, serverNames, gateway }
+}

--- a/packages/opencode/src/altimate/datamate-connect.ts
+++ b/packages/opencode/src/altimate/datamate-connect.ts
@@ -1,0 +1,162 @@
+// Wiring a datamate up as a live MCP server.
+//
+// Extracted from the `datamate_manager` tool's 'add' operation so the tool and the /datamates
+// picker share one implementation. Server-only: it touches Instance and the live MCP registry, so
+// it must not be imported from TUI-side plugin code (see ./datamate-config.ts for the reads that
+// are safe there). The picker reaches this through POST /altimate/datamate/connect.
+import { AltimateApi } from "./api/client"
+import { MCP } from "../mcp"
+import { addMcpToConfig, listMcpInConfig, resolveConfigPath } from "../mcp/config"
+import { Instance } from "../project/instance"
+import { Global } from "../global"
+import { Log } from "@/altimate/util/log"
+import { DATAMATE_KEY, readDatamateTransportFromIde } from "./datamate-transport"
+import { slugify } from "./datamate-config"
+
+const log = Log.create({ service: "datamate" })
+
+/** Project root for config resolution — falls back to cwd when no git repo is detected. */
+export function projectRoot() {
+  const wt = Instance.worktree
+  return wt === "/" ? Instance.directory : wt
+}
+
+type McpServerStatus = Awaited<ReturnType<typeof MCP.status>>[string]
+
+export type DatamateConnectResult = {
+  /**
+   * `already-connected` — the server was in config and live, nothing changed.
+   * `connected` — wired and the connection came up.
+   * `pending` — written to config but the connection has not come up yet.
+   */
+  status: "already-connected" | "connected" | "pending"
+  datamateId: string
+  datamateName: string
+  /** MCP server name the datamate is wired under — DATAMATE_KEY in gateway mode. */
+  serverName: string
+  /** True when an IDE/extension datamate entry supplied the transport. */
+  gateway: boolean
+  /** Tools the server exposes; 0 unless the connection is up. */
+  toolCount: number
+  /** Config file the entry lives in. */
+  configPath: string
+  /** Live MCP status, carried for the `pending` case so callers can explain the stall. */
+  mcpStatus?: McpServerStatus
+  /** Per-datamate entries left over alongside the gateway — worth cleaning up. */
+  staleEntries: string[]
+}
+
+/**
+ * Wire a datamate as an MCP server: resolve its transport, persist the config entry, and connect.
+ *
+ * When an IDE MCP config has a "datamate" entry (written by VS Code, Cursor, etc.) the server name
+ * is always DATAMATE_KEY regardless of which datamate was chosen — the extension's gateway already
+ * serves every datamate's tools over one connection, and a per-datamate entry would duplicate the
+ * whole tool set. `name` is honored only in standalone mode.
+ *
+ * Throws on any API/config failure; callers format the error for their surface.
+ */
+export async function connectDatamate(input: {
+  datamateId: string
+  name?: string
+  scope?: "project" | "global"
+}): Promise<DatamateConnectResult> {
+  const datamate = await AltimateApi.getDatamate(input.datamateId)
+  // readDatamateTransportFromIde returns the exact command from the IDE config so we
+  // reuse the same process the extension already manages, not a second one.
+  const transport = await readDatamateTransportFromIde(projectRoot())
+
+  if (transport !== null) {
+    log.info("connectDatamate: IDE transport detected, entering single-gateway mode", {
+      serverName: DATAMATE_KEY,
+      transportType: transport.type,
+    })
+  } else {
+    log.info("connectDatamate: no IDE transport found, using standalone cloud config")
+  }
+
+  const serverName = transport !== null ? DATAMATE_KEY : (input.name ?? `datamate-${slugify(datamate.name)}`)
+
+  const creds = transport ? undefined : await AltimateApi.getCredentials()
+  const mcpConfig =
+    transport?.type === "remote"
+      ? { type: "remote" as const, url: transport.url }
+      : transport?.type === "local"
+        ? // Use the exact command from the IDE config so we reuse the process the
+          // extension manages rather than spawning a second one. The extension and
+          // altimate-code would otherwise maintain two separate stdio child processes
+          // connected to the same datamate binary, wasting resources.
+          { type: "local" as const, command: transport.command }
+        : AltimateApi.buildMcpConfig(creds!, input.datamateId)
+
+  const isGlobal = input.scope === "global"
+  const configPath = await resolveConfigPath(isGlobal ? Global.Path.config : projectRoot(), isGlobal)
+
+  const base = {
+    datamateId: input.datamateId,
+    datamateName: datamate.name,
+    serverName,
+    gateway: transport !== null,
+    configPath,
+  }
+
+  let staleEntries: string[] = []
+
+  if (transport !== null) {
+    const existingNames = await listMcpInConfig(configPath)
+    staleEntries = existingNames.filter((n) => n !== DATAMATE_KEY && n.startsWith("datamate-"))
+    if (staleEntries.length > 0) {
+      log.info("connectDatamate: stale per-datamate entries detected alongside extension gateway", {
+        staleEntries,
+      })
+    }
+
+    if (existingNames.includes(DATAMATE_KEY)) {
+      const allStatus = await MCP.status()
+      if (allStatus[DATAMATE_KEY]?.status === "connected") {
+        log.info("connectDatamate: already connected, skipping add", { serverName: DATAMATE_KEY })
+        return {
+          ...base,
+          status: "already-connected",
+          toolCount: await countTools(DATAMATE_KEY + "_"),
+          staleEntries,
+        }
+      }
+      // In config but not connected — reconnect via MCP.connect() so persistMcpEnabled
+      // is called and the enabled:true state survives the next session restart.
+      // MCP.add() skips persistMcpEnabled, so a session that had the server disabled
+      // would not re-enable it on the next restart.
+      log.info("connectDatamate: reconnecting existing datamate entry", { serverName: DATAMATE_KEY })
+      await MCP.connect(DATAMATE_KEY)
+    } else {
+      log.info("connectDatamate: adding new datamate entry", { serverName: DATAMATE_KEY, type: mcpConfig.type })
+      await addMcpToConfig(DATAMATE_KEY, { ...mcpConfig, enabled: true }, configPath)
+      await MCP.add(DATAMATE_KEY, mcpConfig)
+    }
+  } else {
+    log.info("connectDatamate: standalone mode, adding per-datamate entry", {
+      serverName,
+      type: mcpConfig.type,
+    })
+    await addMcpToConfig(serverName, { ...mcpConfig, enabled: true }, configPath)
+    await MCP.add(serverName, mcpConfig)
+  }
+
+  const allStatus = await MCP.status()
+  const mcpStatus = allStatus[serverName]
+  if (mcpStatus?.status !== "connected") {
+    return { ...base, status: "pending", toolCount: 0, mcpStatus, staleEntries }
+  }
+
+  return {
+    ...base,
+    status: "connected",
+    toolCount: await countTools(serverName.replace(/[^a-zA-Z0-9_-]/g, "_")),
+    staleEntries,
+  }
+}
+
+async function countTools(prefix: string): Promise<number> {
+  const mcpTools = await MCP.tools()
+  return Object.keys(mcpTools).filter((k) => k.startsWith(prefix)).length
+}

--- a/packages/opencode/src/altimate/tools/datamate.ts
+++ b/packages/opencode/src/altimate/tools/datamate.ts
@@ -2,37 +2,13 @@ import z from "zod"
 import { Tool } from "../../tool/tool"
 import { AltimateApi } from "../api/client"
 import { MCP } from "../../mcp"
-import {
-  addMcpToConfig,
-  removeMcpFromConfig,
-  listMcpInConfig,
-  resolveConfigPath,
-  findAllConfigPaths,
-} from "../../mcp/config"
-import { Instance } from "../../project/instance"
+import { removeMcpFromConfig, listMcpInConfig, resolveConfigPath, findAllConfigPaths } from "../../mcp/config"
 import { Global } from "../../global"
-import { Log } from "@/altimate/util/log"
-import { DATAMATE_KEY, readDatamateTransportFromIde } from "../datamate-transport"
+import { DATAMATE_KEY } from "../datamate-transport"
+import { connectDatamate, projectRoot } from "../datamate-connect"
+import { slugify } from "../datamate-config"
 
-const log = Log.create({ service: "datamate" })
-
-/** Project root for config resolution — falls back to cwd when no git repo is detected. */
-function projectRoot() {
-  const wt = Instance.worktree
-  return wt === "/" ? Instance.directory : wt
-}
-
-export function slugify(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "")
-}
-
-// Scans .vscode/mcp.json, .cursor/mcp.json, .github/copilot/mcp.json in projectRootDir
-// so this works in Cursor, Copilot, and other IDEs that write their own MCP config file.
-// Returns the exact command from the IDE config so altimate-code reuses the same process
-// the extension already manages rather than spawning a second one.
+export { slugify }
 
 export const DatamateManagerTool = Tool.define("datamate_manager", {
   description:
@@ -165,8 +141,8 @@ async function handleListIntegrations() {
   }
 }
 
-// DATAMATE_KEY is imported from altimate/datamate-transport.ts (shared constant).
-
+// The wiring itself lives in altimate/datamate-connect.ts so the /datamates picker takes the exact
+// same steps; this handler only renders the outcome as tool output.
 async function handleAdd(args: { datamate_id?: string; name?: string; scope?: "project" | "global" }) {
   if (!args.datamate_id) {
     return {
@@ -176,129 +152,38 @@ async function handleAdd(args: { datamate_id?: string; name?: string; scope?: "p
     }
   }
   try {
-    const datamate = await AltimateApi.getDatamate(args.datamate_id)
-    // readDatamateTransportFromIde returns the exact command from the IDE config so we
-    // reuse the same process the extension already manages, not a second one.
-    const transport = await readDatamateTransportFromIde(projectRoot())
+    const result = await connectDatamate({
+      datamateId: args.datamate_id,
+      name: args.name,
+      scope: args.scope,
+    })
+    const { datamateName, serverName, toolCount, configPath } = result
 
-    if (transport !== null) {
-      log.info("handleAdd: IDE transport detected, entering single-gateway mode", {
-        serverName: DATAMATE_KEY,
-        transportType: transport.type,
-      })
-    } else {
-      log.info("handleAdd: no IDE transport found, using standalone cloud config")
-    }
-
-    // If an IDE MCP config has a "datamate" entry (written by VS Code, Cursor, etc.),
-    // always use DATAMATE_KEY ("datamate") as the server name regardless
-    // of which specific datamate the user selected. This prevents duplicate tool sets
-    // — the extension's gateway already serves all datamate tools through a single
-    // MCP connection.
-    // In standalone/CLI mode (no IDE datamate entry), fall back to per-datamate naming
-    // with cloud URL.
-    const serverName = transport !== null
-      ? DATAMATE_KEY
-      : (args.name ?? `datamate-${slugify(datamate.name)}`)
-
-    const creds = transport ? undefined : await AltimateApi.getCredentials()
-    const mcpConfig =
-      transport?.type === "remote"
-        ? { type: "remote" as const, url: transport.url }
-        : transport?.type === "local"
-          // Use the exact command from the IDE config so we reuse the process the
-          // extension manages rather than spawning a second one. The extension and
-          // altimate-code would otherwise maintain two separate stdio child processes
-          // connected to the same datamate binary, wasting resources.
-          ? { type: "local" as const, command: transport.command }
-          : AltimateApi.buildMcpConfig(creds!, args.datamate_id)
-
-    const isGlobal = args.scope === "global"
-    const configPath = await resolveConfigPath(isGlobal ? Global.Path.config : projectRoot(), isGlobal)
-
-    if (transport !== null) {
-      // IDE/extension mode: check if DATAMATE_KEY is already wired up
-      const existingNames = await listMcpInConfig(configPath)
-      const staleEntries = existingNames.filter(
-        (n) => n !== DATAMATE_KEY && n.startsWith("datamate-"),
-      )
-      if (staleEntries.length > 0) {
-        log.info("handleAdd: stale per-datamate entries detected alongside extension gateway", {
-          staleEntries,
-        })
-      }
-
-      if (existingNames.includes(DATAMATE_KEY)) {
-        // Already in config — just ensure it is connected in this session
-        const allStatus = await MCP.status()
-        if (allStatus[DATAMATE_KEY]?.status === "connected") {
-          log.info("handleAdd: already connected, skipping add", {
-            serverName: DATAMATE_KEY,
-          })
-          const mcpTools = await MCP.tools()
-          const toolCount = Object.keys(mcpTools).filter((k) =>
-            k.startsWith(DATAMATE_KEY + "_"),
-          ).length
-          const staleNote =
-            staleEntries.length > 0
-              ? `\n\nNote: stale per-datamate entries found in config: ${staleEntries.join(", ")} — use operation 'remove' to clean them up.`
-              : ""
-          return {
-            title: `Datamate '${datamate.name}': already connected via '${DATAMATE_KEY}'`,
-            metadata: { serverName: DATAMATE_KEY, datamateId: args.datamate_id, toolCount },
-            output: `Datamate tools are already available via the '${DATAMATE_KEY}' MCP server (${toolCount} tools active).${staleNote}`,
-          }
-        }
-        // In config but not connected — reconnect via MCP.connect() so persistMcpEnabled
-        // is called and the enabled:true state survives the next session restart.
-        // Bug-fix: was previously MCP.add() which skips persistMcpEnabled, so a session
-        // that had the server disabled would not re-enable it on the next restart.
-        log.info("handleAdd: reconnecting existing datamate entry", {
-          serverName: DATAMATE_KEY,
-        })
-        await MCP.connect(DATAMATE_KEY)
-      } else {
-        // Not in config yet — write to disk then connect
-        log.info("handleAdd: adding new datamate entry", {
-          serverName: DATAMATE_KEY,
-          type: mcpConfig.type,
-        })
-        await addMcpToConfig(DATAMATE_KEY, { ...mcpConfig, enabled: true }, configPath)
-        await MCP.add(DATAMATE_KEY, mcpConfig)
-      }
-    } else {
-      // Standalone/CLI mode — original behaviour: per-datamate name + cloud URL
-      log.info("handleAdd: standalone mode, adding per-datamate entry", {
-        serverName,
-        type: mcpConfig.type,
-      })
-      await addMcpToConfig(serverName, { ...mcpConfig, enabled: true }, configPath)
-      await MCP.add(serverName, mcpConfig)
-    }
-
-    // Check connection status
-    const allStatus = await MCP.status()
-    const serverStatus = allStatus[serverName]
-    const connected = serverStatus?.status === "connected"
-
-    if (!connected) {
+    if (result.status === "already-connected") {
+      const staleNote =
+        result.staleEntries.length > 0
+          ? `\n\nNote: stale per-datamate entries found in config: ${result.staleEntries.join(", ")} — use operation 'remove' to clean them up.`
+          : ""
       return {
-        title: `Datamate '${datamate.name}': saved (connection pending)`,
-        metadata: { serverName, datamateId: args.datamate_id, configPath, status: serverStatus },
-        output: `Saved datamate '${datamate.name}' (ID: ${args.datamate_id}) as MCP server '${serverName}' to ${configPath}.\n\nConnection status: ${serverStatus?.status ?? "unknown"}${serverStatus && "error" in serverStatus ? ` — ${serverStatus.error}` : ""}.\nIt will auto-connect on next session start.`,
+        title: `Datamate '${datamateName}': already connected via '${DATAMATE_KEY}'`,
+        metadata: { serverName: DATAMATE_KEY, datamateId: args.datamate_id, toolCount },
+        output: `Datamate tools are already available via the '${DATAMATE_KEY}' MCP server (${toolCount} tools active).${staleNote}`,
       }
     }
 
-    // Get tool count from the newly connected server
-    const mcpTools = await MCP.tools()
-    const toolCount = Object.keys(mcpTools).filter((k) =>
-      k.startsWith(serverName.replace(/[^a-zA-Z0-9_-]/g, "_")),
-    ).length
+    if (result.status === "pending") {
+      const status = result.mcpStatus
+      return {
+        title: `Datamate '${datamateName}': saved (connection pending)`,
+        metadata: { serverName, datamateId: args.datamate_id, configPath, status },
+        output: `Saved datamate '${datamateName}' (ID: ${args.datamate_id}) as MCP server '${serverName}' to ${configPath}.\n\nConnection status: ${status?.status ?? "unknown"}${status && "error" in status ? ` — ${status.error}` : ""}.\nIt will auto-connect on next session start.`,
+      }
+    }
 
     return {
-      title: `Datamate '${datamate.name}': connected as '${serverName}'`,
+      title: `Datamate '${datamateName}': connected as '${serverName}'`,
       metadata: { serverName, datamateId: args.datamate_id, toolCount, configPath },
-      output: `Connected datamate '${datamate.name}' (ID: ${args.datamate_id}) as MCP server '${serverName}'.\n\n${toolCount} tools are now available. They will be usable in the next message.\n\nConfiguration saved to ${configPath} for future sessions.`,
+      output: `Connected datamate '${datamateName}' (ID: ${args.datamate_id}) as MCP server '${serverName}'.\n\n${toolCount} tools are now available. They will be usable in the next message.\n\nConfiguration saved to ${configPath} for future sessions.`,
     }
   } catch (e) {
     return {

--- a/packages/opencode/src/plugin/tui/altimate/datamates.tsx
+++ b/packages/opencode/src/plugin/tui/altimate/datamates.tsx
@@ -182,64 +182,76 @@ function buildOptions(wired: WiredDatamates, datamates: Datamate[]): TuiDialogSe
   })
 }
 
+// Sentinel value for informational rows (loading / no credentials / error / empty). Selecting
+// them is a no-op. Same device as skill-ops' synthetic install row.
+const STATUS_ROW = "__datamate_status__"
+
 function DialogDatamateList(props: { api: TuiPluginApi }) {
   const { api } = props
   const [state] = createResource(() => loadState(api))
 
+  // One DialogSelect for every state. Swapping the top-level dialog component (e.g. a
+  // DialogAlert fallback while loading) re-mounts this factory, which re-creates the
+  // resource and refetches in a loop — so status states render as rows, not alerts.
+  const options = createMemo<TuiDialogSelectOption<string>[]>(() => {
+    const current = state()
+    if (!current) return [{ title: "Loading datamates...", value: STATUS_ROW }]
+    if (current.kind === "unconfigured")
+      return [
+        {
+          title: "Altimate credentials not found",
+          description: "Run /connect and pick the Altimate provider, then reopen /datamates.",
+          value: STATUS_ROW,
+        },
+      ]
+    if (current.kind === "error")
+      return [
+        {
+          title: "Failed to load datamates",
+          description: current.message.slice(0, 80),
+          value: STATUS_ROW,
+        },
+      ]
+    if (current.datamates.length === 0)
+      return [
+        {
+          title: "No datamates in this workspace yet",
+          description: "Create one in the Altimate console, then reopen /datamates.",
+          value: STATUS_ROW,
+        },
+      ]
+    return buildOptions(current.wired, current.datamates)
+  })
+
+  const title = createMemo(() => {
+    const current = state()
+    // With the gateway there is no single active datamate, so the title carries the explanation.
+    return current?.kind === "ready" && current.wired.gateway ? "Datamates (via extension gateway)" : "Datamates"
+  })
+
+  // Standalone mode points the cursor at the wired datamate; gateway mode leaves it unset.
+  const activeId = createMemo(() => {
+    const current = state()
+    if (current?.kind !== "ready" || current.wired.gateway) return undefined
+    return [...current.wired.ids][0]
+  })
+
   return (
-    <Show when={state()} fallback={<api.ui.DialogAlert title="Datamates" message="Loading datamates..." />}>
-      {(resolved) => {
-        const current = resolved()
-        if (current.kind === "unconfigured") {
-          return (
-            <api.ui.DialogAlert
-              title="Datamates"
-              message={
-                "Altimate credentials not found.\n\n" +
-                "Run /connect and pick the Altimate provider to add your instance name and API key, " +
-                "then reopen /datamates."
-              }
-            />
-          )
-        }
-        if (current.kind === "error") {
-          return (
-            <api.ui.DialogAlert
-              title="Datamates"
-              message={`Failed to load datamates: ${current.message.slice(0, 300)}`}
-            />
-          )
-        }
-        if (current.datamates.length === 0) {
-          return (
-            <api.ui.DialogAlert
-              title="Datamates"
-              message={
-                "No datamates in this workspace yet.\n\n" +
-                "Create one in the Altimate console (or ask the agent to), then reopen /datamates."
-              }
-            />
-          )
-        }
-        // With the gateway there is no single active datamate, so leave `current` unset and let the
-        // title carry the explanation; standalone mode can point the cursor at the wired one.
-        const activeId = current.wired.gateway ? undefined : [...current.wired.ids][0]
-        return (
-          <api.ui.DialogSelect
-            title={current.wired.gateway ? "Datamates (via extension gateway)" : "Datamates"}
-            placeholder="Search datamates..."
-            options={buildOptions(current.wired, current.datamates)}
-            current={activeId}
-            onSelect={(item) => {
-              const datamate = current.datamates.find((d) => d.id === item.value)
-              if (!datamate) return
-              api.ui.dialog.clear()
-              void wireDatamate(api, datamate)
-            }}
-          />
-        )
+    <api.ui.DialogSelect
+      title={title()}
+      placeholder="Search datamates..."
+      options={options()}
+      current={activeId()}
+      onSelect={(item) => {
+        if (item.value === STATUS_ROW) return
+        const current = state()
+        if (current?.kind !== "ready") return
+        const datamate = current.datamates.find((d) => d.id === item.value)
+        if (!datamate) return
+        api.ui.dialog.clear()
+        void wireDatamate(api, datamate)
       }}
-    </Show>
+    />
   )
 }
 
@@ -321,10 +333,17 @@ const tui: TuiPlugin = async (api) => {
     slots: {
       home_bottom() {
         const dismissed = createMemo(() => api.kv.get(BANNER_KV_KEY, false))
-        // Once a datamate MCP server exists there is nothing left to promote. Read live MCP status
-        // rather than the config so the banner also stays hidden for gateway-supplied servers.
+        // Once a datamate MCP server is connected there is nothing left to promote. Read live MCP
+        // status rather than the config so the banner also stays hidden for gateway-supplied
+        // servers — but only a *connected* server counts: a stale failed `datamate` entry is
+        // exactly the situation the picker fixes, so it must not suppress the promo.
         const connected = createMemo(() =>
-          api.state.mcp().some((item) => item.name === DATAMATE_KEY || item.name.startsWith("datamate-")),
+          api.state
+            .mcp()
+            .some(
+              (item) =>
+                (item.name === DATAMATE_KEY || item.name.startsWith("datamate-")) && item.status === "connected",
+            ),
         )
         const show = createMemo(() => api.state.ready && !dismissed() && !connected())
         return (

--- a/packages/opencode/src/plugin/tui/altimate/datamates.tsx
+++ b/packages/opencode/src/plugin/tui/altimate/datamates.tsx
@@ -1,0 +1,346 @@
+// altimate_change start — fork TUI feature: browse the tenant's datamates and wire one up.
+//
+// Human-facing counterpart to the `datamate_manager` LLM tool. Read-only over the API — it lists
+// datamates and connects the selected one; create/edit/delete stay with the tool and the console.
+//
+// This is an opencode-side, fork-owned plugin per
+// docs/internal/2026-06-23-tui-fork-features-as-plugins-adr.md: it imports opencode-package code
+// (AltimateApi, the datamate config readers) directly and renders through the TuiPluginApi so
+// upstream packages/tui stays untouched.
+//
+// The connect step does NOT happen here. Wiring a datamate mutates the live MCP registry, which
+// only exists in the server — the TUI runs the plugin host in its main thread and talks to a Worker
+// server over RPC (cli/cmd/tui.ts). So selection POSTs to the fork endpoint
+// /altimate/datamate/connect, which calls the same `connectDatamate` the tool's 'add' operation
+// uses. Everything this file does itself (list, read config) is pure API/fs work, safe in-process.
+//
+// Surfaces:
+//   - `altimate.datamate.list` palette command / `/datamates` — the picker.
+//   - a dismissable home_bottom banner pointing at /datamates, hidden once a datamate is wired.
+import type { TuiPlugin, TuiPluginApi, TuiDialogSelectOption } from "@opencode-ai/plugin/tui"
+import type { BuiltinTuiPlugin } from "@opencode-ai/tui/builtins"
+import { createMemo, createResource, Show } from "solid-js"
+import { AltimateApi } from "@/altimate/api/client"
+import { readWiredDatamates, slugify, type WiredDatamates } from "@/altimate/datamate-config"
+import { DATAMATE_KEY } from "@/altimate/datamate-transport"
+
+const id = "altimate:datamates"
+
+/** KV key for the home banner, following the `dismissed_getting_started` naming. */
+const BANNER_KV_KEY = "dismissed_datamates_banner"
+
+type Datamate = Awaited<ReturnType<typeof AltimateApi.listDatamates>>[number]
+
+type ListState =
+  | { kind: "unconfigured" }
+  | { kind: "error"; message: string }
+  | { kind: "ready"; datamates: Datamate[]; wired: WiredDatamates }
+
+/** Mirrors the server's datamate projectRoot(): worktree unless it degenerated to "/". */
+function projectRootDir(api: TuiPluginApi): string {
+  const worktree = api.state.path.worktree
+  if (!worktree || worktree === "/") return api.state.path.directory || process.cwd()
+  return worktree
+}
+
+async function loadState(api: TuiPluginApi): Promise<ListState> {
+  if (!(await AltimateApi.isConfigured())) return { kind: "unconfigured" }
+  try {
+    const [datamates, wired] = await Promise.all([AltimateApi.listDatamates(), readWiredDatamates(projectRootDir(api))])
+    return { kind: "ready", datamates, wired }
+  } catch (err) {
+    return { kind: "error", message: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+// ── Connect (server round-trip) ─────────────────────────────────────────────────────────────────
+
+type RawSdkClient = {
+  post(options: {
+    url: string
+    body?: unknown
+    headers?: Record<string, string>
+  }): Promise<{ data?: unknown; error?: unknown }>
+}
+
+// Guard against a second Enter landing while a connect is in flight.
+let wiring = false
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+/** Render the connect outcome as a toast. Shapes match DatamateConnectResult. */
+function toastResult(api: TuiPluginApi, datamateName: string, result: Record<string, unknown>) {
+  const serverName = asString(result["serverName"]) ?? DATAMATE_KEY
+  const toolCount = typeof result["toolCount"] === "number" ? result["toolCount"] : 0
+  const stale = Array.isArray(result["staleEntries"]) ? result["staleEntries"].filter(asString) : []
+  const staleNote =
+    stale.length > 0 ? `\n\nStale per-datamate config entries: ${stale.join(", ")} — ask the agent to remove them.` : ""
+
+  switch (result["status"]) {
+    case "already-connected":
+      api.ui.toast({
+        message: `'${datamateName}' is already connected via '${serverName}' (${toolCount} tools active).${staleNote}`,
+        variant: "info",
+        duration: 6000,
+      })
+      return
+    case "connected":
+      api.ui.toast({
+        message: `Connected '${datamateName}' as '${serverName}'.\n\n${toolCount} tools are now available — they are usable in the next message.${staleNote}`,
+        variant: "success",
+        duration: 8000,
+      })
+      return
+    case "pending": {
+      const status = asString(asRecord(result["mcpStatus"])?.["status"]) ?? "unknown"
+      api.ui.toast({
+        message: `Saved '${datamateName}' as '${serverName}', but the connection is ${status}.\n\nIt will auto-connect on the next session start.`,
+        variant: "warning",
+        duration: 8000,
+      })
+      return
+    }
+    default:
+      api.ui.toast({
+        message: `Wired '${datamateName}' as '${serverName}', but the server returned an unexpected status.`,
+        variant: "warning",
+        duration: 6000,
+      })
+  }
+}
+
+async function wireDatamate(api: TuiPluginApi, datamate: Datamate): Promise<void> {
+  if (wiring) return
+  wiring = true
+  api.ui.toast({ message: `Connecting '${datamate.name}'...`, variant: "info", duration: 600000 })
+  try {
+    const raw = (api.client as unknown as { client?: RawSdkClient }).client
+    if (!raw) {
+      api.ui.toast({ message: "Cannot reach the altimate-code server.", variant: "error", duration: 6000 })
+      return
+    }
+    const response = await raw.post({
+      url: "/altimate/datamate/connect",
+      body: { datamate_id: datamate.id },
+      headers: { "Content-Type": "application/json" },
+    })
+    const data = asRecord(response.data)
+    const result = asRecord(data?.["result"])
+    if (data?.["ok"] !== true || !result) {
+      const message = asString(data?.["error"]) ?? "the server rejected the request"
+      api.ui.toast({
+        message: `Failed to connect '${datamate.name}': ${message.slice(0, 200)}`,
+        variant: "error",
+        duration: 8000,
+      })
+      return
+    }
+    toastResult(api, datamate.name, result)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    api.ui.toast({
+      message: `Failed to connect '${datamate.name}': ${message.slice(0, 200)}`,
+      variant: "error",
+      duration: 8000,
+    })
+  } finally {
+    wiring = false
+  }
+}
+
+// ── Picker ──────────────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Whether this datamate is currently served.
+ *
+ * Two shapes, both derived from the MCP config (see readWiredDatamates):
+ *   - standalone/cloud — the entry carries `x-datamate-id`, so the exact datamate is known.
+ *   - IDE gateway — a single `datamate` server serves EVERY datamate through one connection, so
+ *     there is no per-datamate id to match and all of them are active. The dialog title says so.
+ */
+function isActive(wired: WiredDatamates, datamate: Datamate): boolean {
+  return wired.gateway || wired.ids.has(datamate.id) || wired.serverNames.includes(`datamate-${slugify(datamate.name)}`)
+}
+
+function buildOptions(wired: WiredDatamates, datamates: Datamate[]): TuiDialogSelectOption<string>[] {
+  const maxWidth = Math.max(0, ...datamates.map((d) => d.name.length))
+  return datamates.map((datamate) => {
+    const description = datamate.description?.replace(/\s+/g, " ").trim()
+    const integrations = datamate.integrations?.map((i) => i.id) ?? []
+    return {
+      title: `${isActive(wired, datamate) ? "✓" : " "} ${datamate.name.padEnd(maxWidth)}`,
+      description: description && description.length > 80 ? description.slice(0, 77) + "..." : description,
+      footer: integrations.length > 0 ? integrations.join(", ") : "no integrations",
+      value: datamate.id,
+    } satisfies TuiDialogSelectOption<string>
+  })
+}
+
+function DialogDatamateList(props: { api: TuiPluginApi }) {
+  const { api } = props
+  const [state] = createResource(() => loadState(api))
+
+  return (
+    <Show when={state()} fallback={<api.ui.DialogAlert title="Datamates" message="Loading datamates..." />}>
+      {(resolved) => {
+        const current = resolved()
+        if (current.kind === "unconfigured") {
+          return (
+            <api.ui.DialogAlert
+              title="Datamates"
+              message={
+                "Altimate credentials not found.\n\n" +
+                "Run /connect and pick the Altimate provider to add your instance name and API key, " +
+                "then reopen /datamates."
+              }
+            />
+          )
+        }
+        if (current.kind === "error") {
+          return (
+            <api.ui.DialogAlert
+              title="Datamates"
+              message={`Failed to load datamates: ${current.message.slice(0, 300)}`}
+            />
+          )
+        }
+        if (current.datamates.length === 0) {
+          return (
+            <api.ui.DialogAlert
+              title="Datamates"
+              message={
+                "No datamates in this workspace yet.\n\n" +
+                "Create one in the Altimate console (or ask the agent to), then reopen /datamates."
+              }
+            />
+          )
+        }
+        // With the gateway there is no single active datamate, so leave `current` unset and let the
+        // title carry the explanation; standalone mode can point the cursor at the wired one.
+        const activeId = current.wired.gateway ? undefined : [...current.wired.ids][0]
+        return (
+          <api.ui.DialogSelect
+            title={current.wired.gateway ? "Datamates (via extension gateway)" : "Datamates"}
+            placeholder="Search datamates..."
+            options={buildOptions(current.wired, current.datamates)}
+            current={activeId}
+            onSelect={(item) => {
+              const datamate = current.datamates.find((d) => d.id === item.value)
+              if (!datamate) return
+              api.ui.dialog.clear()
+              void wireDatamate(api, datamate)
+            }}
+          />
+        )
+      }}
+    </Show>
+  )
+}
+
+function showList(api: TuiPluginApi) {
+  api.ui.dialog.replace(() => <DialogDatamateList api={api} />)
+}
+
+// ── Home banner ─────────────────────────────────────────────────────────────────────────────────
+
+function Banner(props: { api: TuiPluginApi }) {
+  const theme = () => props.api.theme.current
+  return (
+    <box width="100%" maxWidth={75} paddingTop={1} flexShrink={0}>
+      <box
+        backgroundColor={theme().backgroundElement}
+        paddingTop={1}
+        paddingBottom={1}
+        paddingLeft={2}
+        paddingRight={2}
+        flexDirection="row"
+        gap={1}
+      >
+        <text flexShrink={0} fg={theme().text}>
+          ⬖
+        </text>
+        <box flexGrow={1} gap={1}>
+          <box flexDirection="row" justifyContent="space-between">
+            <text fg={theme().text}>
+              <b>Datamates</b>
+            </text>
+            <text fg={theme().textMuted} onMouseDown={() => props.api.kv.set(BANNER_KV_KEY, true)}>
+              ✕
+            </text>
+          </box>
+          <text fg={theme().textMuted}>
+            A datamate brings its integrations — Snowflake, dbt, Jira and more — into this session as tools.
+          </text>
+          <box flexDirection="row" gap={1} justifyContent="space-between">
+            <text fg={theme().text}>Browse your datamates</text>
+            <text fg={theme().textMuted}>/datamates</text>
+          </box>
+        </box>
+      </box>
+    </box>
+  )
+}
+
+const tui: TuiPlugin = async (api) => {
+  api.keymap.registerLayer({
+    commands: [
+      {
+        name: "altimate.datamate.list",
+        title: "Datamates",
+        desc: "Browse your Altimate datamates and connect one to this session",
+        category: "Altimate",
+        namespace: "palette",
+        slashName: "datamates",
+        run() {
+          showList(api)
+        },
+      },
+      // The banner's ✕ needs a mouse; keep a keyboard route to dismissal (as tips.toggle does).
+      {
+        name: "altimate.datamate.banner.hide",
+        title: "Hide datamates tip",
+        desc: "Dismiss the datamates banner on the home screen",
+        category: "Altimate",
+        namespace: "palette",
+        run() {
+          api.kv.set(BANNER_KV_KEY, true)
+          api.ui.dialog.clear()
+        },
+      },
+    ],
+  })
+
+  api.slots.register({
+    order: 110,
+    slots: {
+      home_bottom() {
+        const dismissed = createMemo(() => api.kv.get(BANNER_KV_KEY, false))
+        // Once a datamate MCP server exists there is nothing left to promote. Read live MCP status
+        // rather than the config so the banner also stays hidden for gateway-supplied servers.
+        const connected = createMemo(() =>
+          api.state.mcp().some((item) => item.name === DATAMATE_KEY || item.name.startsWith("datamate-")),
+        )
+        const show = createMemo(() => api.state.ready && !dismissed() && !connected())
+        return (
+          <Show when={show()}>
+            <Banner api={api} />
+          </Show>
+        )
+      },
+    },
+  })
+}
+
+const plugin: BuiltinTuiPlugin = {
+  id,
+  tui,
+}
+
+export default plugin
+// altimate_change end

--- a/packages/opencode/src/plugin/tui/altimate/index.ts
+++ b/packages/opencode/src/plugin/tui/altimate/index.ts
@@ -13,6 +13,7 @@ import ProviderCredentials from "./provider-credentials"
 import PromptEnhance from "./prompt-enhance"
 import SkillOps from "./skill-ops"
 import TraceViewer from "./trace-viewer"
+import Datamates from "./datamates"
 
 // Feature plugins are registered here as they are ported from the pre-merge sources on `main`
 // (see the ADR re-home plan). Each lives in its own file under this directory and default-exports
@@ -22,6 +23,6 @@ import TraceViewer from "./trace-viewer"
 //   import PromptEnhance from "./prompt-enhance"
 //   import TraceViewer from "./trace-viewer"
 export function altimateTuiPlugins(_flags: Pick<RuntimeFlags.Info, "experimentalEventSystem">): BuiltinTuiPlugin[] {
-  return [ProviderCredentials, PromptEnhance, SkillOps, TraceViewer]
+  return [ProviderCredentials, PromptEnhance, SkillOps, TraceViewer, Datamates]
 }
 // altimate_change end

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -34,6 +34,7 @@ import { MCP } from "../mcp"
 // Import sync + fresh-read helpers directly from the shared transport module.
 // Using datamate-transport.ts instead of serve.ts avoids a dep on a cmd handler.
 import { syncDatamateUrlFromVscodeMcp } from "../altimate/datamate-transport"
+import { connectDatamate } from "../altimate/datamate-connect"
 import { readMcpEntryFromDisk } from "../mcp/config"
 import { resolveConfigPath } from "../mcp/config"
 import { enhancePrompt, isAutoEnhanceEnabled } from "../altimate/enhance-prompt"
@@ -713,6 +714,23 @@ export namespace Server {
           const error = err instanceof Error ? err.message : String(err)
           log.error("reload-datamate: failed", { error })
           return c.json({ ok: false, error }, 500)
+        }
+      })
+      // altimate_change end
+      // altimate_change start — POST /altimate/datamate/connect
+      // Wires a datamate as an MCP server on behalf of the /datamates TUI picker. The picker runs in
+      // the TUI main thread, which has no Instance/MCP runtime (the server lives in a Worker — see
+      // cli/cmd/tui.ts), so the connect step has to happen here. Shares connectDatamate with the
+      // datamate_manager tool's 'add' operation so both surfaces wire identically.
+      .post("/altimate/datamate/connect", validator("json", z.object({ datamate_id: z.string() })), async (c) => {
+        const { datamate_id } = c.req.valid("json")
+        try {
+          const result = await connectDatamate({ datamateId: datamate_id })
+          return c.json({ ok: true as const, result })
+        } catch (err) {
+          const error = err instanceof Error ? err.message : String(err)
+          log.error("datamate connect: failed", { datamateId: datamate_id, error })
+          return c.json({ ok: false as const, error }, 500)
         }
       })
       // altimate_change end

--- a/packages/opencode/test/upstream/fork-feature-guards.test.ts
+++ b/packages/opencode/test/upstream/fork-feature-guards.test.ts
@@ -222,6 +222,39 @@ describe("fork feature presence guards (merge drop detection)", () => {
     expect(skill).toMatch(/DialogSkillCreate[\s\S]{0,80}initialValue/)
   })
 
+  // The /datamates picker is registered from the fork plugin aggregator and reaches the live MCP
+  // registry through a fork server endpoint (the TUI main thread has no MCP runtime). A merge that
+  // drops the registration, the endpoint, or the shared connectDatamate core leaves the command
+  // silently absent or the picker unable to wire anything — no compile error either way.
+  test("datamates picker is registered and shares the tool's connect core", async () => {
+    const aggregator = await read("src/plugin/tui/altimate/index.ts")
+    expect(aggregator).toContain('from "./datamates"')
+    expect(aggregator).toMatch(/return \[[^\]]*Datamates[^\]]*\]/)
+
+    const picker = await read("src/plugin/tui/altimate/datamates.tsx")
+    expect(picker).toMatch(/name: "altimate\.datamate\.list"/)
+    expect(picker).toMatch(/slashName: "datamates"/)
+    expect(picker).toContain("/altimate/datamate/connect")
+    // The banner lives in home_bottom behind a KV dismissal key.
+    expect(picker).toMatch(/home_bottom\(\)/)
+    expect(picker).toContain("dismissed_datamates_banner")
+
+    // The picker must NOT import the server-only wiring module — that would drag Instance/MCP into
+    // the TUI main thread, where neither exists.
+    expect(picker).not.toContain("datamate-connect")
+
+    const server = await read("src/server/server.ts")
+    expect(server).toContain('"/altimate/datamate/connect"')
+    expect(server).toContain("connectDatamate(")
+
+    // One implementation of the wiring, shared by the tool's 'add' operation and the picker.
+    const connect = await read("src/altimate/datamate-connect.ts")
+    expect(connect).toContain("export async function connectDatamate")
+    expect(connect).toContain("MCP.connect(DATAMATE_KEY)") // reconnect path persists enabled:true
+    const datamate = await read("src/altimate/tools/datamate.ts")
+    expect(datamate).toContain("connectDatamate(")
+  })
+
   test("re-homed TUI upstream fixes keep prompt/update/child-session behavior", async () => {
     const promptEnhance = await read("src/plugin/tui/altimate/prompt-enhance.tsx")
     expect(promptEnhance).toMatch(


### PR DESCRIPTION
### Issue for this PR

No GitHub issue — internal ticket AI-8138 (epic AI-7523, datamates integration).

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds the first human-facing surface for datamates in the CLI:

- **`/datamates` palette command** — a read-only picker listing the tenant's datamates (name, description, integrations) with an active-datamate ✓ marker. Selecting one wires the datamate MCP server; its tools appear with the Altimate badge. No create/edit/delete.
- **Onboarding banner** — dismissable home-screen box promoting `/datamates` (KV key `dismissed_datamates_banner`, keyboard-dismissable via a palette command, auto-hidden once any datamate server is connected).

Why it's shaped this way: the TUI plugin thread has no `Instance`/`MCP` runtime (the server runs in a Worker), so the picker cannot wire MCP in-process. The wiring core is extracted out of the `datamate_manager` tool's `add` operation into `connectDatamate()`, and a new fork endpoint `POST /altimate/datamate/connect` (same precedent as `reload-datamate`) lets both surfaces share it exactly — IDE-gateway detection, reconnect-vs-add, `MCP.connect` so enabled-state persists, stale-entry reporting. The LLM tool's outputs are unchanged. `datamate-config.ts` holds config-only reads safe on the TUI thread; a guard test asserts the picker never imports the server-only module.

Known limitation (deliberate): in IDE-gateway mode a single `datamate` server serves every datamate, so no per-datamate ✓ is derivable from config — the dialog titles itself "(via extension gateway)". Cross-surface selection sync is a follow-up on the epic.

### How did you verify your code works?

- Typecheck clean; fork-feature-guard + datamate + TUI plugin-lifecycle tests pass (77/77). Wider-sweep failures reproduced identically at the base commit (pre-existing, unrelated).
- Live TUI pass (tmux-driven) caught and fixed two defects: the loading-state dialog swap re-created the resource in a refetch loop, and the banner let a stale failed `datamate` entry suppress it. Both fixed in the second commit; picker, ✓ marker, and banner verified visually (screenshots below).
- End-to-end against the hosted multi-tenant endpoint: `POST /altimate/datamate/connect` with a real datamate id → `status: connected`, 11 tools, correct remote entry (URL + 4 auth headers) written to the project's `.altimate-code/altimate-code.json`, and `readWiredDatamates` resolves the active id for the picker's ✓.

### Screenshots / recordings

Headless TUI captures (tmux) from the verified flow:

**Onboarding banner on home** (shown when no datamate is connected; a stale *failed* entry no longer suppresses it)
![banner](https://raw.githubusercontent.com/ralphstodomingo/altimate-pr-assets/main/ai-8138-banner-home.png)

**`/datamates` picker** — tenant datamates with integration footers
![picker](https://raw.githubusercontent.com/ralphstodomingo/altimate-pr-assets/main/ai-8138-datamates-picker.png)

**Reopened after connecting** — active datamate carries the ✓, cursor lands on it
![active](https://raw.githubusercontent.com/ralphstodomingo/altimate-pr-assets/main/ai-8138-datamates-active-check.png)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)