### PR TITLE
feat(tui): toggle YOLO mode from the TUI with ctrl+y

### DIFF
--- a/packages/opencode/test/tui-journeys/yolo-console.test.ts
+++ b/packages/opencode/test/tui-journeys/yolo-console.test.ts
@@ -1,0 +1,96 @@
+// altimate_change — does ctrl+y collide with the opentui console's copy-selection?
+//
+// `app.tsx` configures the console overlay with
+// `consoleOptions: { keyBindings: [{ name: "y", ctrl: true, action: "copy-selection" }] }`,
+// so `ctrl+y` already means something while the console holds focus. Review flagged the
+// runtime behaviour as undefined and untested — a static keybind-config check cannot
+// answer it, because the console binding does not live in TuiKeybind.Definitions.
+//
+// This drives the real binary: open the console, press ctrl+y, and record what actually
+// happens. The assertion is deliberately written around whichever behaviour is real,
+// with the finding documented, rather than asserting a behaviour we would prefer.
+import { describe, expect, test } from "bun:test"
+import { booted, suiteEnabled, withJourney, type TmuxJourney } from "./harness"
+
+const maybeDescribe = suiteEnabled() ? describe : describe.skip
+const journeyOptions = { timeout: 90_000, retry: 1 }
+
+const CONFIRM = /Turn on YOLO mode for this session\?/i
+const ENABLED = /YOLO ON/i
+
+// The console toggle ships unbound ("none"); bind it so the journey can open the overlay.
+const consoleEnv = {
+  env: { ALTIMATE_CLI_YOLO: "false" },
+  config: (base: Record<string, unknown>) => ({
+    ...base,
+    keybinds: { ...((base.keybinds as Record<string, unknown>) ?? {}), app_console: "ctrl+o" },
+  }),
+}
+
+async function openConsole(tui: TmuxJourney) {
+  tui.send("C-o")
+  // The console overlay repaints the pane; give it a beat to appear.
+  await Bun.sleep(1500)
+}
+
+maybeDescribe("real-binary TUI journeys: yolo vs console focus", () => {
+  test(
+    "ctrl+y with the console open does not silently half-fire",
+    async () => {
+      await withJourney(
+        "yolo console focus",
+        async (tui) => {
+          await booted(tui)
+          const before = tui.snapshot()
+          expect(before).not.toMatch(ENABLED)
+
+          await openConsole(tui)
+          tui.send("C-y")
+          await Bun.sleep(2000)
+          const after = tui.snapshot()
+
+          // Measured behaviour: the yolo binding takes precedence over the console's
+          // copy-selection, and the confirmation still gates the bypass. Pinned as an
+          // assertion rather than logged, so a future precedence change has to be a
+          // deliberate decision instead of a silent one.
+          //
+          // The dangerous state this rules out is `enabled && !dialogShown` — a
+          // permission bypass switched on by a keystroke aimed at the console.
+          expect(CONFIRM.test(after)).toBe(true)
+          expect(ENABLED.test(after)).toBe(false)
+
+          // Escaping leaves no half-applied state.
+          tui.send("Escape")
+          await tui.waitFor((plain) => !CONFIRM.test(plain), 20_000)
+          expect(tui.snapshot()).not.toMatch(ENABLED)
+        },
+        consoleEnv,
+      )
+    },
+    journeyOptions,
+  )
+
+  test(
+    "ctrl+y still works normally after the console is closed again",
+    async () => {
+      // Guards the practical regression: whatever the console does with the key, the
+      // shortcut must not be left broken once the overlay is dismissed.
+      await withJourney(
+        "yolo console restore",
+        async (tui) => {
+          await booted(tui)
+          await openConsole(tui)
+          tui.send("C-o") // close
+          await Bun.sleep(1500)
+
+          tui.send("C-y")
+          await tui.waitFor((plain) => CONFIRM.test(plain), 20_000)
+          tui.send("y")
+          await tui.waitFor((plain) => ENABLED.test(plain), 20_000)
+        },
+        consoleEnv,
+      )
+    },
+    journeyOptions,
+  )
+})

--- a/packages/opencode/test/tui-journeys/yolo-effect.test.ts
+++ b/packages/opencode/test/tui-journeys/yolo-effect.test.ts
@@ -1,0 +1,202 @@
+// altimate_change — functional end-to-end coverage for YOLO mode.
+//
+// yolo.test.ts proves the UI states. This file proves the thing the UI is a
+// control for: that enabling yolo actually stops the agent asking, that disabling
+// restores asking, and that the guardrails the confirmation dialog promises are
+// real rather than aspirational.
+//
+// Assertions are on OBSERVABLE SIDE EFFECTS (did the command run? does the marker
+// file exist?) rather than on the permission dialog's text. journeys.test.ts
+// documents that the permission prompt does not render reliably under the mock-model
+// harness, so dialog-text assertions are flaky — but whether a tool actually EXECUTED
+// is unambiguous, and is the property that matters for a permission bypass.
+import { describe, expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { booted, submitPrompt, suiteEnabled, withJourney, type TmuxJourney } from "./harness"
+
+const maybeDescribe = suiteEnabled() ? describe : describe.skip
+const journeyOptions = { timeout: 90_000, retry: 1 }
+
+// bash must be "ask" for this suite to mean anything: the harness default is
+// `"*": "allow"`, under which nothing ever prompts and yolo would be a no-op.
+const askForBash = {
+  env: { ALTIMATE_CLI_YOLO: "false" },
+  config: (base: Record<string, unknown>) => {
+    const agent = (base.agent ?? {}) as Record<string, Record<string, unknown>>
+    return {
+      ...base,
+      agent: {
+        ...agent,
+        builder: {
+          ...agent.builder,
+          permission: { "*": "allow", question: "allow", plan_enter: "allow", bash: "ask" },
+        },
+      },
+    }
+  },
+}
+
+async function exists(file: string) {
+  return await fs
+    .stat(file)
+    .then(() => true)
+    .catch(() => false)
+}
+
+async function enableYolo(tui: TmuxJourney) {
+  tui.send("C-y")
+  await tui.waitFor((plain) => /Turn on YOLO mode for this session\?/i.test(plain), 20_000)
+  tui.send("y")
+  await tui.waitFor((plain) => /YOLO ON/i.test(plain), 20_000)
+}
+
+maybeDescribe("real-binary TUI journeys: yolo mode behaviour", () => {
+  test(
+    "yolo off: an ask-gated command does NOT run on its own",
+    async () => {
+      // Control case. If this ever starts passing trivially (the command runs with
+      // yolo off), the suite below proves nothing and the permission gate has broken.
+      await withJourney(
+        "yolo effect control",
+        async (tui, ctx) => {
+          const marker = path.join(ctx.workspace, "ran-without-yolo.txt")
+          await booted(tui)
+          await tui.ctx.llm.tool("bash", {
+            command: `touch ${JSON.stringify(marker)}`,
+            description: "create marker",
+          })
+          await tui.ctx.llm.text("done")
+          await submitPrompt(tui, "create the marker")
+          await Bun.sleep(12_000)
+          expect(await exists(marker)).toBe(false)
+        },
+        askForBash,
+      )
+    },
+    journeyOptions,
+  )
+
+  test(
+    "yolo on: an ask-gated command runs without prompting",
+    async () => {
+      await withJourney(
+        "yolo effect enabled",
+        async (tui, ctx) => {
+          const marker = path.join(ctx.workspace, "ran-with-yolo.txt")
+          await booted(tui)
+          await enableYolo(tui)
+          await tui.ctx.llm.tool("bash", {
+            command: `touch ${JSON.stringify(marker)}`,
+            description: "create marker",
+          })
+          await tui.ctx.llm.text("done")
+          await submitPrompt(tui, "create the marker")
+          await tui.waitFor(async () => await exists(marker), 40_000)
+          expect(await exists(marker)).toBe(true)
+        },
+        askForBash,
+      )
+    },
+    journeyOptions,
+  )
+
+  test(
+    "guardrails hold under yolo: a denied DDL command never executes",
+    async () => {
+      // The claim printed in the confirmation dialog. DROP DATABASE is a hard "deny"
+      // in agent.ts safetyDenials, and Permission.ask refuses deny matches before any
+      // event reaches the TUI — so yolo must have no way to auto-approve it.
+      //
+      // The command is `DROP DATABASE x ; touch <marker>`: the whole string matches the
+      // "DROP DATABASE *" deny pattern, so bash should never run. If the guardrail
+      // leaked, bash WOULD run and the trailing touch would land the marker even though
+      // the DDL itself is not a shell builtin. Marker present == guardrail bypassed.
+      await withJourney(
+        "yolo effect guardrail",
+        async (tui, ctx) => {
+          const marker = path.join(ctx.workspace, "ddl-bypassed.txt")
+          await booted(tui)
+          await enableYolo(tui)
+          await tui.ctx.llm.tool("bash", {
+            command: `DROP DATABASE prod ; touch ${JSON.stringify(marker)}`,
+            description: "drop the database",
+          })
+          await tui.ctx.llm.text("done")
+          await submitPrompt(tui, "drop the prod database")
+          await Bun.sleep(15_000)
+          expect(await exists(marker)).toBe(false)
+        },
+        askForBash,
+      )
+    },
+    journeyOptions,
+  )
+
+  test(
+    "control for the guardrail test: the same semicolon-chained shape DOES run under yolo",
+    async () => {
+      // Without this, the guardrail test above is vacuous: a missing marker file would
+      // be equally consistent with "the deny rule worked" and with "semicolon-chained
+      // commands never execute under this harness at all". This runs the identical
+      // shape with the DDL prefix replaced by a harmless echo, so the ONLY difference
+      // between the two cases is the denied pattern.
+      await withJourney(
+        "yolo effect guardrail control",
+        async (tui, ctx) => {
+          const marker = path.join(ctx.workspace, "chained-ran.txt")
+          await booted(tui)
+          await enableYolo(tui)
+          await tui.ctx.llm.tool("bash", {
+            command: `echo prod ; touch ${JSON.stringify(marker)}`,
+            description: "harmless chained command",
+          })
+          await tui.ctx.llm.text("done")
+          await submitPrompt(tui, "run the harmless chained command")
+          await tui.waitFor(async () => await exists(marker), 40_000)
+          expect(await exists(marker)).toBe(true)
+        },
+        askForBash,
+      )
+    },
+    journeyOptions,
+  )
+
+  test(
+    "turning yolo back off restores prompting",
+    async () => {
+      await withJourney(
+        "yolo effect toggled back off",
+        async (tui, ctx) => {
+          const allowed = path.join(ctx.workspace, "while-on.txt")
+          const blocked = path.join(ctx.workspace, "after-off.txt")
+          await booted(tui)
+          await enableYolo(tui)
+
+          await tui.ctx.llm.tool("bash", {
+            command: `touch ${JSON.stringify(allowed)}`,
+            description: "create marker",
+          })
+          await tui.ctx.llm.text("done")
+          await submitPrompt(tui, "first marker")
+          await tui.waitFor(async () => await exists(allowed), 40_000)
+
+          // Off again — no confirmation expected on the way out.
+          tui.send("C-y")
+          await tui.waitFor((plain) => !/YOLO ON/i.test(plain), 20_000)
+
+          await tui.ctx.llm.tool("bash", {
+            command: `touch ${JSON.stringify(blocked)}`,
+            description: "create marker",
+          })
+          await tui.ctx.llm.text("done")
+          await submitPrompt(tui, "second marker")
+          await Bun.sleep(12_000)
+          expect(await exists(blocked)).toBe(false)
+        },
+        askForBash,
+      )
+    },
+    journeyOptions,
+  )
+})

--- a/packages/opencode/test/tui-journeys/yolo-subagent.test.ts
+++ b/packages/opencode/test/tui-journeys/yolo-subagent.test.ts
@@ -1,0 +1,101 @@
+// altimate_change — end-to-end proof that YOLO mode reaches SUBAGENTS.
+//
+// This is the behaviour the root-session normalization in src/util/yolo.ts exists
+// for, and the claim the confirmation dialog makes ("Applies to subagents too").
+// Until now it was only covered by unit tests over a synthetic parent map.
+//
+// Why it is not trivially covered: the task tool spawns the subagent in its OWN
+// child session (packages/opencode/src/tool/task.ts creates one with parentID), so
+// its permission requests arrive tagged with the CHILD id. A naive per-session
+// lookup keyed on the id the user can see would leave subagents prompting forever.
+//
+// The `general` subagent inherits bash: "ask" from the agent defaults, so its bash
+// call genuinely needs a permission decision. The off-control below is mandatory,
+// not decorative: without it, a passing "marker exists" case would be equally
+// consistent with "bash was allowed all along".
+//
+// Mock LLM queue is FIFO and shared across parent and child sessions; title requests
+// are intercepted by the harness and do not consume queue items. Order is therefore:
+//   1. parent turn      -> task(general)
+//   2. subagent turn    -> bash(touch marker)
+//   3. subagent closing -> text
+//   4. parent closing   -> text
+import { describe, expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { booted, submitPrompt, suiteEnabled, withJourney, type TmuxJourney } from "./harness"
+
+const maybeDescribe = suiteEnabled() ? describe : describe.skip
+const journeyOptions = { timeout: 120_000, retry: 1 }
+
+const baseEnv = { env: { ALTIMATE_CLI_YOLO: "false" } }
+
+async function exists(file: string) {
+  return await fs
+    .stat(file)
+    .then(() => true)
+    .catch(() => false)
+}
+
+async function enableYolo(tui: TmuxJourney) {
+  tui.send("C-y")
+  await tui.waitFor((plain) => /Turn on YOLO mode for this session\?/i.test(plain), 20_000)
+  tui.send("y")
+  await tui.waitFor((plain) => /YOLO ON/i.test(plain), 20_000)
+}
+
+async function scriptSubagentBash(tui: TmuxJourney, marker: string) {
+  await tui.ctx.llm.tool("task", {
+    subagent_type: "general",
+    description: "create marker",
+    prompt: "create the marker file",
+  })
+  await tui.ctx.llm.tool("bash", {
+    command: `touch ${JSON.stringify(marker)}`,
+    description: "create marker",
+  })
+  await tui.ctx.llm.text("subagent done")
+  await tui.ctx.llm.text("parent done")
+  await submitPrompt(tui, "delegate the marker creation")
+}
+
+maybeDescribe("real-binary TUI journeys: yolo reaches subagents", () => {
+  test(
+    "yolo on: a subagent's ask-gated command runs without prompting",
+    async () => {
+      await withJourney(
+        "yolo subagent inherits",
+        async (tui, ctx) => {
+          const marker = path.join(ctx.workspace, "subagent-with-yolo.txt")
+          await booted(tui)
+          await enableYolo(tui)
+          await scriptSubagentBash(tui, marker)
+          await tui.waitFor(async () => await exists(marker), 60_000)
+          expect(await exists(marker)).toBe(true)
+        },
+        baseEnv,
+      )
+    },
+    journeyOptions,
+  )
+
+  test(
+    "control — yolo off: the same subagent command does NOT run",
+    async () => {
+      // Proves the test above measures yolo inheritance rather than bash simply
+      // being permitted for subagents.
+      await withJourney(
+        "yolo subagent control",
+        async (tui, ctx) => {
+          const marker = path.join(ctx.workspace, "subagent-without-yolo.txt")
+          await booted(tui)
+          await scriptSubagentBash(tui, marker)
+          await Bun.sleep(25_000)
+          expect(await exists(marker)).toBe(false)
+        },
+        baseEnv,
+      )
+    },
+    journeyOptions,
+  )
+})

--- a/packages/opencode/test/tui-journeys/yolo.test.ts
+++ b/packages/opencode/test/tui-journeys/yolo.test.ts
@@ -1,0 +1,151 @@
+// altimate_change — real-binary journey for the YOLO mode ctrl+y toggle.
+//
+// Covers the four states the spec mocks up, in order:
+//   1. the `ctrl+y yolo` hint is visible on the chat panel
+//   2. ctrl+y opens a confirmation prompt that requires an explicit Yes/No
+//   3. answering Yes shows the enabled state
+//   4. ctrl+y again turns it off with NO confirmation prompt
+//
+// Plus the properties that are easy to regress and invisible in a screenshot:
+// declining leaves it off, the shortcut exists before the first prompt has created
+// a session, and the confirmation copy states which guardrails survive.
+//
+// Every journey pins ALTIMATE_CLI_YOLO=false. Without it the suite inherits whatever
+// the developer's shell has set (yolo is a common local default), which silently
+// inverts the starting state and makes the first ctrl+y a *disable*.
+import { describe, expect, test } from "bun:test"
+import { booted, submitPrompt, suiteEnabled, withJourney, type TmuxJourney } from "./harness"
+
+const maybeDescribe = suiteEnabled() ? describe : describe.skip
+const journeyOptions = { timeout: 75_000, retry: 1 }
+const journeyEnv = { env: { ALTIMATE_CLI_YOLO: "false" } }
+
+const CONFIRM = /Turn on YOLO mode for this session\?/i
+const ENABLED = /YOLO ON/i
+const HINT_OFF = /ctrl\+y\s+yolo/i
+
+async function openConfirm(tui: TmuxJourney) {
+  tui.send("C-y")
+  await tui.waitFor((plain) => CONFIRM.test(plain), 20_000)
+}
+
+async function inSession(tui: TmuxJourney) {
+  await booted(tui)
+  await tui.ctx.llm.text("ready")
+  await submitPrompt(tui, "hi")
+  await tui.waitFor((plain) => plain.includes("ready"), 30_000)
+}
+
+maybeDescribe("real-binary TUI journeys: yolo mode", () => {
+  test(
+    "yolo: hint shows, ctrl+y confirms, Yes enables, ctrl+y disables without confirming",
+    async () => {
+      await withJourney(
+        "yolo toggle round trip",
+        async (tui) => {
+          await inSession(tui)
+
+          // 1. hint on the chat panel, in the off state
+          await tui.waitFor((plain) => HINT_OFF.test(plain), 20_000)
+          expect(tui.snapshot()).not.toMatch(ENABLED)
+
+          // 2. ctrl+y asks first rather than enabling straight away
+          await openConfirm(tui)
+          const confirmScreen = tui.snapshot()
+          expect(confirmScreen).toMatch(/Yes/)
+          expect(confirmScreen).toMatch(/No/)
+
+          // 3. Yes enables, and the enabled state is visible
+          tui.send("y")
+          await tui.waitFor((plain) => ENABLED.test(plain), 20_000)
+
+          // 4. ctrl+y again turns it off WITHOUT a confirmation prompt
+          tui.send("C-y")
+          await tui.waitFor((plain) => !ENABLED.test(plain), 20_000)
+          expect(tui.snapshot()).not.toMatch(CONFIRM)
+        },
+        journeyEnv,
+      )
+    },
+    journeyOptions,
+  )
+
+  test(
+    "yolo: answering No leaves it off",
+    async () => {
+      await withJourney(
+        "yolo confirm declined",
+        async (tui) => {
+          await inSession(tui)
+          await openConfirm(tui)
+          tui.send("n")
+          await tui.waitFor((plain) => !CONFIRM.test(plain), 20_000)
+          expect(tui.snapshot()).not.toMatch(ENABLED)
+        },
+        journeyEnv,
+      )
+    },
+    journeyOptions,
+  )
+
+  test(
+    "yolo: escape dismisses the confirmation without enabling",
+    async () => {
+      await withJourney(
+        "yolo confirm escaped",
+        async (tui) => {
+          await inSession(tui)
+          await openConfirm(tui)
+          tui.send("Escape")
+          await tui.waitFor((plain) => !CONFIRM.test(plain), 20_000)
+          expect(tui.snapshot()).not.toMatch(ENABLED)
+        },
+        journeyEnv,
+      )
+    },
+    journeyOptions,
+  )
+
+  test(
+    "yolo: the shortcut works on the welcome screen, before any session exists",
+    async () => {
+      // Regression guard: the command was originally registered in the session route,
+      // so on first launch the hint was missing and ctrl+y did nothing at all.
+      await withJourney(
+        "yolo pre-session",
+        async (tui) => {
+          await booted(tui)
+          await tui.waitFor((plain) => HINT_OFF.test(plain), 20_000)
+          await openConfirm(tui)
+          tui.send("y")
+          await tui.waitFor((plain) => ENABLED.test(plain), 20_000)
+        },
+        journeyEnv,
+      )
+    },
+    journeyOptions,
+  )
+
+  test(
+    "yolo: the confirmation states which guardrails survive",
+    async () => {
+      // The prompt must not read as "the agent can now do anything". Server-side deny
+      // rules (DROP DATABASE / DROP SCHEMA / TRUNCATE) are never auto-approved because
+      // Permission.ask refuses them before any event reaches the TUI, and a user
+      // deciding Yes/No is entitled to know that.
+      await withJourney(
+        "yolo confirm copy",
+        async (tui) => {
+          await booted(tui)
+          await openConfirm(tui)
+          const plain = tui.snapshot()
+          expect(plain).toMatch(/DROP DATABASE/i)
+          expect(plain).toMatch(/[Ss]till blocked/)
+          expect(plain).toMatch(/session only|turns off when you quit/i)
+        },
+        journeyEnv,
+      )
+    },
+    journeyOptions,
+  )
+})

--- a/packages/opencode/test/tui-journeys/yolo.test.ts
+++ b/packages/opencode/test/tui-journeys/yolo.test.ts
@@ -138,10 +138,19 @@ maybeDescribe("real-binary TUI journeys: yolo mode", () => {
         async (tui) => {
           await booted(tui)
           await openConfirm(tui)
-          const plain = tui.snapshot()
+          // Normalize before matching. The dialog re-wraps to the pane width AND draws a
+          // box border, so a wrapped sentence reads as "... turns off when you │ │ quit".
+          // Asserting on a phrase that happens to fit one line makes the test a hostage
+          // to copy length and terminal size, so strip the border glyphs and collapse
+          // whitespace first.
+          const plain = tui
+            .snapshot()
+            .replace(/[│┃╭╮╰╯─━┄|]/g, " ")
+            .replace(/\s+/g, " ")
           expect(plain).toMatch(/DROP DATABASE/i)
           expect(plain).toMatch(/[Ss]till blocked/)
-          expect(plain).toMatch(/session only|turns off when you quit/i)
+          expect(plain).toMatch(/turns off when you quit/i)
+          expect(plain).toMatch(/subagents/i)
         },
         journeyEnv,
       )

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -484,14 +484,6 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
   )
 
   // Update terminal window title based on current route and session
-  // altimate_change start - yolo mode: hand a welcome-screen choice to the first session
-  // that appears, then clear it so it does not leak into later sessions.
-  createEffect(() => {
-    if (route.data.type !== "session") return
-    sync.yolo.adopt(route.data.sessionID)
-  })
-  // altimate_change end
-
   createEffect(() => {
     if (!terminalTitleEnabled() || Flag.OPENCODE_DISABLE_TERMINAL_TITLE) return
 
@@ -889,7 +881,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
         category: "Session",
         slashName: "yolo",
         run: () => {
-          const sessionID = route.data.type === "session" ? route.data.sessionID : undefined
+          const currentSessionID = () => (route.data.type === "session" ? route.data.sessionID : undefined)
+          const sessionID = currentSessionID()
           if (sync.yolo.enabled(sessionID)) {
             sync.yolo.set(sessionID, false)
             toast.show({ message: "YOLO mode off — the agent will ask before acting", variant: "info" })
@@ -899,6 +892,17 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
             <DialogYoloConfirm
               onChoose={(enable) => {
                 if (!enable) return
+                // The route can change while the confirmation is open — session.quick_switch.N
+                // is registered without a mode so it stays live during a modal, and session
+                // deletion auto-navigates home. Applying the captured id then would enable
+                // YOLO on a session the user is no longer looking at.
+                if (currentSessionID() !== sessionID) {
+                  toast.show({
+                    message: "Session changed while confirming — YOLO mode not enabled",
+                    variant: "info",
+                  })
+                  return
+                }
                 sync.yolo.set(sessionID, true)
                 toast.show({ message: "YOLO mode on for this session", variant: "warning" })
               }}

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -65,6 +65,8 @@ import { DialogStatus } from "./component/dialog-status"
 import { DialogThemeList } from "./component/dialog-theme-list"
 import { DialogHelp } from "./ui/dialog-help"
 import { DialogAgent } from "./component/dialog-agent"
+// altimate_change - yolo mode confirmation gate
+import { DialogYoloConfirm } from "./component/dialog-yolo-confirm"
 import { DialogSessionList } from "./component/dialog-session-list"
 import { DialogWorkspaceList } from "./component/dialog-workspace-list"
 import { DialogConsoleOrg } from "./component/dialog-console-org"
@@ -133,6 +135,10 @@ const appBindingCommands = [
   "mcp.list",
   "agent.cycle",
   "agent.cycle.reverse",
+  // altimate_change - yolo mode toggle (ctrl+y). App-scope rather than session-scope so
+  // the shortcut and its hint exist on the welcome screen too, before the first prompt
+  // has created a session.
+  "session.yolo.toggle",
   "variant.cycle",
   "variant.list",
   "provider.connect",
@@ -478,6 +484,14 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
   )
 
   // Update terminal window title based on current route and session
+  // altimate_change start - yolo mode: hand a welcome-screen choice to the first session
+  // that appears, then clear it so it does not leak into later sessions.
+  createEffect(() => {
+    if (route.data.type !== "session") return
+    sync.yolo.adopt(route.data.sessionID)
+  })
+  // altimate_change end
+
   createEffect(() => {
     if (!terminalTitleEnabled() || Flag.OPENCODE_DISABLE_TERMINAL_TITLE) return
 
@@ -865,6 +879,34 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
           local.agent.move(1)
         },
       },
+      // altimate_change start - yolo mode: ctrl+y toggle. Enabling is gated behind an
+      // explicit Yes/No; disabling is immediate, so turning a dangerous mode off is never
+      // harder than leaving it on. Applies to the current session only (or, on the
+      // welcome screen, to the session about to be created).
+      {
+        name: "session.yolo.toggle",
+        title: "Toggle YOLO mode",
+        category: "Session",
+        slashName: "yolo",
+        run: () => {
+          const sessionID = route.data.type === "session" ? route.data.sessionID : undefined
+          if (sync.yolo.enabled(sessionID)) {
+            sync.yolo.set(sessionID, false)
+            toast.show({ message: "YOLO mode off — the agent will ask before acting", variant: "info" })
+            return
+          }
+          dialog.replace(() => (
+            <DialogYoloConfirm
+              onChoose={(enable) => {
+                if (!enable) return
+                sync.yolo.set(sessionID, true)
+                toast.show({ message: "YOLO mode on for this session", variant: "warning" })
+              }}
+            />
+          ))
+        },
+      },
+      // altimate_change end
       {
         name: "variant.cycle",
         title: "Variant cycle",

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -135,10 +135,11 @@ const appBindingCommands = [
   "mcp.list",
   "agent.cycle",
   "agent.cycle.reverse",
-  // altimate_change - yolo mode toggle (ctrl+y). App-scope rather than session-scope so
-  // the shortcut and its hint exist on the welcome screen too, before the first prompt
+  // altimate_change start — yolo mode toggle (ctrl+y). App-scope rather than session-scope
+  // so the shortcut and its hint exist on the welcome screen too, before the first prompt
   // has created a session.
   "session.yolo.toggle",
+  // altimate_change end
   "variant.cycle",
   "variant.list",
   "provider.connect",

--- a/packages/tui/src/component/dialog-yolo-confirm.tsx
+++ b/packages/tui/src/component/dialog-yolo-confirm.tsx
@@ -35,7 +35,7 @@ export function DialogYoloConfirm(props: { onChoose: (enable: boolean) => void }
     {
       label: "Yes",
       run: () => run(true),
-      help: "Stop asking for this session. Applies to subagents too.",
+      help: "Stop asking for this conversation and its subagents.",
     },
     {
       label: "No",
@@ -103,7 +103,7 @@ export function DialogYoloConfirm(props: { onChoose: (enable: boolean) => void }
           auto-approved.
         </text>
         <text fg={theme.textMuted} wrapMode="word" width="100%">
-          Applies to this session only, and turns off when you quit. Press{" "}
+          Applies to this conversation and any subagents it spawns, and turns off when you quit. Press{" "}
           <span style={{ fg: theme.text }}>ctrl+y</span> again to turn it off.
         </text>
         <box gap={1}>

--- a/packages/tui/src/component/dialog-yolo-confirm.tsx
+++ b/packages/tui/src/component/dialog-yolo-confirm.tsx
@@ -56,13 +56,19 @@ export function DialogYoloConfirm(props: { onChoose: (enable: boolean) => void }
       options[selected()].run()
       return
     }
+    // stopPropagation for consistency with the `return` branch above. The dialog blurs
+    // the focused renderable on open and only refocuses in a later tick, so a stray
+    // character cannot reach the prompt today — this keeps it that way if that ordering
+    // ever changes.
     if (evt.name === "y" && !evt.ctrl && !evt.meta) {
       evt.preventDefault()
+      evt.stopPropagation()
       run(true)
       return
     }
     if (evt.name === "n" && !evt.ctrl && !evt.meta) {
       evt.preventDefault()
+      evt.stopPropagation()
       run(false)
     }
   })

--- a/packages/tui/src/component/dialog-yolo-confirm.tsx
+++ b/packages/tui/src/component/dialog-yolo-confirm.tsx
@@ -1,0 +1,142 @@
+import { createSignal, For, onMount } from "solid-js"
+import { TextAttributes, RGBA } from "@opentui/core"
+import { useKeyboard } from "@opentui/solid"
+import { useTheme, selectedForeground } from "../context/theme"
+import { useDialog } from "../ui/dialog"
+
+// altimate_change — YOLO mode confirmation gate (ctrl+y).
+//
+// Shown only when ENABLING. Disabling is immediate and unconfirmed, because
+// turning a dangerous mode off should never have friction.
+//
+// The copy deliberately states what stays protected as well as what stops
+// asking. Yolo can only auto-answer prompts the SERVER chose to raise:
+// Permission.ask (packages/opencode/src/permission/index.ts) evaluates the
+// ruleset first and refuses "deny" matches outright without emitting an event,
+// so the configured guardrails (DROP DATABASE / DROP SCHEMA / TRUNCATE, on both
+// bash and sql_execute_write — see packages/opencode/src/agent/agent.ts) are
+// unreachable from here. Overstating the risk would be as misleading as
+// understating it, so we name both halves.
+//
+// Defaults to "No" — unlike the scan gate, the safe choice is the passive one.
+export function DialogYoloConfirm(props: { onChoose: (enable: boolean) => void }) {
+  const { theme } = useTheme()
+  const dialog = useDialog()
+  const [selected, setSelected] = createSignal(1) // 1 = No (safe default)
+
+  onMount(() => dialog.setSize("large"))
+
+  function run(enable: boolean) {
+    dialog.clear()
+    props.onChoose(enable)
+  }
+
+  const options = [
+    {
+      label: "Yes",
+      run: () => run(true),
+      help: "Stop asking for this session. Applies to subagents too.",
+    },
+    {
+      label: "No",
+      run: () => run(false),
+      help: "Keep asking before each action.",
+    },
+  ]
+
+  useKeyboard((evt) => {
+    if (evt.name === "up" || evt.name === "down") {
+      setSelected((prev) => (prev + 1) % 2)
+      evt.preventDefault()
+      return
+    }
+    if (evt.name === "return") {
+      evt.preventDefault()
+      evt.stopPropagation()
+      options[selected()].run()
+      return
+    }
+    if (evt.name === "y" && !evt.ctrl && !evt.meta) {
+      evt.preventDefault()
+      run(true)
+      return
+    }
+    if (evt.name === "n" && !evt.ctrl && !evt.meta) {
+      evt.preventDefault()
+      run(false)
+    }
+  })
+
+  const selFg = selectedForeground(theme)
+  const transparent = RGBA.fromInts(0, 0, 0, 0)
+
+  return (
+    <box paddingLeft={2} paddingRight={2} paddingBottom={1}>
+      <box
+        border
+        borderStyle="rounded"
+        borderColor={theme.warning}
+        title=" YOLO mode "
+        titleAlignment="left"
+        paddingLeft={2}
+        paddingRight={2}
+        paddingTop={1}
+        paddingBottom={1}
+        gap={1}
+      >
+        <box flexDirection="row" justifyContent="space-between">
+          <text fg={theme.text} attributes={TextAttributes.BOLD}>
+            Turn on YOLO mode for this session?
+          </text>
+          <text fg={theme.textMuted} onMouseUp={() => dialog.clear()}>
+            esc
+          </text>
+        </box>
+        <text fg={theme.textMuted} wrapMode="word" width="100%">
+          The agent will run actions without asking you first — including editing files, running shell commands like{" "}
+          <span style={{ fg: theme.text }}>rm -rf</span> and{" "}
+          <span style={{ fg: theme.text }}>git push --force</span>, and reading .env files.
+        </text>
+        <text fg={theme.textMuted} wrapMode="word" width="100%">
+          <span style={{ fg: theme.success }}>Still blocked: </span>
+          your configured guardrails stay in force. DROP DATABASE, DROP SCHEMA and TRUNCATE remain denied and are not
+          auto-approved.
+        </text>
+        <text fg={theme.textMuted} wrapMode="word" width="100%">
+          Applies to this session only, and turns off when you quit. Press{" "}
+          <span style={{ fg: theme.text }}>ctrl+y</span> again to turn it off.
+        </text>
+        <box gap={1}>
+          <For each={options}>
+            {(option, index) => {
+              const active = () => selected() === index()
+              return (
+                <box flexDirection="row" gap={1} onMouseMove={() => setSelected(index())} onMouseUp={() => option.run()}>
+                  <text flexShrink={0} fg={theme.primary}>
+                    {active() ? "❯" : " "}
+                  </text>
+                  <box
+                    width={6}
+                    flexShrink={0}
+                    paddingLeft={1}
+                    paddingRight={1}
+                    backgroundColor={active() ? theme.primary : transparent}
+                  >
+                    <text fg={active() ? selFg : theme.text} attributes={active() ? TextAttributes.BOLD : undefined}>
+                      {option.label}
+                    </text>
+                  </box>
+                  <box flexGrow={1}>
+                    <text wrapMode="word" width="100%">
+                      <span style={{ fg: theme.textMuted }}>{option.help}</span>
+                    </text>
+                  </box>
+                </box>
+              )
+            }}
+          </For>
+        </box>
+      </box>
+    </box>
+  )
+}

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -211,6 +211,13 @@ export function Prompt(props: PromptProps) {
   const keymap = useOpencodeKeymap()
   const agentShortcut = useCommandShortcut("agent.cycle")
   const paletteShortcut = useCommandShortcut("command.palette.show")
+  // altimate_change start - yolo mode hint on the chat panel
+  const yoloShortcut = useCommandShortcut("session.yolo.toggle")
+  // Pass sessionID through even when undefined: on the welcome screen the mode can
+  // already be on (pending adoption by the session about to be created), and the hint
+  // must reflect that rather than always reading "off".
+  const yoloEnabled = createMemo(() => sync.yolo.enabled(props.sessionID))
+  // altimate_change end
   const renderer = useRenderer()
   const exit = useExit()
   const dimensions = useTerminalDimensions()
@@ -1777,6 +1784,24 @@ export function Prompt(props: PromptProps) {
                   <text fg={theme.text}>
                     {paletteShortcut()} <span style={{ fg: theme.textMuted }}>commands</span>
                   </text>
+                  {/* altimate_change start - yolo mode hint + live state on the chat panel.
+                      Warning-coloured once on, so the enabled state is visible right where
+                      the user types rather than only in the footer. */}
+                  <Show when={yoloShortcut()}>
+                    <Show
+                      when={yoloEnabled()}
+                      fallback={
+                        <text fg={theme.text}>
+                          {yoloShortcut()} <span style={{ fg: theme.textMuted }}>yolo</span>
+                        </text>
+                      }
+                    >
+                      <text fg={theme.warning}>
+                        {yoloShortcut()} <span style={{ fg: theme.warning }}>△ YOLO ON</span>
+                      </text>
+                    </Show>
+                  </Show>
+                  {/* altimate_change end */}
                 </Match>
                 <Match when={store.mode === "shell"}>
                   <text fg={theme.text}>

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1132,10 +1132,11 @@ export function Prompt(props: PromptProps) {
       }
 
       sessionID = res.data.id
-      // altimate_change - yolo mode: bind a welcome-screen choice to the session it was
-      // actually meant for, at the moment of creation. Doing this on route change instead
-      // would also fire when resuming an existing conversation.
+      // altimate_change start — yolo mode: bind a welcome-screen choice to the session it
+      // was actually meant for, at the moment of creation. Doing this on route change
+      // instead would also fire when resuming an existing conversation.
       sync.yolo.adopt(sessionID)
+      // altimate_change end
     }
 
     // altimate_change start — restore auto-enhance-before-submit for normal prompts

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1132,6 +1132,10 @@ export function Prompt(props: PromptProps) {
       }
 
       sessionID = res.data.id
+      // altimate_change - yolo mode: bind a welcome-screen choice to the session it was
+      // actually meant for, at the moment of creation. Doing this on route change instead
+      // would also fire when resuming an existing conversation.
+      sync.yolo.adopt(sessionID)
     }
 
     // altimate_change start — restore auto-enhance-before-submit for normal prompts

--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -102,6 +102,8 @@ export const Definitions = {
   session_child_cycle_reverse: keybind("left", "Go to previous child session"),
   session_parent: keybind("up", "Go to parent session"),
   session_pin_toggle: keybind("ctrl+f", "Pin or unpin session in the session list"),
+  // altimate_change - yolo mode: enabling asks for confirmation, disabling is immediate
+  session_yolo_toggle: keybind("ctrl+y", "Toggle YOLO mode for this session"),
   session_quick_switch_1: keybind("<leader>1", "Switch to session in quick slot 1"),
   session_quick_switch_2: keybind("<leader>2", "Switch to session in quick slot 2"),
   session_quick_switch_3: keybind("<leader>3", "Switch to session in quick slot 3"),
@@ -310,6 +312,8 @@ export const CommandMap = {
   session_child_cycle_reverse: "session.child.previous",
   session_parent: "session.parent",
   session_pin_toggle: "session.pin.toggle",
+  // altimate_change - yolo mode
+  session_yolo_toggle: "session.yolo.toggle",
   session_quick_switch_1: "session.quick_switch.1",
   session_quick_switch_2: "session.quick_switch.2",
   session_quick_switch_3: "session.quick_switch.3",

--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -102,8 +102,9 @@ export const Definitions = {
   session_child_cycle_reverse: keybind("left", "Go to previous child session"),
   session_parent: keybind("up", "Go to parent session"),
   session_pin_toggle: keybind("ctrl+f", "Pin or unpin session in the session list"),
-  // altimate_change - yolo mode: enabling asks for confirmation, disabling is immediate
+  // altimate_change start — yolo mode: enabling asks for confirmation, disabling is immediate
   session_yolo_toggle: keybind("ctrl+y", "Toggle YOLO mode for this session"),
+  // altimate_change end
   session_quick_switch_1: keybind("<leader>1", "Switch to session in quick slot 1"),
   session_quick_switch_2: keybind("<leader>2", "Switch to session in quick slot 2"),
   session_quick_switch_3: keybind("<leader>3", "Switch to session in quick slot 3"),
@@ -312,8 +313,9 @@ export const CommandMap = {
   session_child_cycle_reverse: "session.child.previous",
   session_parent: "session.parent",
   session_pin_toggle: "session.pin.toggle",
-  // altimate_change - yolo mode
+  // altimate_change start — yolo mode
   session_yolo_toggle: "session.yolo.toggle",
+  // altimate_change end
   session_quick_switch_1: "session.quick_switch.1",
   session_quick_switch_2: "session.quick_switch.2",
   session_quick_switch_3: "session.quick_switch.3",

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -360,9 +360,10 @@ export const {
           void bootstrap()
           break
         case "permission.replied": {
-          // altimate_change — was inline; shares removePermission with the yolo
+          // altimate_change start — was inline; shares removePermission with the yolo
           // auto-approve path so the removal logic exists in one place.
           removePermission(event.properties.sessionID, event.properties.requestID)
+          // altimate_change end
           break
         }
 

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -233,26 +233,86 @@ export const {
     }
 
     // altimate_change start - yolo mode scoping. The rules (root-session normalization
-    // so subagents inherit, and explicit-choice-beats---yolo) live in util/yolo.ts so
-    // they are unit-testable without a renderer; these are thin bindings to the store.
-    const parentOf = (sessionID: string) => result.session.get(sessionID)?.parentID
+    // so subagents inherit, explicit-choice-beats---yolo, and fail-closed on an
+    // unresolvable chain) live in util/yolo.ts so they are unit-testable without a
+    // renderer; these are thin bindings to the store.
+    const getSessionNode = (sessionID: string) => result.session.get(sessionID)
 
-    function rootSessionID(sessionID: string): string {
-      return Yolo.rootSessionID(sessionID, parentOf)
+    function rootSessionID(sessionID: string): string | undefined {
+      return Yolo.resolveRoot(sessionID, getSessionNode)
     }
 
-    // A welcome-screen choice acts as the fallback until a session adopts it.
+    // The process-wide default ONLY. A welcome-screen (pending) choice deliberately does
+    // NOT feed this: it belongs to the session about to be created, and letting it act as
+    // a fallback would auto-approve for every other undecided session — including one
+    // still streaming in the background after `session.new` navigated away from it.
     function yoloFallback(): boolean {
-      return store.yolo_pending ?? Flag.ALTIMATE_CLI_YOLO
+      return Flag.ALTIMATE_CLI_YOLO
     }
 
     function yoloEnabled(sessionID: string): boolean {
       return Yolo.yoloEnabled({
         sessionID,
         overrides: store.yolo,
-        parentOf,
+        getSession: getSessionNode,
         fallback: yoloFallback(),
       })
+    }
+
+    // Insert a permission request into the store so the normal prompt renders. Extracted
+    // from the permission.asked handler so the yolo path can fall back to it.
+    function enqueuePermission(request: PermissionRequest) {
+      const requests = store.permission[request.sessionID]
+      if (!requests) {
+        setStore("permission", request.sessionID, [request])
+        return
+      }
+      const match = search(requests, request.id, (r) => r.id)
+      if (match.found) {
+        setStore("permission", request.sessionID, match.index, reconcile(request))
+        return
+      }
+      setStore(
+        "permission",
+        request.sessionID,
+        produce((draft) => {
+          draft.splice(match.index, 0, request)
+        }),
+      )
+    }
+
+    // Auto-approve on behalf of the user. MUST fail loudly: the handler does not enqueue
+    // the request, so if the reply is lost the server-side Deferred in Permission.ask
+    // never settles and the agent hangs with nothing on screen explaining why.
+    //
+    // `throwOnError: true` is required — the generated SDK client defaults to returning
+    // `{ error }` rather than throwing (packages/sdk/js/src/gen/client/client.gen.ts), so
+    // a plain `.catch()` here would never fire on an ordinary HTTP failure.
+    async function autoApprove(request: PermissionRequest, workspace?: string) {
+      try {
+        await sdk.client.permission.reply(
+          { requestID: request.id, reply: "once", workspace },
+          { throwOnError: true },
+        )
+      } catch (e) {
+        console.error("yolo mode auto-approve failed", {
+          error: e instanceof Error ? e.message : String(e),
+          requestID: request.id,
+        })
+        // Fall back to asking the user rather than silently swallowing the request.
+        enqueuePermission(request)
+      }
+    }
+
+    // Enabling yolo while a prompt is already on screen must clear that prompt too.
+    // Without this, the most natural moment to press ctrl+y — the agent is blocked
+    // asking for approval — shows "YOLO ON" next to a still-blocked agent.
+    function flushPendingPermissions(root: string, workspace?: string) {
+      for (const [sessionID, requests] of Object.entries(store.permission)) {
+        if (!requests?.length) continue
+        if (rootSessionID(sessionID) !== root) continue
+        for (const request of [...requests]) void autoApprove(request, workspace)
+      }
     }
     // altimate_change end
 
@@ -288,38 +348,11 @@ export const {
           // event for a "deny" match, so configured guardrails (DROP DATABASE, DROP
           // SCHEMA, TRUNCATE) never reach this handler and cannot be auto-approved.
           if (yoloEnabled(request.sessionID)) {
-            void sdk.client.permission
-              .reply({
-                requestID: request.id,
-                reply: "once",
-                workspace,
-              })
-              .catch((e) => {
-                console.error("yolo mode auto-approve failed", {
-                  error: e instanceof Error ? e.message : String(e),
-                  requestID: request.id,
-                })
-              })
+            void autoApprove(request, workspace)
             break
           }
           // altimate_change end
-          const requests = store.permission[request.sessionID]
-          if (!requests) {
-            setStore("permission", request.sessionID, [request])
-            break
-          }
-          const match = search(requests, request.id, (r) => r.id)
-          if (match.found) {
-            setStore("permission", request.sessionID, match.index, reconcile(request))
-            break
-          }
-          setStore(
-            "permission",
-            request.sessionID,
-            produce((draft) => {
-              draft.splice(match.index, 0, request)
-            }),
-          )
+          enqueuePermission(request)
           break
         }
 
@@ -379,6 +412,16 @@ export const {
               }),
             )
           }
+          // altimate_change - yolo mode: drop the override with the session. Harmless
+          // today (ids are unique, so a stale entry cannot be re-matched) but a stale
+          // `true` outliving its session is exactly what turns into a bug if this map
+          // ever gains persistence.
+          setStore(
+            "yolo",
+            produce((draft) => {
+              delete draft[event.properties.info.id]
+            }),
+          )
           break
         }
         case "session.updated": {
@@ -754,26 +797,44 @@ export const {
       // --yolo default for free; reactivity comes from the underlying store.
       yolo: {
         // sessionID is optional so the welcome screen (no session yet) can read and
-        // set the mode with the same API the session view uses.
+        // set the mode with the same API the session view uses. With no session this
+        // reports the PENDING choice — a display value only; it never influences the
+        // decision made for any real session.
         enabled(sessionID?: string) {
-          if (!sessionID) return yoloFallback()
+          if (!sessionID) return store.yolo_pending ?? Flag.ALTIMATE_CLI_YOLO
           return yoloEnabled(sessionID)
         },
-        set(sessionID: string | undefined, value: boolean) {
+        set(sessionID: string | undefined, value: boolean, workspace?: string) {
           if (!sessionID) {
             setStore("yolo_pending", value)
             return
           }
-          setStore("yolo", rootSessionID(sessionID), value)
+          // An unresolvable chain still has to be settable — key it by the id we were
+          // given so the user's explicit choice is recorded somewhere.
+          const root = rootSessionID(sessionID) ?? sessionID
+          setStore("yolo", root, value)
+          if (value) flushPendingPermissions(root, workspace)
         },
-        // Hand a pre-session choice to the first session that appears, then clear it.
-        // Never overwrites an explicit choice already made for that session.
+        // Hand a pre-session choice to the session that was just CREATED, then clear it.
+        // Deliberately called from the creation path rather than from a route effect:
+        // a route effect fires on any navigation into a session, so resuming an old
+        // conversation after a welcome-screen enable would silently yolo that one.
         adopt(sessionID: string) {
           const pending = store.yolo_pending
           if (pending === undefined) return
-          const root = rootSessionID(sessionID)
+          const root = rootSessionID(sessionID) ?? sessionID
           if (store.yolo[root] === undefined) setStore("yolo", root, pending)
           setStore("yolo_pending", undefined)
+        },
+        // Drop state for a session that no longer exists.
+        forget(sessionID: string) {
+          if (store.yolo[sessionID] === undefined) return
+          setStore(
+            "yolo",
+            produce((draft) => {
+              delete draft[sessionID]
+            }),
+          )
         },
       },
       // altimate_change end

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -33,6 +33,7 @@ import path from "path"
 import { useKV } from "./kv"
 // altimate_change start - yolo mode + smooth streaming
 import { Flag } from "@opencode-ai/core/flag/flag"
+import * as Yolo from "../util/yolo"
 // altimate_change end
 
 const emptyConsoleState: ConsoleState = {
@@ -77,6 +78,19 @@ export const {
       permission: {
         [sessionID: string]: PermissionRequest[]
       }
+      // altimate_change start - yolo mode: per-session override, keyed by ROOT session.
+      // Absent = inherit the process-wide Flag.ALTIMATE_CLI_YOLO default (set by --yolo);
+      // present = explicit user choice for this session, which can turn a globally
+      // enabled yolo back off. Deliberately in-memory only: yolo must never survive a
+      // restart, or resuming an old session would silently reinstate it.
+      yolo: {
+        [sessionID: string]: boolean
+      }
+      // Choice made on the welcome screen, before any session exists. Adopted by the
+      // first session created and then cleared, so it does NOT become a process-wide
+      // default that silently yolos every later session ("current session only").
+      yolo_pending: boolean | undefined
+      // altimate_change end
       question: {
         [sessionID: string]: QuestionRequest[]
       }
@@ -128,6 +142,9 @@ export const {
       status: "loading",
       agent: [],
       permission: {},
+      // altimate_change - yolo mode: per-session override map (see type above)
+      yolo: {},
+      yolo_pending: undefined,
       question: {},
       command: [],
       provider: [],
@@ -215,6 +232,30 @@ export const {
         .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
     }
 
+    // altimate_change start - yolo mode scoping. The rules (root-session normalization
+    // so subagents inherit, and explicit-choice-beats---yolo) live in util/yolo.ts so
+    // they are unit-testable without a renderer; these are thin bindings to the store.
+    const parentOf = (sessionID: string) => result.session.get(sessionID)?.parentID
+
+    function rootSessionID(sessionID: string): string {
+      return Yolo.rootSessionID(sessionID, parentOf)
+    }
+
+    // A welcome-screen choice acts as the fallback until a session adopts it.
+    function yoloFallback(): boolean {
+      return store.yolo_pending ?? Flag.ALTIMATE_CLI_YOLO
+    }
+
+    function yoloEnabled(sessionID: string): boolean {
+      return Yolo.yoloEnabled({
+        sessionID,
+        overrides: store.yolo,
+        parentOf,
+        fallback: yoloFallback(),
+      })
+    }
+    // altimate_change end
+
     event.subscribe((event, { workspace }) => {
       switch (event.type) {
         case "server.instance.disposed":
@@ -237,8 +278,16 @@ export const {
 
         case "permission.asked": {
           const request = event.properties
-          // altimate_change start - yolo mode: auto-approve without showing prompt
-          if (Flag.ALTIMATE_CLI_YOLO) {
+          // altimate_change start - yolo mode: auto-approve without showing prompt.
+          // Scoped to the request's root session so a subagent's own child session
+          // inherits the choice the user made on the conversation they can actually see.
+          //
+          // Safety note: this can only ever answer requests the SERVER already decided
+          // to ask about. Permission.ask (packages/opencode/src/permission/index.ts)
+          // evaluates the ruleset first and returns DeniedError without emitting any
+          // event for a "deny" match, so configured guardrails (DROP DATABASE, DROP
+          // SCHEMA, TRUNCATE) never reach this handler and cannot be auto-approved.
+          if (yoloEnabled(request.sessionID)) {
             void sdk.client.permission
               .reply({
                 requestID: request.id,
@@ -700,6 +749,34 @@ export const {
       get path() {
         return project.instance.path()
       },
+      // altimate_change start - yolo mode: per-session toggle surfaced to the TUI.
+      // Reads go through yoloEnabled() so callers get root-session semantics and the
+      // --yolo default for free; reactivity comes from the underlying store.
+      yolo: {
+        // sessionID is optional so the welcome screen (no session yet) can read and
+        // set the mode with the same API the session view uses.
+        enabled(sessionID?: string) {
+          if (!sessionID) return yoloFallback()
+          return yoloEnabled(sessionID)
+        },
+        set(sessionID: string | undefined, value: boolean) {
+          if (!sessionID) {
+            setStore("yolo_pending", value)
+            return
+          }
+          setStore("yolo", rootSessionID(sessionID), value)
+        },
+        // Hand a pre-session choice to the first session that appears, then clear it.
+        // Never overwrites an explicit choice already made for that session.
+        adopt(sessionID: string) {
+          const pending = store.yolo_pending
+          if (pending === undefined) return
+          const root = rootSessionID(sessionID)
+          if (store.yolo[root] === undefined) setStore("yolo", root, pending)
+          setStore("yolo_pending", undefined)
+        },
+      },
+      // altimate_change end
       session: {
         get(sessionID: string) {
           const match = search(store.session, sessionID, (s) => s.id)

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -142,9 +142,10 @@ export const {
       status: "loading",
       agent: [],
       permission: {},
-      // altimate_change - yolo mode: per-session override map (see type above)
+      // altimate_change start — yolo mode: per-session override map (see type above)
       yolo: {},
       yolo_pending: undefined,
+      // altimate_change end
       question: {},
       command: [],
       provider: [],
@@ -351,8 +352,10 @@ export const {
             void autoApprove(request, workspace)
             break
           }
-          // altimate_change end
+          // Upstream inlined the store insertion here; extracted to enqueuePermission so
+          // the yolo path can fall back to it when an auto-approve reply fails.
           enqueuePermission(request)
+          // altimate_change end
           break
         }
 
@@ -412,16 +415,17 @@ export const {
               }),
             )
           }
-          // altimate_change - yolo mode: drop the override with the session. Harmless
-          // today (ids are unique, so a stale entry cannot be re-matched) but a stale
-          // `true` outliving its session is exactly what turns into a bug if this map
-          // ever gains persistence.
+          // altimate_change start — yolo mode: drop the override with the session.
+          // Harmless today (ids are unique, so a stale entry cannot be re-matched) but a
+          // stale `true` outliving its session is exactly what turns into a bug if this
+          // map ever gains persistence.
           setStore(
             "yolo",
             produce((draft) => {
               delete draft[event.properties.info.id]
             }),
           )
+          // altimate_change end
           break
         }
         case "session.updated": {

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -360,17 +360,9 @@ export const {
           void bootstrap()
           break
         case "permission.replied": {
-          const requests = store.permission[event.properties.sessionID]
-          if (!requests) break
-          const match = search(requests, event.properties.requestID, (r) => r.id)
-          if (!match.found) break
-          setStore(
-            "permission",
-            event.properties.sessionID,
-            produce((draft) => {
-              draft.splice(match.index, 1)
-            }),
-          )
+          // altimate_change — was inline; shares removePermission with the yolo
+          // auto-approve path so the removal logic exists in one place.
+          removePermission(event.properties.sessionID, event.properties.requestID)
           break
         }
 
@@ -866,16 +858,6 @@ export const {
           const root = rootSessionID(sessionID) ?? sessionID
           if (store.yolo[root] === undefined) setStore("yolo", root, pending)
           setStore("yolo_pending", undefined)
-        },
-        // Drop state for a session that no longer exists.
-        forget(sessionID: string) {
-          if (store.yolo[sessionID] === undefined) return
-          setStore(
-            "yolo",
-            produce((draft) => {
-              delete draft[sessionID]
-            }),
-          )
         },
       },
       // altimate_change end

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -282,6 +282,30 @@ export const {
       )
     }
 
+    // Remove a settled permission request from the store. Idempotent — both the
+    // `permission.replied` event and a successful auto-approve call it.
+    function removePermission(sessionID: string, requestID: string) {
+      const requests = store.permission[sessionID]
+      if (!requests?.length) return
+      const match = search(requests, requestID, (r) => r.id)
+      if (!match.found) return
+      setStore(
+        "permission",
+        sessionID,
+        produce((draft) => {
+          draft.splice(match.index, 1)
+        }),
+      )
+    }
+
+    // Requests currently being auto-approved. A reply is not removed from
+    // store.permission until the server's `permission.replied` event lands, so without
+    // this a second flush (toggle off then on again, or two set() calls) would reply to
+    // the same request twice. The second reply targets an already-settled request, the
+    // server rejects it, and the rejection would be misread as a lost reply — putting a
+    // prompt back on screen for something already answered.
+    const autoApproving = new Set<string>()
+
     // Auto-approve on behalf of the user. MUST fail loudly: the handler does not enqueue
     // the request, so if the reply is lost the server-side Deferred in Permission.ask
     // never settles and the agent hangs with nothing on screen explaining why.
@@ -289,12 +313,23 @@ export const {
     // `throwOnError: true` is required — the generated SDK client defaults to returning
     // `{ error }` rather than throwing (packages/sdk/js/src/gen/client/client.gen.ts), so
     // a plain `.catch()` here would never fire on an ordinary HTTP failure.
+    //
+    // The workspace is read here rather than taken from callers: the session permission
+    // UI passes `project.workspace.current()` on every reply, and threading it through
+    // each call site is exactly how it went missing on the flush path.
     async function autoApprove(request: PermissionRequest, workspace?: string) {
+      if (autoApproving.has(request.id)) return
+      autoApproving.add(request.id)
       try {
         await sdk.client.permission.reply(
-          { requestID: request.id, reply: "once", workspace },
+          { requestID: request.id, reply: "once", workspace: workspace ?? project.workspace.current() },
           { throwOnError: true },
         )
+        // Drop it now rather than waiting for the server's `permission.replied` event.
+        // The in-flight set above only covers concurrent duplicates; a later flush (toggle
+        // off, then on again) would still find the request sitting in the store and reply
+        // to an already-settled id. The event handler's removal is idempotent.
+        removePermission(request.sessionID, request.id)
       } catch (e) {
         console.error("yolo mode auto-approve failed", {
           error: e instanceof Error ? e.message : String(e),
@@ -302,6 +337,8 @@ export const {
         })
         // Fall back to asking the user rather than silently swallowing the request.
         enqueuePermission(request)
+      } finally {
+        autoApproving.delete(request.id)
       }
     }
 

--- a/packages/tui/src/routes/session/footer.tsx
+++ b/packages/tui/src/routes/session/footer.tsx
@@ -5,6 +5,9 @@ import { useDirectory } from "../../context/directory"
 import { useConnected } from "../../component/use-connected"
 import { createStore } from "solid-js/store"
 import { useRoute } from "../../context/route"
+// altimate_change start - yolo mode visual indicator
+import { Flag } from "@opencode-ai/core/flag/flag"
+// altimate_change end
 // altimate_change start - upgrade indicator in session footer
 import { UpgradeIndicator } from "../../component/upgrade-indicator"
 // altimate_change end
@@ -20,11 +23,6 @@ export function Footer() {
     if (route.data.type !== "session") return []
     return sync.data.permission[route.data.sessionID] ?? []
   })
-  // altimate_change start - yolo mode visual indicator, now per-session and reactive.
-  // Previously read Flag.ALTIMATE_CLI_YOLO directly, which is a plain process.env getter
-  // and therefore never re-rendered when the mode changed.
-  const yolo = createMemo(() => sync.yolo.enabled(route.data.type === "session" ? route.data.sessionID : undefined))
-  // altimate_change end
   const directory = useDirectory()
   const connected = useConnected()
 
@@ -69,9 +67,9 @@ export function Footer() {
           </Match>
           <Match when={connected()}>
             {/* altimate_change start - yolo mode visual indicator */}
-            <Show when={yolo()}>
+            <Show when={Flag.ALTIMATE_CLI_YOLO}>
               <text fg={theme.warning}>
-                <span style={{ fg: theme.warning }}>△</span> YOLO ON
+                <span style={{ fg: theme.warning }}>△</span> YOLO
               </text>
             </Show>
             {/* altimate_change end */}

--- a/packages/tui/src/routes/session/footer.tsx
+++ b/packages/tui/src/routes/session/footer.tsx
@@ -5,9 +5,6 @@ import { useDirectory } from "../../context/directory"
 import { useConnected } from "../../component/use-connected"
 import { createStore } from "solid-js/store"
 import { useRoute } from "../../context/route"
-// altimate_change start - yolo mode visual indicator
-import { Flag } from "@opencode-ai/core/flag/flag"
-// altimate_change end
 // altimate_change start - upgrade indicator in session footer
 import { UpgradeIndicator } from "../../component/upgrade-indicator"
 // altimate_change end
@@ -23,6 +20,11 @@ export function Footer() {
     if (route.data.type !== "session") return []
     return sync.data.permission[route.data.sessionID] ?? []
   })
+  // altimate_change start - yolo mode visual indicator, now per-session and reactive.
+  // Previously read Flag.ALTIMATE_CLI_YOLO directly, which is a plain process.env getter
+  // and therefore never re-rendered when the mode changed.
+  const yolo = createMemo(() => sync.yolo.enabled(route.data.type === "session" ? route.data.sessionID : undefined))
+  // altimate_change end
   const directory = useDirectory()
   const connected = useConnected()
 
@@ -67,9 +69,9 @@ export function Footer() {
           </Match>
           <Match when={connected()}>
             {/* altimate_change start - yolo mode visual indicator */}
-            <Show when={Flag.ALTIMATE_CLI_YOLO}>
+            <Show when={yolo()}>
               <text fg={theme.warning}>
-                <span style={{ fg: theme.warning }}>△</span> YOLO
+                <span style={{ fg: theme.warning }}>△</span> YOLO ON
               </text>
             </Show>
             {/* altimate_change end */}

--- a/packages/tui/src/util/yolo.ts
+++ b/packages/tui/src/util/yolo.ts
@@ -1,0 +1,49 @@
+// altimate_change — YOLO mode scoping rules, kept pure so they can be tested
+// without standing up the sync context or a renderer.
+//
+// Two rules, both load-bearing:
+//
+// 1. Yolo is a property of the conversation the user turned it on in. Subagents
+//    spawned by the task tool run in their own CHILD session
+//    (packages/opencode/src/tool/task.ts creates one with parentID), so their
+//    permission requests arrive tagged with the child id. Every lookup therefore
+//    normalizes to the root ancestor, or enabling yolo would appear to do nothing
+//    the moment the agent delegated work.
+//
+// 2. An explicit per-session choice beats the process-wide default. That default
+//    comes from `--yolo` / ALTIMATE_CLI_YOLO. Without rule 2, a user who launched
+//    with --yolo could never turn it off from the TUI, which the ctrl+y contract
+//    requires ("allow users to disable it without confirmation").
+
+/** Walk a session to the root of its parent chain. */
+export function rootSessionID(sessionID: string, parentOf: (sessionID: string) => string | undefined): string {
+  let current = sessionID
+  const seen = new Set<string>([current])
+  // Depth cap AND cycle detection: this runs on the permission-event hot path, and
+  // a malformed parent chain (self-parent, or a cycle introduced by a bad restore)
+  // must not spin forever.
+  for (let depth = 0; depth < MAX_PARENT_DEPTH; depth++) {
+    const parentID = parentOf(current)
+    if (!parentID || seen.has(parentID)) return current
+    seen.add(parentID)
+    current = parentID
+  }
+  return current
+}
+
+export const MAX_PARENT_DEPTH = 32
+
+/**
+ * Resolve whether yolo is active for the session a permission request came from.
+ *
+ * `overrides` is keyed by ROOT session id; `fallback` is the process-wide default.
+ */
+export function yoloEnabled(input: {
+  sessionID: string
+  overrides: Record<string, boolean | undefined>
+  parentOf: (sessionID: string) => string | undefined
+  fallback: boolean
+}): boolean {
+  const root = rootSessionID(input.sessionID, input.parentOf)
+  return input.overrides[root] ?? input.fallback
+}

--- a/packages/tui/src/util/yolo.ts
+++ b/packages/tui/src/util/yolo.ts
@@ -1,7 +1,7 @@
 // altimate_change — YOLO mode scoping rules, kept pure so they can be tested
 // without standing up the sync context or a renderer.
 //
-// Two rules, both load-bearing:
+// Three rules, all load-bearing:
 //
 // 1. Yolo is a property of the conversation the user turned it on in. Subagents
 //    spawned by the task tool run in their own CHILD session
@@ -14,36 +14,59 @@
 //    comes from `--yolo` / ALTIMATE_CLI_YOLO. Without rule 2, a user who launched
 //    with --yolo could never turn it off from the TUI, which the ctrl+y contract
 //    requires ("allow users to disable it without confirmation").
+//
+// 3. An unresolvable session FAILS CLOSED. The parent chain is resolved against
+//    the TUI's session store, which is populated by events and can lag behind a
+//    permission request for a freshly created child. If we cannot prove which root
+//    a request belongs to, we must not auto-approve it — otherwise a request whose
+//    root the user explicitly turned OFF would miss that override and inherit a
+//    `--yolo` fallback of true. Failing closed only ever costs a prompt.
 
-/** Walk a session to the root of its parent chain. */
-export function rootSessionID(sessionID: string, parentOf: (sessionID: string) => string | undefined): string {
+export const MAX_PARENT_DEPTH = 32
+
+export type SessionNode = { readonly parentID?: string }
+
+/**
+ * Resolve a session to the root of its parent chain.
+ *
+ * Returns `undefined` when the chain cannot be resolved: an unknown session
+ * anywhere in the chain, or a chain longer than MAX_PARENT_DEPTH (which also
+ * covers a cycle introduced by a bad restore). Callers must treat `undefined`
+ * as "do not auto-approve".
+ */
+export function resolveRoot(
+  sessionID: string,
+  getSession: (sessionID: string) => SessionNode | undefined,
+): string | undefined {
   let current = sessionID
   const seen = new Set<string>([current])
-  // Depth cap AND cycle detection: this runs on the permission-event hot path, and
-  // a malformed parent chain (self-parent, or a cycle introduced by a bad restore)
-  // must not spin forever.
   for (let depth = 0; depth < MAX_PARENT_DEPTH; depth++) {
-    const parentID = parentOf(current)
+    const session = getSession(current)
+    // Unknown session: we cannot tell a true root from an unhydrated child.
+    if (!session) return undefined
+    const parentID = session.parentID
     if (!parentID || seen.has(parentID)) return current
     seen.add(parentID)
     current = parentID
   }
-  return current
+  return undefined
 }
-
-export const MAX_PARENT_DEPTH = 32
 
 /**
  * Resolve whether yolo is active for the session a permission request came from.
  *
- * `overrides` is keyed by ROOT session id; `fallback` is the process-wide default.
+ * `overrides` is keyed by ROOT session id. `fallback` is the process-wide default
+ * (`--yolo`) and must NOT carry any pre-session/pending choice — a pending choice
+ * belongs to the session about to be created, not to every session that happens to
+ * have no explicit override.
  */
 export function yoloEnabled(input: {
   sessionID: string
   overrides: Record<string, boolean | undefined>
-  parentOf: (sessionID: string) => string | undefined
+  getSession: (sessionID: string) => SessionNode | undefined
   fallback: boolean
 }): boolean {
-  const root = rootSessionID(input.sessionID, input.parentOf)
+  const root = resolveRoot(input.sessionID, input.getSession)
+  if (root === undefined) return false
   return input.overrides[root] ?? input.fallback
 }

--- a/packages/tui/src/util/yolo.ts
+++ b/packages/tui/src/util/yolo.ts
@@ -45,7 +45,11 @@ export function resolveRoot(
     // Unknown session: we cannot tell a true root from an unhydrated child.
     if (!session) return undefined
     const parentID = session.parentID
-    if (!parentID || seen.has(parentID)) return current
+    if (!parentID) return current
+    // A cycle means no root exists. Returning the node we happened to stop on would
+    // treat a malformed chain as a valid root and let it inherit `--yolo` or an override
+    // keyed on that node — the same fail-open shape the unknown-session case guards.
+    if (seen.has(parentID)) return undefined
     seen.add(parentID)
     current = parentID
   }

--- a/packages/tui/test/cli/cmd/tui/sync-fixture.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-fixture.tsx
@@ -2,6 +2,10 @@
 import { testRender } from "@opentui/solid"
 import { onMount } from "solid-js"
 import { ArgsProvider } from "../../../../src/context/args"
+// altimate_change - SyncProvider calls useExit(). Without this provider every test in
+// this harness failed with "Exit context must be used within a context provider", which
+// is why the three pre-existing `tui sync` tests were red on main.
+import { ExitProvider } from "../../../../src/context/exit"
 import { KVProvider, useKV } from "../../../../src/context/kv"
 import { ProjectProvider, useProject } from "../../../../src/context/project"
 import { SDKProvider } from "../../../../src/context/sdk"
@@ -45,15 +49,17 @@ export async function mount(override?: FetchHandler, state?: string) {
   const app = await testRender(() => (
     <TestTuiContexts paths={state ? { state } : undefined}>
       <ArgsProvider>
-        <KVProvider>
-          <SDKProvider url="http://test" directory={directory} fetch={calls.fetch} events={events.source}>
-            <ProjectProvider>
-              <SyncProvider>
-                <Probe />
-              </SyncProvider>
-            </ProjectProvider>
-          </SDKProvider>
-        </KVProvider>
+        <ExitProvider exit={() => {}}>
+          <KVProvider>
+            <SDKProvider url="http://test" directory={directory} fetch={calls.fetch} events={events.source}>
+              <ProjectProvider>
+                <SyncProvider>
+                  <Probe />
+                </SyncProvider>
+              </ProjectProvider>
+            </SDKProvider>
+          </KVProvider>
+        </ExitProvider>
       </ArgsProvider>
     </TestTuiContexts>
   ))

--- a/packages/tui/test/cli/cmd/tui/yolo-sync.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/yolo-sync.test.tsx
@@ -220,6 +220,32 @@ describe("tui sync: yolo auto-approve", () => {
     }
   })
 
+  // Regression: flushPendingPermissions does not remove requests from the store — that
+  // waits for the server's permission.replied event. Toggling off and on again, or two
+  // set() calls, would otherwise reply to the same request twice; the server rejects the
+  // second, autoApprove misreads the rejection as a lost reply, and a prompt reappears
+  // for a request that was already answered.
+  test("enabling twice does not reply to the same request twice", async () => {
+    const { app, emit, sync, replies, tmp } = await setup()
+    try {
+      emit(askEvent(ROOT, "perm_1"))
+      await wait(() => pending(sync, ROOT).length === 1)
+
+      sync.yolo.set(ROOT, true)
+      await wait(() => replies.length === 1)
+      // Second enable while the first reply is still settling.
+      sync.yolo.set(ROOT, true)
+      await Bun.sleep(300)
+
+      expect(replies).toHaveLength(1)
+      // And no phantom prompt got re-inserted.
+      expect(pending(sync, ROOT)).toHaveLength(0)
+    } finally {
+      app.renderer.destroy()
+      await tmp[Symbol.asyncDispose]()
+    }
+  })
+
   test("deleting a session drops its yolo override", async () => {
     const { app, emit, sync, tmp } = await setup()
     try {

--- a/packages/tui/test/cli/cmd/tui/yolo-sync.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/yolo-sync.test.tsx
@@ -79,7 +79,12 @@ function askEvent(sessionID: string, id: string): GlobalEvent {
 const REPLY = /^\/permission\/[^/]+\/reply$/
 
 /** Mount with a known session list and a recorder for permission replies. */
-async function setup(options?: { sessions?: ReturnType<typeof sessionRow>[]; failReply?: boolean }) {
+async function setup(options?: {
+  sessions?: ReturnType<typeof sessionRow>[]
+  failReply?: boolean
+  /** Hold the reply open so a second toggle lands while the first is still in flight. */
+  replyDelayMs?: number
+}) {
   const replies: string[] = []
   const sessions = options?.sessions ?? [sessionRow(ROOT)]
   const tmp = await tmpdir()
@@ -88,8 +93,10 @@ async function setup(options?: { sessions?: ReturnType<typeof sessionRow>[]; fai
     if (url.pathname === "/session") return json(sessions)
     if (REPLY.test(url.pathname)) {
       replies.push(url.pathname)
-      if (options?.failReply) return json({ error: "boom" }, { status: 500 })
-      return json({})
+      const respond = () => (options?.failReply ? json({ error: "boom" }, { status: 500 }) : json({}))
+      // Returning a pending promise (rather than an async fn) keeps the handler's
+      // return type `Response | Promise<Response> | undefined`.
+      return options?.replyDelayMs ? Bun.sleep(options.replyDelayMs).then(respond) : respond()
     }
     return undefined
   }, tmp.path)
@@ -230,20 +237,24 @@ describe("tui sync: yolo auto-approve", () => {
   // second, autoApprove misreads the rejection as a lost reply, and a prompt reappears
   // for a request that was already answered.
   test("enabling twice does not reply to the same request twice", async () => {
-    const { app, emit, sync, replies, tmp } = await setup()
+    // The reply is held open so the second toggle genuinely lands while the first is
+    // in flight. With an instant mock the store is already cleared by the time the
+    // second set() runs, so the second flush is a no-op and the in-flight guard is
+    // never exercised — the test would pass without testing anything.
+    const { app, emit, sync, replies, tmp } = await setup({ replyDelayMs: 250 })
     try {
       emit(askEvent(ROOT, "perm_1"))
       await wait(() => pending(sync, ROOT).length === 1)
 
       sync.yolo.set(ROOT, true)
       await wait(() => replies.length === 1)
-      // Second enable while the first reply is still settling.
+      // Still in flight here: the request has not been removed yet.
+      expect(pending(sync, ROOT)).toHaveLength(1)
       sync.yolo.set(ROOT, true)
-      await Bun.sleep(300)
 
+      await wait(() => pending(sync, ROOT).length === 0)
+      await Bun.sleep(200)
       expect(replies).toHaveLength(1)
-      // And no phantom prompt got re-inserted.
-      expect(pending(sync, ROOT)).toHaveLength(0)
     } finally {
       app.renderer.destroy()
       await tmp[Symbol.asyncDispose]()

--- a/packages/tui/test/cli/cmd/tui/yolo-sync.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/yolo-sync.test.tsx
@@ -214,6 +214,10 @@ describe("tui sync: yolo auto-approve", () => {
       await wait(() => pending(sync, ROOT).length === 1)
       sync.yolo.set(ROOT, true)
       await wait(() => replies.length === 1)
+      // Assert the behaviour in the test's name, not just that a reply went out: the
+      // prompt must actually leave the screen. autoApprove removes it optimistically on
+      // success, so this does not depend on the server's permission.replied event.
+      await wait(() => pending(sync, ROOT).length === 0)
     } finally {
       app.renderer.destroy()
       await tmp[Symbol.asyncDispose]()

--- a/packages/tui/test/cli/cmd/tui/yolo-sync.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/yolo-sync.test.tsx
@@ -1,0 +1,285 @@
+/** @jsxImportSource @opentui/solid */
+// altimate_change — in-process coverage for the YOLO auto-approve path.
+//
+// The real-binary journeys under packages/opencode/test/tui-journeys are the richer
+// tests, but they are gated on OPENCODE_TEST_CLI + tmux and CI deliberately does not
+// set them (see the note in .github/workflows/ci.yml). Everything in this file runs
+// on every PR, so the security-relevant invariants actually gate the merge:
+//
+//   - an enabled session auto-approves; a disabled one does not
+//   - a failed reply falls back to prompting instead of dropping the request
+//   - subagents inherit via the root session
+//   - an unresolvable session fails CLOSED
+//   - a pre-session (pending) choice never leaks into other sessions
+//   - enabling clears prompts that are already on screen
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { tmpdir } from "../../../fixture/fixture"
+import { json, mount, wait } from "./sync-fixture"
+import type { GlobalEvent } from "@opencode-ai/sdk/v2"
+
+// Pin the process-wide default. Flag.ALTIMATE_CLI_YOLO reads process.env at access time,
+// so without this the suite inherits whatever the developer's shell exports — yolo is a
+// common local default, and it silently inverts the expected starting state (every
+// "should not auto-approve" case would auto-approve). CI leaves it unset, so this is
+// also what keeps local and CI behaviour identical.
+const FLAG = "ALTIMATE_CLI_YOLO"
+let previousFlag: string | undefined
+
+beforeEach(() => {
+  previousFlag = process.env[FLAG]
+  process.env[FLAG] = "false"
+})
+
+afterEach(() => {
+  if (previousFlag === undefined) delete process.env[FLAG]
+  else process.env[FLAG] = previousFlag
+})
+
+const ROOT = "ses_root"
+const CHILD = "ses_child"
+const OTHER = "ses_other"
+
+function sessionRow(id: string, parentID?: string) {
+  return {
+    id,
+    slug: id,
+    projectID: "proj_test",
+    directory: "/tmp/opencode/packages/tui",
+    title: "t",
+    version: "1",
+    parentID,
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    time: { created: 1, updated: 1 },
+  }
+}
+
+function askEvent(sessionID: string, id: string): GlobalEvent {
+  return {
+    directory: "/tmp/opencode/packages/tui",
+    project: "proj_test",
+    payload: {
+      id: `evt_${id}`,
+      type: "permission.asked",
+      properties: {
+        id,
+        sessionID,
+        permission: "bash",
+        patterns: ["rm -rf *"],
+        metadata: {},
+        always: [],
+      },
+    },
+  } as unknown as GlobalEvent
+}
+
+// The runtime path used by sdk.client.permission.reply. Note this differs from the
+// entry in packages/sdk/js/src/gen/sdk.gen.ts — the TUI goes through a different client,
+// so this was taken from an observed request rather than from the generated spec.
+const REPLY = /^\/permission\/[^/]+\/reply$/
+
+/** Mount with a known session list and a recorder for permission replies. */
+async function setup(options?: { sessions?: ReturnType<typeof sessionRow>[]; failReply?: boolean }) {
+  const replies: string[] = []
+  const sessions = options?.sessions ?? [sessionRow(ROOT)]
+  const tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+  const mounted = await mount((url) => {
+    if (url.pathname === "/session") return json(sessions)
+    if (REPLY.test(url.pathname)) {
+      replies.push(url.pathname)
+      if (options?.failReply) return json({ error: "boom" }, { status: 500 })
+      return json({})
+    }
+    return undefined
+  }, tmp.path)
+  return { ...mounted, replies, tmp }
+}
+
+function pending(sync: Awaited<ReturnType<typeof setup>>["sync"], sessionID: string) {
+  return sync.data.permission[sessionID] ?? []
+}
+
+describe("tui sync: yolo auto-approve", () => {
+  test("auto-approves a permission request when yolo is on for the session", async () => {
+    const { app, emit, sync, replies, tmp } = await setup()
+    try {
+      sync.yolo.set(ROOT, true)
+      emit(askEvent(ROOT, "perm_1"))
+      await wait(() => replies.length === 1)
+      expect(pending(sync, ROOT)).toHaveLength(0)
+    } finally {
+      app.renderer.destroy()
+      await tmp[Symbol.asyncDispose]()
+    }
+  })
+
+  test("does not auto-approve when yolo is off — the request is shown instead", async () => {
+    const { app, emit, sync, replies, tmp } = await setup()
+    try {
+      emit(askEvent(ROOT, "perm_1"))
+      await wait(() => pending(sync, ROOT).length === 1)
+      expect(replies).toHaveLength(0)
+    } finally {
+      app.renderer.destroy()
+      await tmp[Symbol.asyncDispose]()
+    }
+  })
+
+  // The silent-drop bug: the handler does not enqueue the request before replying, so a
+  // lost reply leaves the server-side Deferred unresolved and the agent hanging with
+  // nothing on screen. The generated SDK returns `{ error }` instead of throwing unless
+  // `throwOnError` is set, so this also guards that opt-in.
+  test("a failed auto-approve falls back to prompting instead of dropping the request", async () => {
+    const { app, emit, sync, replies, tmp } = await setup({ failReply: true })
+    try {
+      sync.yolo.set(ROOT, true)
+      emit(askEvent(ROOT, "perm_1"))
+      await wait(() => replies.length === 1)
+      await wait(() => pending(sync, ROOT).length === 1)
+      expect(pending(sync, ROOT)[0]?.id).toBe("perm_1")
+    } finally {
+      app.renderer.destroy()
+      await tmp[Symbol.asyncDispose]()
+    }
+  })
+
+  test("a subagent's request is auto-approved via its root session", async () => {
+    const { app, emit, sync, replies, tmp } = await setup({
+      sessions: [sessionRow(ROOT), sessionRow(CHILD, ROOT)],
+    })
+    try {
+      sync.yolo.set(ROOT, true)
+      emit(askEvent(CHILD, "perm_1"))
+      await wait(() => replies.length === 1)
+      expect(pending(sync, CHILD)).toHaveLength(0)
+    } finally {
+      app.renderer.destroy()
+      await tmp[Symbol.asyncDispose]()
+    }
+  })
+
+  test("a request from an unknown session fails closed even with yolo on elsewhere", async () => {
+    const { app, emit, sync, replies, tmp } = await setup()
+    try {
+      sync.yolo.set(ROOT, true)
+      emit(askEvent("ses_ghost", "perm_1"))
+      await wait(() => pending(sync, "ses_ghost").length === 1)
+      expect(replies).toHaveLength(0)
+    } finally {
+      app.renderer.destroy()
+      await tmp[Symbol.asyncDispose]()
+    }
+  })
+
+  // The critical finding: a welcome-screen choice must not auto-approve for a session
+  // that is still running in the background. `session.new` navigates to home while the
+  // previous session keeps streaming, so this is reachable through the normal flow.
+  test("a pre-session choice does NOT auto-approve for an already-running session", async () => {
+    const { app, emit, sync, replies, tmp } = await setup({
+      sessions: [sessionRow(ROOT), sessionRow(OTHER)],
+    })
+    try {
+      sync.yolo.set(undefined, true) // welcome screen: "yolo the session I'm about to start"
+      expect(sync.yolo.enabled()).toBe(true) // shown as on for the welcome screen
+      emit(askEvent(OTHER, "perm_1"))
+      await wait(() => pending(sync, OTHER).length === 1)
+      expect(replies).toHaveLength(0)
+    } finally {
+      app.renderer.destroy()
+      await tmp[Symbol.asyncDispose]()
+    }
+  })
+
+  test("adopt binds a pending choice to one session and clears it", async () => {
+    const { app, sync, tmp } = await setup({ sessions: [sessionRow(ROOT), sessionRow(OTHER)] })
+    try {
+      sync.yolo.set(undefined, true)
+      sync.yolo.adopt(ROOT)
+      expect(sync.yolo.enabled(ROOT)).toBe(true)
+      // Cleared, so a later session (e.g. one resumed from the session list) is untouched.
+      expect(sync.yolo.enabled(OTHER)).toBe(false)
+      sync.yolo.adopt(OTHER)
+      expect(sync.yolo.enabled(OTHER)).toBe(false)
+    } finally {
+      app.renderer.destroy()
+      await tmp[Symbol.asyncDispose]()
+    }
+  })
+
+  test("enabling yolo clears a prompt that is already on screen", async () => {
+    const { app, emit, sync, replies, tmp } = await setup()
+    try {
+      emit(askEvent(ROOT, "perm_1"))
+      await wait(() => pending(sync, ROOT).length === 1)
+      sync.yolo.set(ROOT, true)
+      await wait(() => replies.length === 1)
+    } finally {
+      app.renderer.destroy()
+      await tmp[Symbol.asyncDispose]()
+    }
+  })
+
+  test("deleting a session drops its yolo override", async () => {
+    const { app, emit, sync, tmp } = await setup()
+    try {
+      sync.yolo.set(ROOT, true)
+      expect(sync.yolo.enabled(ROOT)).toBe(true)
+      emit({
+        directory: "/tmp/opencode/packages/tui",
+        project: "proj_test",
+        payload: {
+          id: "evt_del",
+          type: "session.deleted",
+          properties: { info: sessionRow(ROOT) },
+        },
+      } as unknown as GlobalEvent)
+      await wait(() => sync.data.yolo[ROOT] === undefined)
+    } finally {
+      app.renderer.destroy()
+      await tmp[Symbol.asyncDispose]()
+    }
+  })
+})
+
+describe("tui sync: yolo under --yolo", () => {
+  // beforeEach pins the flag off; these cases opt into a --yolo launch.
+  async function withFlag(fn: () => Promise<void>) {
+    process.env[FLAG] = "true"
+    await fn()
+  }
+
+  test("an explicit off beats the --yolo default", async () => {
+    await withFlag(async () => {
+      const { app, emit, sync, replies, tmp } = await setup()
+      try {
+        sync.yolo.set(ROOT, false)
+        emit(askEvent(ROOT, "perm_1"))
+        await wait(() => pending(sync, ROOT).length === 1)
+        expect(replies).toHaveLength(0)
+      } finally {
+        app.renderer.destroy()
+        await tmp[Symbol.asyncDispose]()
+      }
+    })
+  })
+
+  // The fail-open bypass: under --yolo with the root explicitly turned OFF, a child
+  // request arriving before the child session is hydrated must not resolve to itself
+  // and inherit the true fallback.
+  test("an unhydrated child does not inherit --yolo past an explicit parent off", async () => {
+    await withFlag(async () => {
+      // CHILD is deliberately absent from the session list.
+      const { app, emit, sync, replies, tmp } = await setup({ sessions: [sessionRow(ROOT)] })
+      try {
+        sync.yolo.set(ROOT, false)
+        emit(askEvent(CHILD, "perm_1"))
+        await wait(() => pending(sync, CHILD).length === 1)
+        expect(replies).toHaveLength(0)
+      } finally {
+        app.renderer.destroy()
+        await tmp[Symbol.asyncDispose]()
+      }
+    })
+  })
+})

--- a/packages/tui/test/util/yolo.test.ts
+++ b/packages/tui/test/util/yolo.test.ts
@@ -25,12 +25,20 @@ describe("resolveRoot", () => {
     expect(resolveRoot("grandchild", store({ grandchild: "child", child: "root", root: undefined }))).toBe("root")
   })
 
-  test("a self-parenting session terminates instead of looping", () => {
-    expect(resolveRoot("a", store({ a: "a" }))).toBe("a")
+  // A cycle has no root, so it must fail closed rather than resolve to whichever node
+  // the walk happened to stop on — that node could carry an override, or inherit --yolo.
+  test("a self-parenting session does not resolve", () => {
+    expect(resolveRoot("a", store({ a: "a" }))).toBeUndefined()
   })
 
-  test("a parent cycle terminates instead of looping", () => {
-    expect(resolveRoot("a", store({ a: "b", b: "a" }))).toBe("b")
+  test("a parent cycle does not resolve", () => {
+    expect(resolveRoot("a", store({ a: "b", b: "a" }))).toBeUndefined()
+  })
+
+  test("a cyclic chain never auto-approves, even under --yolo", () => {
+    const cyclic = store({ a: "b", b: "a" })
+    expect(yoloEnabled({ sessionID: "a", overrides: {}, getSession: cyclic, fallback: true })).toBe(false)
+    expect(yoloEnabled({ sessionID: "a", overrides: { b: true }, getSession: cyclic, fallback: false })).toBe(false)
   })
 
   // Fail-closed cases. Each returns undefined, which callers must treat as

--- a/packages/tui/test/util/yolo.test.ts
+++ b/packages/tui/test/util/yolo.test.ts
@@ -1,84 +1,144 @@
 import { describe, expect, test } from "bun:test"
-import { MAX_PARENT_DEPTH, rootSessionID, yoloEnabled } from "../../src/util/yolo"
+import { MAX_PARENT_DEPTH, resolveRoot, yoloEnabled, type SessionNode } from "../../src/util/yolo"
 
-// Build a parentOf lookup from a child -> parent map.
-function chain(map: Record<string, string>) {
-  return (sessionID: string) => map[sessionID]
+// Build a getSession lookup from a child -> parent map. Every id in the map (and every
+// parent it names) is treated as a KNOWN session unless listed in `unknown`.
+function store(map: Record<string, string | undefined>, unknown: string[] = []) {
+  const ids = new Set<string>([...Object.keys(map), ...Object.values(map).filter((v): v is string => !!v)])
+  for (const id of unknown) ids.delete(id)
+  return (sessionID: string): SessionNode | undefined => {
+    if (!ids.has(sessionID)) return undefined
+    return { parentID: map[sessionID] }
+  }
 }
 
-describe("rootSessionID", () => {
+describe("resolveRoot", () => {
   test("a root session resolves to itself", () => {
-    expect(rootSessionID("a", chain({}))).toBe("a")
+    expect(resolveRoot("a", store({ a: undefined }))).toBe("a")
   })
 
   test("a subagent resolves to its parent", () => {
-    expect(rootSessionID("child", chain({ child: "root" }))).toBe("root")
+    expect(resolveRoot("child", store({ child: "root", root: undefined }))).toBe("root")
   })
 
   test("a nested subagent resolves to the top of the chain", () => {
-    expect(rootSessionID("grandchild", chain({ grandchild: "child", child: "root" }))).toBe("root")
+    expect(resolveRoot("grandchild", store({ grandchild: "child", child: "root", root: undefined }))).toBe("root")
   })
 
   test("a self-parenting session terminates instead of looping", () => {
-    expect(rootSessionID("a", chain({ a: "a" }))).toBe("a")
+    expect(resolveRoot("a", store({ a: "a" }))).toBe("a")
   })
 
   test("a parent cycle terminates instead of looping", () => {
-    expect(rootSessionID("a", chain({ a: "b", b: "a" }))).toBe("b")
+    expect(resolveRoot("a", store({ a: "b", b: "a" }))).toBe("b")
   })
 
-  test("a chain longer than the depth cap terminates", () => {
-    const map: Record<string, string> = {}
+  // Fail-closed cases. Each returns undefined, which callers must treat as
+  // "cannot prove the root — do not auto-approve".
+  test("an unknown session does not resolve", () => {
+    expect(resolveRoot("ghost", store({}))).toBeUndefined()
+  })
+
+  test("an unhydrated child does not resolve to itself", () => {
+    // The dangerous case: returning "child" here would miss an override on the root.
+    expect(resolveRoot("child", store({ child: "root", root: undefined }, ["child"]))).toBeUndefined()
+  })
+
+  test("an unknown ancestor does not resolve", () => {
+    expect(resolveRoot("child", store({ child: "root", root: undefined }, ["root"]))).toBeUndefined()
+  })
+
+  test("a chain longer than the depth cap does not resolve", () => {
+    const map: Record<string, string | undefined> = {}
     const length = MAX_PARENT_DEPTH + 10
     for (let i = 0; i < length; i++) map[`s${i}`] = `s${i + 1}`
-    // Must return *something* without hanging; the cap is a safety valve, not a feature.
-    expect(typeof rootSessionID("s0", chain(map))).toBe("string")
+    map[`s${length}`] = undefined
+    expect(resolveRoot("s0", store(map))).toBeUndefined()
+  })
+
+  test("a chain exactly at the depth cap still resolves", () => {
+    // Guards the boundary in the other direction, so the cap cannot silently
+    // shrink to something that rejects ordinary nesting.
+    const map: Record<string, string | undefined> = {}
+    for (let i = 0; i < MAX_PARENT_DEPTH - 1; i++) map[`s${i}`] = `s${i + 1}`
+    map[`s${MAX_PARENT_DEPTH - 1}`] = undefined
+    expect(resolveRoot("s0", store(map))).toBe(`s${MAX_PARENT_DEPTH - 1}`)
   })
 })
 
 describe("yoloEnabled", () => {
-  const parentOf = chain({ child: "root", grandchild: "child" })
+  const sessions = store({ root: undefined, child: "root", grandchild: "child", other: undefined })
 
   test("defaults to off when nothing is set", () => {
-    expect(yoloEnabled({ sessionID: "root", overrides: {}, parentOf, fallback: false })).toBe(false)
+    expect(yoloEnabled({ sessionID: "root", overrides: {}, getSession: sessions, fallback: false })).toBe(false)
   })
 
   test("inherits the process-wide --yolo default", () => {
-    expect(yoloEnabled({ sessionID: "root", overrides: {}, parentOf, fallback: true })).toBe(true)
+    expect(yoloEnabled({ sessionID: "root", overrides: {}, getSession: sessions, fallback: true })).toBe(true)
   })
 
   test("an explicit per-session enable wins over an off default", () => {
-    expect(yoloEnabled({ sessionID: "root", overrides: { root: true }, parentOf, fallback: false })).toBe(true)
+    expect(yoloEnabled({ sessionID: "root", overrides: { root: true }, getSession: sessions, fallback: false })).toBe(
+      true,
+    )
   })
 
-  // The contract from the ticket: "allow users to disable it without confirmation".
+  // The contract from the spec: "allow users to disable it without confirmation".
   // Without this, launching with --yolo would make the session impossible to un-yolo.
   test("an explicit per-session disable wins over --yolo", () => {
-    expect(yoloEnabled({ sessionID: "root", overrides: { root: false }, parentOf, fallback: true })).toBe(false)
+    expect(yoloEnabled({ sessionID: "root", overrides: { root: false }, getSession: sessions, fallback: true })).toBe(
+      false,
+    )
   })
 
-  // The regression that motivated root-session normalization: subagents run in their
-  // own child session, so a naive per-session lookup would leave them prompting.
   test("a subagent inherits its parent's enable", () => {
-    expect(yoloEnabled({ sessionID: "child", overrides: { root: true }, parentOf, fallback: false })).toBe(true)
+    expect(yoloEnabled({ sessionID: "child", overrides: { root: true }, getSession: sessions, fallback: false })).toBe(
+      true,
+    )
   })
 
   test("a nested subagent inherits the root's enable", () => {
-    expect(yoloEnabled({ sessionID: "grandchild", overrides: { root: true }, parentOf, fallback: false })).toBe(true)
+    expect(
+      yoloEnabled({ sessionID: "grandchild", overrides: { root: true }, getSession: sessions, fallback: false }),
+    ).toBe(true)
   })
 
   test("a subagent inherits its parent's disable even under --yolo", () => {
-    expect(yoloEnabled({ sessionID: "child", overrides: { root: false }, parentOf, fallback: true })).toBe(false)
+    expect(yoloEnabled({ sessionID: "child", overrides: { root: false }, getSession: sessions, fallback: true })).toBe(
+      false,
+    )
   })
 
-  // An override written against a CHILD id must not be consulted — the toggle always
-  // writes to the root, so a child-keyed entry means something went wrong upstream and
-  // silently honouring it would reintroduce per-child divergence.
   test("an override keyed by a child id is ignored in favour of the root", () => {
-    expect(yoloEnabled({ sessionID: "child", overrides: { child: true }, parentOf, fallback: false })).toBe(false)
+    expect(yoloEnabled({ sessionID: "child", overrides: { child: true }, getSession: sessions, fallback: false })).toBe(
+      false,
+    )
   })
 
   test("an unrelated session is unaffected by another session's override", () => {
-    expect(yoloEnabled({ sessionID: "other", overrides: { root: true }, parentOf, fallback: false })).toBe(false)
+    expect(yoloEnabled({ sessionID: "other", overrides: { root: true }, getSession: sessions, fallback: false })).toBe(
+      false,
+    )
+  })
+
+  // The bypass this fail-closed rule exists to prevent: launched with --yolo, the user
+  // explicitly turned it OFF on the root, then a child's request arrives before the
+  // child session has been hydrated into the store. Resolving the child to itself would
+  // miss the override and inherit fallback=true — auto-approving despite an explicit off.
+  test("an unhydrated child does NOT inherit --yolo past an explicit parent disable", () => {
+    const lagging = store({ root: undefined, child: "root" }, ["child"])
+    expect(yoloEnabled({ sessionID: "child", overrides: { root: false }, getSession: lagging, fallback: true })).toBe(
+      false,
+    )
+  })
+
+  test("an unknown session never auto-approves, even under --yolo", () => {
+    expect(yoloEnabled({ sessionID: "ghost", overrides: {}, getSession: sessions, fallback: true })).toBe(false)
+  })
+
+  test("an unknown session never auto-approves, even with an override on that id", () => {
+    expect(yoloEnabled({ sessionID: "ghost", overrides: { ghost: true }, getSession: sessions, fallback: false })).toBe(
+      false,
+    )
   })
 })

--- a/packages/tui/test/util/yolo.test.ts
+++ b/packages/tui/test/util/yolo.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test"
+import { MAX_PARENT_DEPTH, rootSessionID, yoloEnabled } from "../../src/util/yolo"
+
+// Build a parentOf lookup from a child -> parent map.
+function chain(map: Record<string, string>) {
+  return (sessionID: string) => map[sessionID]
+}
+
+describe("rootSessionID", () => {
+  test("a root session resolves to itself", () => {
+    expect(rootSessionID("a", chain({}))).toBe("a")
+  })
+
+  test("a subagent resolves to its parent", () => {
+    expect(rootSessionID("child", chain({ child: "root" }))).toBe("root")
+  })
+
+  test("a nested subagent resolves to the top of the chain", () => {
+    expect(rootSessionID("grandchild", chain({ grandchild: "child", child: "root" }))).toBe("root")
+  })
+
+  test("a self-parenting session terminates instead of looping", () => {
+    expect(rootSessionID("a", chain({ a: "a" }))).toBe("a")
+  })
+
+  test("a parent cycle terminates instead of looping", () => {
+    expect(rootSessionID("a", chain({ a: "b", b: "a" }))).toBe("b")
+  })
+
+  test("a chain longer than the depth cap terminates", () => {
+    const map: Record<string, string> = {}
+    const length = MAX_PARENT_DEPTH + 10
+    for (let i = 0; i < length; i++) map[`s${i}`] = `s${i + 1}`
+    // Must return *something* without hanging; the cap is a safety valve, not a feature.
+    expect(typeof rootSessionID("s0", chain(map))).toBe("string")
+  })
+})
+
+describe("yoloEnabled", () => {
+  const parentOf = chain({ child: "root", grandchild: "child" })
+
+  test("defaults to off when nothing is set", () => {
+    expect(yoloEnabled({ sessionID: "root", overrides: {}, parentOf, fallback: false })).toBe(false)
+  })
+
+  test("inherits the process-wide --yolo default", () => {
+    expect(yoloEnabled({ sessionID: "root", overrides: {}, parentOf, fallback: true })).toBe(true)
+  })
+
+  test("an explicit per-session enable wins over an off default", () => {
+    expect(yoloEnabled({ sessionID: "root", overrides: { root: true }, parentOf, fallback: false })).toBe(true)
+  })
+
+  // The contract from the ticket: "allow users to disable it without confirmation".
+  // Without this, launching with --yolo would make the session impossible to un-yolo.
+  test("an explicit per-session disable wins over --yolo", () => {
+    expect(yoloEnabled({ sessionID: "root", overrides: { root: false }, parentOf, fallback: true })).toBe(false)
+  })
+
+  // The regression that motivated root-session normalization: subagents run in their
+  // own child session, so a naive per-session lookup would leave them prompting.
+  test("a subagent inherits its parent's enable", () => {
+    expect(yoloEnabled({ sessionID: "child", overrides: { root: true }, parentOf, fallback: false })).toBe(true)
+  })
+
+  test("a nested subagent inherits the root's enable", () => {
+    expect(yoloEnabled({ sessionID: "grandchild", overrides: { root: true }, parentOf, fallback: false })).toBe(true)
+  })
+
+  test("a subagent inherits its parent's disable even under --yolo", () => {
+    expect(yoloEnabled({ sessionID: "child", overrides: { root: false }, parentOf, fallback: true })).toBe(false)
+  })
+
+  // An override written against a CHILD id must not be consulted — the toggle always
+  // writes to the root, so a child-keyed entry means something went wrong upstream and
+  // silently honouring it would reintroduce per-child divergence.
+  test("an override keyed by a child id is ignored in favour of the root", () => {
+    expect(yoloEnabled({ sessionID: "child", overrides: { child: true }, parentOf, fallback: false })).toBe(false)
+  })
+
+  test("an unrelated session is unaffected by another session's override", () => {
+    expect(yoloEnabled({ sessionID: "other", overrides: { root: true }, parentOf, fallback: false })).toBe(false)
+  })
+})

--- a/packages/tui/test/yolo-keybind.test.tsx
+++ b/packages/tui/test/yolo-keybind.test.tsx
@@ -1,0 +1,97 @@
+/** @jsxImportSource @opentui/solid */
+// altimate_change — the ctrl+y binding contract for YOLO mode.
+//
+// The scoping rules are covered in test/util/yolo.test.ts; this file covers the
+// half that lives in config, i.e. that the shortcut the ticket specifies actually
+// resolves to the toggle command and can be remapped like any other binding.
+import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
+import { createBindingLookup } from "@opentui/keymap/extras"
+import { testRender, useRenderer } from "@opentui/solid"
+import { expect, test } from "bun:test"
+import { onCleanup } from "solid-js"
+import { TuiKeybind } from "../src/config/keybind"
+import { OPENCODE_BASE_MODE, OpencodeKeymapProvider, registerOpencodeKeymap } from "../src/keymap"
+
+const COMMAND = "session.yolo.toggle"
+
+function createResolvedKeymapConfig(input: TuiKeybind.KeybindOverrides = {}) {
+  const keybinds = TuiKeybind.parse(input)
+  return {
+    keybinds: createBindingLookup(TuiKeybind.toBindingConfig(keybinds), {
+      commandMap: TuiKeybind.CommandMap,
+      bindingDefaults: TuiKeybind.bindingDefaults(),
+    }),
+    leader_timeout: 2000,
+  }
+}
+
+async function strokesFor(overrides: TuiKeybind.KeybindOverrides = {}) {
+  const captured: { sequence: string[][] } = { sequence: [] }
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const config = createResolvedKeymapConfig(overrides)
+    const offKeymap = registerOpencodeKeymap(keymap, renderer, config)
+    const offLayer = keymap.registerLayer({
+      mode: OPENCODE_BASE_MODE,
+      commands: [{ name: COMMAND, run() {} }],
+      bindings: config.keybinds.gather("session", [COMMAND]),
+    })
+    const bindings = keymap.getCommandBindings({ visibility: "registered", commands: [COMMAND] })
+    captured.sequence =
+      bindings.get(COMMAND)?.map((binding) =>
+        binding.sequence.map((part) => {
+          const stroke = part.stroke
+          return [stroke.ctrl ? "ctrl" : "", stroke.name].filter(Boolean).join("+")
+        }),
+      ) ?? []
+    onCleanup(() => {
+      offLayer()
+      offKeymap()
+    })
+
+    return (
+      <OpencodeKeymapProvider keymap={keymap}>
+        <box />
+      </OpencodeKeymapProvider>
+    )
+  }
+
+  const app = await testRender(() => <Harness />)
+  try {
+    return captured.sequence
+  } finally {
+    app.renderer.destroy()
+  }
+}
+
+test("yolo toggle is bound to ctrl+y by default", async () => {
+  expect(await strokesFor()).toEqual([["ctrl+y"]])
+})
+
+test("yolo toggle can be remapped like any other binding", async () => {
+  expect(await strokesFor({ session_yolo_toggle: "ctrl+g" })).toEqual([["ctrl+g"]])
+})
+
+test("yolo toggle can be disabled entirely", async () => {
+  expect(await strokesFor({ session_yolo_toggle: "none" })).toEqual([])
+})
+
+test("ctrl+y is not claimed by another session-scope command", async () => {
+  // Scoped deliberately to session_* bindings rather than every definition: this
+  // codebase intentionally reuses the same stroke across different layers (ctrl+f is
+  // session_pin_toggle, model_favorite_toggle, input_move_right AND
+  // permission.prompt.fullscreen), so a global "nothing else may use ctrl+y" assertion
+  // would fire on a perfectly legitimate future binding in an unrelated dialog. The
+  // real ambiguity risk is two commands in the SAME layer.
+  const conflicts = Object.entries(TuiKeybind.Definitions)
+    .filter(([name]) => name.startsWith("session_") && name !== "session_yolo_toggle")
+    .filter(([, definition]) => {
+      const value = definition.default
+      const values = Array.isArray(value) ? value : [value]
+      return values.some((item) => typeof item === "string" && item.split(",").includes("ctrl+y"))
+    })
+    .map(([name]) => name)
+  expect(conflicts).toEqual([])
+})


### PR DESCRIPTION
### Issue for this PR

Closes #1079

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

YOLO mode already exists, but you can only switch it on at launch (`--yolo` /
`ALTIMATE_CLI_YOLO`). If you're already in a conversation and get tired of
approving every step, there's no way to turn it on. This adds `ctrl+y`.

Enabling asks first. Disabling doesn't — turning a dangerous mode off shouldn't
be harder than leaving it on.

Three things that weren't obvious while building it:

- **Subagents needed handling.** A subagent runs in its own child session, so
  its permission requests arrive tagged with the child's id, not the one you
  can see. Without normalizing to the root of the parent chain, you'd switch
  YOLO on and it would still stop and ask the moment the agent delegated
  anything. `packages/tui/src/util/yolo.ts` does that walk.
- **The old footer badge could never have updated.** It read
  `Flag.ALTIMATE_CLI_YOLO`, which is a `process.env` getter rather than a
  signal, so it only ever reflected the startup value. It's reactive now.
- **State is in memory only, on purpose.** If it were persisted, reopening an
  old session tomorrow would silently put you back in YOLO.

An explicit toggle also beats the `--yolo` default in both directions, so a
session started with `--yolo` can still be switched off.

The confirmation deliberately says what *stays* blocked, not just what stops
asking. YOLO can only auto-answer prompts the server chose to raise — deny
rules are refused in `Permission.ask` before any event reaches the TUI, so
`DROP DATABASE` / `DROP SCHEMA` / `TRUNCATE` can't be auto-approved by it. The
real exposure is the "ask"-level rules: `rm -rf`, force pushes, reading `.env`.
Saying "the agent can now do anything" would have been misleading in both
directions.

### How did you verify your code works?

`bun test` in `packages/tui`, plus the real-binary tmux journeys
(`packages/opencode/test/tui-journeys`), which drive the compiled CLI and assert
what's actually on screen.

12 new journeys. The ones worth calling out assert **whether a command actually
executed**, not what the dialog says — `journeys.test.ts` already documents that
the permission prompt doesn't render reliably under the mock model, and "did the
tool run?" is the property that matters for a permission bypass anyway:

- with YOLO off, an ask-gated `bash` command does not run
- with YOLO on, it does
- with YOLO on, a denied DDL command still never runs — plus a control running
  the identical `;`-chained shape with the DDL swapped for `echo`, so the denied
  pattern is the only difference between the blocked and passing case
- a subagent's ask-gated command runs with YOLO on and not with it off; I checked
  the session table to confirm a real child session was involved rather than the
  work quietly happening in the parent

Two bugs the journeys caught that the unit tests were happy with: the shortcut
didn't exist before your first message (registered in the session route, which
isn't mounted on the welcome screen), and enabling it there showed no change
because both indicators hard-coded "off" when there was no session yet.

Rebased on `main` (`b18bbf3c46`) and re-ran everything after, since #1067 touched
the same welcome screen. Full journey suite 22 pass / 3 pre-existing todo / 0
fail. TUI unit suite matches the `main` baseline exactly (9 pre-existing
failures, unchanged).

### Screenshots / recordings

Captured from the journey suite. Hint on the chat panel, off then on:

```
tab agents  ctrl+p commands  ctrl+y yolo
tab agents  ctrl+p commands  ctrl+y △ YOLO ON
```

The confirmation:

```
╭─ YOLO mode ────────────────────────────────────────────────────────────────────╮
│  Turn on YOLO mode for this session?                                      esc  │
│                                                                                │
│  The agent will run actions without asking you first — including editing       │
│  files, running shell commands like rm -rf and git push --force, and           │
│  reading .env files.                                                           │
│                                                                                │
│  Still blocked: your configured guardrails stay in force. DROP DATABASE, DROP  │
│  SCHEMA and TRUNCATE remain denied and are not auto-approved.                  │
│                                                                                │
│  Applies to this session only, and turns off when you quit. Press ctrl+y again │
│  to turn it off.                                                               │
│                                                                                │
│     Yes   Stop asking for this session. Applies to subagents too.              │
│                                                                                │
│  ❯  No    Keep asking before each action.                                      │
╰────────────────────────────────────────────────────────────────────────────────╯
```

Defaults to **No**. `ctrl+y` again turns it off with no prompt.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01964Prd1Sz5JwWZmNTrFdiU


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session-scoped YOLO mode with `Ctrl+Y` toggle support.
  * Added confirmation dialogs for enabling or disabling YOLO mode.
  * Added visible YOLO status indicators in the prompt and session footer.
  * YOLO mode supports session inheritance while retaining permission guardrails.

* **Bug Fixes**
  * Improved permission handling when enabling, disabling, or changing sessions.

* **Tests**
  * Added coverage for confirmation flows, console interactions, subagents, permission prompts, guardrails, and keybinding customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->