### PR TITLE
fix: [#1052] bundled cleanup — 5 deferred items + 3 review-fixes

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -19,6 +19,6 @@ if (process.versions.bun !== expectedBunVersion) {
 '
 bun typecheck
 # altimate_change — #1052 D8: scan pushed content for internal-tracker refs
-# (Jira keys, altimateai.atlassian.net). Silent on clean; exits 1 on hit.
-# Bypass with SKIP_TRACKER_CHECK=1 for genuine emergencies.
+# (see RULES in the script for the specific patterns). Silent on clean;
+# exits 1 on hit. Bypass with SKIP_TRACKER_CHECK=1 for genuine emergencies.
 bun script/check-tracker-leaks.ts

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -18,3 +18,7 @@ if (process.versions.bun !== expectedBunVersion) {
 }
 '
 bun typecheck
+# altimate_change — #1052 D8: scan pushed content for internal-tracker refs
+# (Jira keys, altimateai.atlassian.net). Silent on clean; exits 1 on hit.
+# Bypass with SKIP_TRACKER_CHECK=1 for genuine emergencies.
+bun script/check-tracker-leaks.ts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ https://github.com/anomalyco/models.dev
   bun dev
   ```
 
+`bun install` sets up the pre-push hook via `husky` — subsequent `git push` runs a bun-version check, `bun typecheck`, and a scan for internal-tracker references. If the tracker scan blocks you legitimately (extremely unlikely on this public repo), bypass with `SKIP_TRACKER_CHECK=1 git push`.
+
 ### Running against a different directory
 
 By default, `bun dev` runs Altimate Code in the `packages/opencode` directory. To run it against a different directory or repository:

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -541,10 +541,16 @@ for (const item of targets) {
   // are relative to the workspace root (dir = packages/opencode) so the test
   // can resolve them from its own cwd without env plumbing.
   const stampInputs: Array<{ path: string; sha256: string }> = []
+  // altimate_change — #1052 D10 review-fix (M2): resolve inputs relative to
+  // REPO_ROOT (not `dir` = packages/opencode). Workspace-package files live
+  // OUTSIDE packages/opencode; a `dir`-relative path for those would render as
+  // `../tui/src/...` which the smoke-test reader would then have to un-prefix.
+  // REPO_ROOT-relative keeps paths portable and the reader trivial.
+  const _stampRoot = path.resolve(dir, "../..") // repo root
   const addFile = (absPath: string) => {
     try {
       const buf = fs.readFileSync(absPath)
-      const rel = path.relative(dir, absPath)
+      const rel = path.relative(_stampRoot, absPath)
       const hash = createHash("sha256").update(buf).digest("hex")
       stampInputs.push({ path: rel, sha256: hash })
     } catch {
@@ -564,6 +570,12 @@ for (const item of targets) {
   addFile(parserWorker)
   // Per-target altimate-core NAPI prebuild
   addFile(platformNodeSrc)
+  // altimate_change — #1052 D10 review-fix (M2): package.json + bun.lock cover
+  // dependency-version bumps that change what Bun.build embeds. Without these,
+  // `bun install` bumping a bundled dep would leave the stamp reporting fresh.
+  const REPO_ROOT = path.resolve(dir, "../..")
+  addFile(path.join(REPO_ROOT, "package.json"))
+  addFile(path.join(REPO_ROOT, "bun.lock"))
   // src/ + script/ TypeScript tree — hash every file the compiler actually saw
   // (same extension filter build.ts globs for embedding).
   const IGNORED = new Set(["node_modules", ".turbo", ".cache", "dist", "target"])
@@ -588,6 +600,30 @@ for (const item of targets) {
   }
   walk(path.join(dir, "src"))
   walk(path.join(dir, "script"))
+  // altimate_change — #1052 D10 review-fix (M2): also hash every workspace
+  // package's src/ tree. `packages/opencode/src` imports from
+  // `@opencode-ai/{core,tui,util,plugin,sdk,server,cli,...}` and
+  // `@altimateai/{dbt-tools,drivers}` — Bun.build follows these imports and
+  // bundles them into the binary transitively. The original stamp walked only
+  // packages/opencode, so edits under any sibling workspace package would leave
+  // the binary silently stale. Enumerate `packages/*/src` at build time (rather
+  // than hard-coding names) so new packages get covered automatically.
+  const packagesRoot = path.resolve(REPO_ROOT, "packages")
+  try {
+    for (const pkg of fs.readdirSync(packagesRoot, { withFileTypes: true })) {
+      if (!pkg.isDirectory() || pkg.name.startsWith(".")) continue
+      // Skip packages/opencode — already covered by the walks above.
+      if (pkg.name === "opencode") continue
+      const pkgSrc = path.join(packagesRoot, pkg.name, "src")
+      if (fs.existsSync(pkgSrc)) walk(pkgSrc)
+      // Each workspace package.json influences its resolution/exports and could
+      // change what ends up in the binary even when its src/ files are unchanged.
+      const pkgJson = path.join(packagesRoot, pkg.name, "package.json")
+      if (fs.existsSync(pkgJson)) addFile(pkgJson)
+    }
+  } catch {
+    // packages/ missing (unlikely at build time) — skip; addFile() ignores non-existent paths anyway.
+  }
   // Deterministic order so the aggregate hash is stable across build runs.
   stampInputs.sort((a, b) => a.path.localeCompare(b.path))
   const aggregate = createHash("sha256")

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -649,6 +649,9 @@ for (const item of targets) {
         // Roots the walk covered, so the read side can detect files added after
         // the build rather than only rehashing what was present at build time.
         roots: [...new Set(walkedRoots)].sort(),
+        // Glob form so the read side notices a package added AFTER this build;
+        // concrete roots only describe what existed while it ran.
+        rootGlobs: ["packages/*/src"],
         inputs: stampInputs,
       },
       null,

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -17,6 +17,7 @@ process.chdir(dir)
 
 import { Script } from "@opencode-ai/script"
 import pkg from "../package.json"
+import { walkInputs } from "./stamp-inputs"
 
 // Python engine has been eliminated — all methods run natively in TypeScript.
 // ALTIMATE_ENGINE_VERSION is no longer needed at runtime.
@@ -147,43 +148,49 @@ const allTargets: {
 ]
 
 // If --targets is provided, filter to only matching OS values
-const validOsValues = new Set(allTargets.map(t => t.os))
-const targetsFlag = process.argv.find(a => a.startsWith('--targets='))?.split('=')[1]?.split(',')
+const validOsValues = new Set(allTargets.map((t) => t.os))
+const targetsFlag = process.argv
+  .find((a) => a.startsWith("--targets="))
+  ?.split("=")[1]
+  ?.split(",")
 if (targetsFlag) {
-  const invalid = targetsFlag.filter(t => !validOsValues.has(t))
+  const invalid = targetsFlag.filter((t) => !validOsValues.has(t))
   if (invalid.length > 0) {
-    console.error(`error: invalid --targets value(s): ${invalid.join(', ')}. Valid values: ${[...validOsValues].join(', ')}`)
+    console.error(
+      `error: invalid --targets value(s): ${invalid.join(", ")}. Valid values: ${[...validOsValues].join(", ")}`,
+    )
     process.exit(1)
   }
 }
 
 // --target-index=N builds a single target by index (for parallel CI matrix)
-const targetIndexFlag = process.argv.find(a => a.startsWith('--target-index='))?.split('=')[1]
+const targetIndexFlag = process.argv.find((a) => a.startsWith("--target-index="))?.split("=")[1]
 
-const targets = targetIndexFlag !== undefined
-  ? [allTargets[parseInt(targetIndexFlag, 10)]].filter(Boolean)
-  : singleFlag
-  ? allTargets.filter((item) => {
-      if (item.os !== process.platform || item.arch !== process.arch) {
-        return false
-      }
+const targets =
+  targetIndexFlag !== undefined
+    ? [allTargets[parseInt(targetIndexFlag, 10)]].filter(Boolean)
+    : singleFlag
+      ? allTargets.filter((item) => {
+          if (item.os !== process.platform || item.arch !== process.arch) {
+            return false
+          }
 
-      // When building for the current platform, prefer a single native binary by default.
-      // Baseline binaries require additional Bun artifacts and can be flaky to download.
-      if (item.avx2 === false) {
-        return baselineFlag
-      }
+          // When building for the current platform, prefer a single native binary by default.
+          // Baseline binaries require additional Bun artifacts and can be flaky to download.
+          if (item.avx2 === false) {
+            return baselineFlag
+          }
 
-      // also skip abi-specific builds for the same reason
-      if (item.abi !== undefined) {
-        return false
-      }
+          // also skip abi-specific builds for the same reason
+          if (item.abi !== undefined) {
+            return false
+          }
 
-      return true
-    })
-  : targetsFlag
-    ? allTargets.filter(t => targetsFlag.includes(t.os))
-    : allTargets
+          return true
+        })
+      : targetsFlag
+        ? allTargets.filter((t) => targetsFlag.includes(t.os))
+        : allTargets
 
 // Defense in depth: refuse to produce no artifacts at all, and refuse to build
 // the glibc target on a musl host where the binary would crash at startup.
@@ -196,13 +203,14 @@ const targets = targetIndexFlag !== undefined
 //     `linux-x64` (glibc), produces a glibc binary that the musl host can't
 //     load, and dies later with a cryptic linker error.
 if (targets.length === 0) {
-  const reason = targetIndexFlag !== undefined
-    ? `--target-index=${targetIndexFlag} is out of range (allTargets has ${allTargets.length} entries — musl/win32-arm64 were removed).`
-    : singleFlag
-      ? `--single found no entry in allTargets matching ${process.platform}/${process.arch} (host may be excluded — see allTargets at the top of build.ts).`
-      : targetsFlag
-        ? `--targets=${targetsFlag.join(",")} matched nothing in allTargets.`
-        : "allTargets is empty."
+  const reason =
+    targetIndexFlag !== undefined
+      ? `--target-index=${targetIndexFlag} is out of range (allTargets has ${allTargets.length} entries — musl/win32-arm64 were removed).`
+      : singleFlag
+        ? `--single found no entry in allTargets matching ${process.platform}/${process.arch} (host may be excluded — see allTargets at the top of build.ts).`
+        : targetsFlag
+          ? `--targets=${targetsFlag.join(",")} matched nothing in allTargets.`
+          : "allTargets is empty."
   console.error(`error: no build targets selected. ${reason}`)
   process.exit(1)
 }
@@ -221,8 +229,12 @@ if (singleFlag && process.platform === "linux") {
     return false
   })()
   if (isMuslHost) {
-    console.error("error: --single on a musl-linux host would build the glibc target and produce a binary the host cannot run.")
-    console.error("       altimate-core has no NAPI prebuild for musl yet. Build on a glibc host, or install via `apk add gcompat` + the npm wrapper.")
+    console.error(
+      "error: --single on a musl-linux host would build the glibc target and produce a binary the host cannot run.",
+    )
+    console.error(
+      "       altimate-core has no NAPI prebuild for musl yet. Build on a glibc host, or install via `apk add gcompat` + the npm wrapper.",
+    )
     process.exit(1)
   }
 }
@@ -240,10 +252,18 @@ await $`rm -rf dist`
 const requiredExternals: string[] = []
 const optionalExternals = [
   // Database drivers — native addons, users install on demand per warehouse
-  "pg", "snowflake-sdk", "@google-cloud/bigquery", "@databricks/sql",
-  "mysql2", "mssql", "oracledb", "duckdb",
+  "pg",
+  "snowflake-sdk",
+  "@google-cloud/bigquery",
+  "@databricks/sql",
+  "mysql2",
+  "mssql",
+  "oracledb",
+  "duckdb",
   // Optional infra packages — native addons or heavy optional deps
-  "keytar", "ssh2", "dockerode",
+  "keytar",
+  "ssh2",
+  "dockerode",
 ]
 
 const binaries: Record<string, string> = {}
@@ -267,7 +287,9 @@ function altimateCorePlatformFor(item: { os: string; arch: "arm64" | "x64"; abi?
   platformTag: string
 } {
   if (item.abi === "musl") {
-    throw new Error(`No @altimateai/altimate-core prebuild for linux-${item.arch}-musl; this target should not be in allTargets.`)
+    throw new Error(
+      `No @altimateai/altimate-core prebuild for linux-${item.arch}-musl; this target should not be in allTargets.`,
+    )
   }
   if (item.os === "darwin") {
     const tag = `darwin-${item.arch}`
@@ -282,7 +304,9 @@ function altimateCorePlatformFor(item: { os: string; arch: "arm64" | "x64"; abi?
       const tag = "win32-x64-msvc"
       return { pkg: `@altimateai/altimate-core-${tag}`, nodeFile: `altimate-core.${tag}.node`, platformTag: tag }
     }
-    throw new Error(`No @altimateai/altimate-core prebuild for win32-${item.arch}; this target should not be in allTargets.`)
+    throw new Error(
+      `No @altimateai/altimate-core prebuild for win32-${item.arch}; this target should not be in allTargets.`,
+    )
   }
   throw new Error(`Unsupported build target: ${item.os}-${item.arch}`)
 }
@@ -299,9 +323,7 @@ const altimateCoreLoaderDir = fs.realpathSync(path.dirname(altimateCoreLoaderPkg
 // .node into today's release archive.
 {
   const expected = pkg.dependencies["@altimateai/altimate-core"]
-  const resolvedVersion = JSON.parse(
-    fs.readFileSync(path.join(altimateCoreLoaderDir, "package.json"), "utf8"),
-  ).version
+  const resolvedVersion = JSON.parse(fs.readFileSync(path.join(altimateCoreLoaderDir, "package.json"), "utf8")).version
   if (resolvedVersion !== expected) {
     throw new Error(
       `build.ts: resolved @altimateai/altimate-core version ${resolvedVersion} ` +
@@ -568,33 +590,24 @@ for (const item of targets) {
   // altimate_change — #1052 D10 review-fix (M2): package.json + bun.lock cover
   // dependency-version bumps that change what Bun.build embeds. Without these,
   // `bun install` bumping a bundled dep would leave the stamp reporting fresh.
-  // Include per-package package.json in the workspace walk below.
+  // Sibling workspace manifests are added in the packages walk below; this
+  // package's own manifest is added here, because that walk skips `opencode`
+  // (its src/ and script/ trees are already covered) and would otherwise leave
+  // `imports`, `exports` and other bundler-relevant fields unstamped.
   addFile(path.join(REPO_ROOT, "package.json"))
   addFile(path.join(REPO_ROOT, "bun.lock"))
+  addFile(path.join(dir, "package.json"))
   // Also include tsconfig files that affect compiled output shape
   // (bot review: tsconfig changes can flip target/moduleResolution).
   addFile(path.join(dir, "tsconfig.json"))
-  // src/ + script/ TypeScript tree — hash every file the compiler actually saw
-  // (same extension filter build.ts globs for embedding).
-  const IGNORED = new Set(["node_modules", ".turbo", ".cache", "dist", "target"])
+  // src/ + script/ TypeScript tree — hash every file the compiler actually saw.
+  // The walk rules live in ./build-inputs so the smoke-test guard can
+  // re-enumerate with identical rules and notice files ADDED after the build.
+  const walkedRoots: string[] = []
   const walk = (root: string): void => {
-    let entries: fs.Dirent[]
-    try {
-      entries = fs.readdirSync(root, { withFileTypes: true })
-    } catch {
-      return
-    }
-    for (const entry of entries) {
-      if (entry.name.startsWith(".")) continue
-      if (IGNORED.has(entry.name)) continue
-      const full = path.join(root, entry.name)
-      if (entry.isDirectory()) {
-        walk(full)
-        continue
-      }
-      if (!/\.(tsx?|json|txt|md)$/.test(entry.name)) continue
-      addFile(full)
-    }
+    if (!fs.existsSync(root)) return
+    walkedRoots.push(path.relative(REPO_ROOT, root))
+    for (const file of walkInputs(root)) addFile(file)
   }
   walk(path.join(dir, "src"))
   walk(path.join(dir, "script"))
@@ -633,6 +646,9 @@ for (const item of targets) {
         target: name,
         version: Script.version,
         aggregate,
+        // Roots the walk covered, so the read side can detect files added after
+        // the build rather than only rehashing what was present at build time.
+        roots: [...new Set(walkedRoots)].sort(),
         inputs: stampInputs,
       },
       null,

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -6,6 +6,8 @@ import path from "path"
 import { fileURLToPath } from "url"
 import { createRequire } from "node:module"
 import solidPlugin from "@opentui/solid/bun-plugin"
+// altimate_change — #1052 D10: sha256 for the per-target build-inputs stamp.
+import { createHash } from "node:crypto"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -523,6 +525,88 @@ for (const item of targets) {
       2,
     ),
   )
+
+  // altimate_change start — #1052 D10: emit a build-inputs stamp so the
+  // smoke-test staleness guard can compare against ALL binary-embedded inputs,
+  // not just src/ + script/ mtimes.
+  //
+  // The previous guard (m5) walked src/ + script/ for the newest mtime — good
+  // for the common case but blind to changes in CHANGELOG.md, migrations,
+  // bundled skills, the models.dev snapshot, the parser worker, and the
+  // per-platform altimate-core prebuild. Editing any of those without touching
+  // a .ts file would leave the guard silent and the binary silently stale.
+  //
+  // Stamp format: JSON with one entry per input, sha256 of file content. Read
+  // side rehashes each listed path and compares; any mismatch → stale. Paths
+  // are relative to the workspace root (dir = packages/opencode) so the test
+  // can resolve them from its own cwd without env plumbing.
+  const stampInputs: Array<{ path: string; sha256: string }> = []
+  const addFile = (absPath: string) => {
+    try {
+      const buf = fs.readFileSync(absPath)
+      const rel = path.relative(dir, absPath)
+      const hash = createHash("sha256").update(buf).digest("hex")
+      stampInputs.push({ path: rel, sha256: hash })
+    } catch {
+      // Missing file: silently skip. The stamp only covers what actually
+      // shipped; a file the build didn't need doesn't invalidate the guard.
+    }
+  }
+  // CHANGELOG.md
+  addFile(changelogPath)
+  // Migrations
+  for (const m of migrationDirs) addFile(path.join(dir, "migration", m, "migration.sql"))
+  // Skills bundled via .opencode/skills/
+  for (const entry of skillEntries) addFile(path.join(skillsRoot, entry.name, "SKILL.md"))
+  // Generated models snapshot (build.ts rewrote it before we got here)
+  addFile(path.join(dir, "src/provider/models-snapshot.ts"))
+  // opentui parser worker
+  addFile(parserWorker)
+  // Per-target altimate-core NAPI prebuild
+  addFile(platformNodeSrc)
+  // src/ + script/ TypeScript tree — hash every file the compiler actually saw
+  // (same extension filter build.ts globs for embedding).
+  const IGNORED = new Set(["node_modules", ".turbo", ".cache", "dist", "target"])
+  const walk = (root: string): void => {
+    let entries: fs.Dirent[]
+    try {
+      entries = fs.readdirSync(root, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith(".")) continue
+      if (IGNORED.has(entry.name)) continue
+      const full = path.join(root, entry.name)
+      if (entry.isDirectory()) {
+        walk(full)
+        continue
+      }
+      if (!/\.(tsx?|json|txt|md)$/.test(entry.name)) continue
+      addFile(full)
+    }
+  }
+  walk(path.join(dir, "src"))
+  walk(path.join(dir, "script"))
+  // Deterministic order so the aggregate hash is stable across build runs.
+  stampInputs.sort((a, b) => a.path.localeCompare(b.path))
+  const aggregate = createHash("sha256")
+    .update(stampInputs.map((i) => `${i.path}\t${i.sha256}`).join("\n"))
+    .digest("hex")
+  await Bun.file(`dist/${name}/bin/build-inputs.json`).write(
+    JSON.stringify(
+      {
+        target: name,
+        version: Script.version,
+        aggregate,
+        inputs: stampInputs,
+      },
+      null,
+      2,
+    ),
+  )
+  // altimate_change end
+
   binaries[name] = Script.version
 }
 

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -538,19 +538,14 @@ for (const item of targets) {
   //
   // Stamp format: JSON with one entry per input, sha256 of file content. Read
   // side rehashes each listed path and compares; any mismatch → stale. Paths
-  // are relative to the workspace root (dir = packages/opencode) so the test
-  // can resolve them from its own cwd without env plumbing.
+  // are REPO_ROOT-relative so entries under packages/tui, packages/core, the
+  // workspace-root package.json, bun.lock, etc. resolve without munging.
+  const REPO_ROOT = path.resolve(dir, "../..")
   const stampInputs: Array<{ path: string; sha256: string }> = []
-  // altimate_change — #1052 D10 review-fix (M2): resolve inputs relative to
-  // REPO_ROOT (not `dir` = packages/opencode). Workspace-package files live
-  // OUTSIDE packages/opencode; a `dir`-relative path for those would render as
-  // `../tui/src/...` which the smoke-test reader would then have to un-prefix.
-  // REPO_ROOT-relative keeps paths portable and the reader trivial.
-  const _stampRoot = path.resolve(dir, "../..") // repo root
   const addFile = (absPath: string) => {
     try {
       const buf = fs.readFileSync(absPath)
-      const rel = path.relative(_stampRoot, absPath)
+      const rel = path.relative(REPO_ROOT, absPath)
       const hash = createHash("sha256").update(buf).digest("hex")
       stampInputs.push({ path: rel, sha256: hash })
     } catch {
@@ -573,9 +568,12 @@ for (const item of targets) {
   // altimate_change — #1052 D10 review-fix (M2): package.json + bun.lock cover
   // dependency-version bumps that change what Bun.build embeds. Without these,
   // `bun install` bumping a bundled dep would leave the stamp reporting fresh.
-  const REPO_ROOT = path.resolve(dir, "../..")
+  // Include per-package package.json in the workspace walk below.
   addFile(path.join(REPO_ROOT, "package.json"))
   addFile(path.join(REPO_ROOT, "bun.lock"))
+  // Also include tsconfig files that affect compiled output shape
+  // (bot review: tsconfig changes can flip target/moduleResolution).
+  addFile(path.join(dir, "tsconfig.json"))
   // src/ + script/ TypeScript tree — hash every file the compiler actually saw
   // (same extension filter build.ts globs for embedding).
   const IGNORED = new Set(["node_modules", ".turbo", ".cache", "dist", "target"])

--- a/packages/opencode/script/stamp-inputs.ts
+++ b/packages/opencode/script/stamp-inputs.ts
@@ -12,8 +12,13 @@ import path from "path"
 /** Directories never part of a build input set. */
 export const IGNORED_DIRS = new Set(["node_modules", ".turbo", ".cache", "dist", "target"])
 
-/** Extensions Bun.build can pull into the binary from a walked source tree. */
-export const INPUT_EXTENSIONS = /\.(tsx?|json|txt|md)$/
+/**
+ * Extensions Bun.build can pull into the binary from a walked source tree.
+ * `.mp3` is here because packages/tui imports its attention sounds with
+ * `{ type: "file" }`, so a changed or added sound is embedded in the binary and
+ * must invalidate the stamp like any source edit.
+ */
+export const INPUT_EXTENSIONS = /\.(tsx?|json|txt|md|mp3)$/
 
 /**
  * Absolute paths of every input file under `root`, applying the shared rules.

--- a/packages/opencode/script/stamp-inputs.ts
+++ b/packages/opencode/script/stamp-inputs.ts
@@ -1,0 +1,46 @@
+// altimate_change start — #1052 D10 bot-review fix: shared build-input walk.
+//
+// The build stamp and the smoke-test staleness guard have to agree on exactly
+// which files count as a build input. When the walk lived only inside build.ts,
+// the guard could rehash the paths the stamp listed but had no way to notice a
+// file ADDED after the build — a new module under any walked root left the
+// binary stale while the guard stayed silent. Sharing the walk lets the guard
+// re-enumerate with identical rules and compare sets, not just hashes.
+import fs from "fs"
+import path from "path"
+
+/** Directories never part of a build input set. */
+export const IGNORED_DIRS = new Set(["node_modules", ".turbo", ".cache", "dist", "target"])
+
+/** Extensions Bun.build can pull into the binary from a walked source tree. */
+export const INPUT_EXTENSIONS = /\.(tsx?|json|txt|md)$/
+
+/**
+ * Absolute paths of every input file under `root`, applying the shared rules.
+ * Missing roots yield an empty list — callers treat that as "nothing to add".
+ */
+export function walkInputs(root: string): string[] {
+  const found: string[] = []
+  const walk = (current: string): void => {
+    let entries: fs.Dirent[]
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith(".")) continue
+      if (IGNORED_DIRS.has(entry.name)) continue
+      const full = path.join(current, entry.name)
+      if (entry.isDirectory()) {
+        walk(full)
+        continue
+      }
+      if (!INPUT_EXTENSIONS.test(entry.name)) continue
+      found.push(full)
+    }
+  }
+  walk(root)
+  return found
+}
+// altimate_change end

--- a/packages/opencode/src/provider/models-catalog.ts
+++ b/packages/opencode/src/provider/models-catalog.ts
@@ -1,0 +1,49 @@
+// altimate_change start — bot-review fix: models.dev catalog validation.
+//
+// Split out of models.ts so it can be tested directly. Every path that can
+// populate the on-disk cache runs through it: the cold fetch, the hourly
+// refresh, and the cache READ (an entry poisoned by an older build must not be
+// trusted either).
+//
+// A 2xx body being valid JSON does not make it the catalog. `null`, `[]`, a
+// scalar and an object-shaped error payload (`{"error": "rate limited"}`) all
+// survive JSON.parse, and a misconfigured proxy returns exactly those with a
+// JSON content-type. Caching one poisons the cache for the whole TTL, and
+// `Provider.state` then maps over it reading `provider.models` / `provider.id`.
+//
+// This is a STRUCTURAL check, deliberately NOT the zod `Provider` schema. A
+// review suggested the schema and it looked right, but `Provider.safeParse`
+// rejects 0 of the 144 providers in our own bundled snapshot: `Model` requires
+// an `options` record that real models.dev entries do not carry. Gating the
+// cache on it meant nothing was ever cached and every load fell through to a
+// network fetch, which hangs in sandboxed CI. So the check asserts only what
+// consumers actually rely on: a non-empty map whose values are provider objects
+// carrying a `models` map.
+//
+// Module shape follows packages/opencode/AGENTS.md: flat exports plus a
+// self-reexport, not `export namespace`.
+
+/** True when `value` is shaped like a models.dev catalog rather than junk. */
+export function isCatalog(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false
+  const entries = Object.values(value)
+  if (entries.length === 0) return false
+  return entries.some((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return false
+    const models = Reflect.get(entry, "models")
+    return !!models && typeof models === "object" && !Array.isArray(models)
+  })
+}
+
+/** Parse a models.dev response body, returning undefined unless it is a catalog. */
+export function parseCatalog(text: string): Record<string, unknown> | undefined {
+  try {
+    const parsed: unknown = JSON.parse(text)
+    return isCatalog(parsed) ? parsed : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export * as ModelsCatalog from "./models-catalog"
+// altimate_change end

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -121,11 +121,18 @@ export namespace ModelsDev {
       const result = await Filesystem.readJson(Flag.OPENCODE_MODELS_PATH ?? filepath).catch(() => {})
       if (result) return result
       const result2 = await fetchApi()
-      if (result2.ok) {
-        await Filesystem.write(filepath, result2.text).catch((e) => {
-          log.error("Failed to write models cache", { error: e })
-        })
-      }
+      // altimate_change — #1052 D14 review-fix (M3): fetchApi returning a non-2xx
+      // (e.g. 5xx with an HTML error body) previously fell through to
+      // `JSON.parse(<HTML>)` and crashed with SyntaxError. Return an empty
+      // catalog instead — callers already tolerate empty results (Provider.state
+      // just yields no models.dev-derived providers, which is the same UX as
+      // running with OPENCODE_DISABLE_MODELS_FETCH=1). Pre-D14 this rarely
+      // fired because the eager refresh usually warmed the disk cache; post-D14
+      // more first-calls fall through to fetch, so more chances to hit the crash.
+      if (!result2.ok) return {}
+      await Filesystem.write(filepath, result2.text).catch((e) => {
+        log.error("Failed to write models cache", { error: e })
+      })
       return JSON.parse(result2.text)
     })
   })
@@ -164,19 +171,24 @@ if (!Flag.OPENCODE_DISABLE_MODELS_FETCH && !process.argv.includes("--get-yargs-c
   //
   // Callers that need model data use `ModelsDev.Data()`, which resolves in this
   // priority order: (1) local disk cache, (2) bundled snapshot at
-  // `models-snapshot.ts` (always embedded in release binaries, regenerated at
-  // each build), (3) `Flock.withLock(...) → fetchApi()` only when both are
-  // absent. The bundled snapshot means release-binary users always have model
-  // metadata even on a cold-start with no network. Long-running processes
-  // (TUI, serve) still receive updates via the hourly `setInterval` below
-  // (`.unref()`'d so it never blocks exit). Short-lived commands rely on the
-  // snapshot's release-time freshness.
+  // `models-snapshot.ts` (embedded in release binaries — regenerated at each
+  // build; dev-mode builds without the snapshot fall through to fetch), (3)
+  // `Flock.withLock(...) → fetchApi()` only when both are absent. Release
+  // binaries therefore have release-time model metadata even on a cold-start
+  // with no network. Long-running processes (TUI, serve) still receive updates
+  // via the hourly `setInterval` below (`.unref()`'d so it never blocks exit).
   //
-  // Trade-off: models added to models.dev between releases do not appear in
-  // short-lived commands until the next release rebuild. Bounded by the release
-  // cadence (~weekly). Users needing bleeding-edge model metadata can run
-  // `altimate-code auth login` or open the TUI, both of which trigger the
-  // hourly interval on start-up rebase.
+  // Trade-off: without an eager fetch, models added to models.dev between
+  // releases would not appear until the hourly interval below fires. The
+  // fire-and-forget refresh() below narrows that window without holding the
+  // event loop — a microtask can't itself keep Bun alive, and if the fetch it
+  // schedules is still in flight at process-exit, the snapshot covers callers
+  // on the next run. The load-bearing part of the D14 fix (removing the
+  // setTimeout(...,0)-wrapped fetch that kept the loop alive) is preserved.
+  //
+  // If this reintroduces the unshare-net hang on CI, drop the Promise.then
+  // line — the snapshot alone still keeps release binaries functional offline.
+  Promise.resolve().then(() => ModelsDev.refresh().catch(() => {}))
   setInterval(async () => {
     await ModelsDev.refresh()
   }, 60 * 60 * 1000).unref()

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -129,11 +129,27 @@ export namespace ModelsDev {
       // running with OPENCODE_DISABLE_MODELS_FETCH=1). Pre-D14 this rarely
       // fired because the eager refresh usually warmed the disk cache; post-D14
       // more first-calls fall through to fetch, so more chances to hit the crash.
+      //
+      // Bot-review follow-up: a 2xx can still carry HTML or truncated JSON
+      // (proxies, load-balancer error pages that respond 200, mid-stream
+      // truncation). Try to parse first; only cache + return on success. On
+      // parse failure, log and return empty — same graceful-degradation path
+      // as the non-2xx branch, and we don't poison the disk cache with junk.
       if (!result2.ok) return {}
+      let parsed: Record<string, unknown>
+      try {
+        parsed = JSON.parse(result2.text)
+      } catch (e) {
+        log.error("models.dev returned non-JSON body; not caching", {
+          error: e,
+          firstBytes: result2.text.slice(0, 120),
+        })
+        return {}
+      }
       await Filesystem.write(filepath, result2.text).catch((e) => {
         log.error("Failed to write models cache", { error: e })
       })
-      return JSON.parse(result2.text)
+      return parsed
     })
   })
 

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -136,12 +136,23 @@ export namespace ModelsDev {
       // parse failure, log and return empty — same graceful-degradation path
       // as the non-2xx branch, and we don't poison the disk cache with junk.
       if (!result2.ok) return {}
-      let parsed: Record<string, unknown>
+      let parsed: unknown
       try {
         parsed = JSON.parse(result2.text)
       } catch (e) {
         log.error("models.dev returned non-JSON body; not caching", {
           error: e,
+          firstBytes: result2.text.slice(0, 120),
+        })
+        return {}
+      }
+      // Bot-review follow-up: syntactically valid JSON is not necessarily the
+      // catalog. `null`, `[]` and scalars all survive JSON.parse — a shape a
+      // misconfigured proxy returns with a JSON content-type. Caching one of
+      // those poisons the disk cache for the whole TTL, and `get()` casts it to
+      // `Record<string, Provider>` for `fromModelsDevProvider` to iterate.
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        log.error("models.dev returned JSON that is not a catalog object; not caching", {
           firstBytes: result2.text.slice(0, 120),
         })
         return {}
@@ -195,18 +206,22 @@ if (!Flag.OPENCODE_DISABLE_MODELS_FETCH && !process.argv.includes("--get-yargs-c
   // via the hourly `setInterval` below (`.unref()`'d so it never blocks exit).
   //
   // Trade-off: without an eager fetch, models added to models.dev between
-  // releases would not appear until the hourly interval below fires. The
-  // fire-and-forget refresh() below narrows that window without holding the
-  // event loop — a microtask can't itself keep Bun alive, and if the fetch it
-  // schedules is still in flight at process-exit, the snapshot covers callers
-  // on the next run. The load-bearing part of the D14 fix (removing the
-  // setTimeout(...,0)-wrapped fetch that kept the loop alive) is preserved.
+  // releases do not appear until a long-running process's hourly interval
+  // fires, or until the disk cache expires and a caller loads on demand. That
+  // is accepted deliberately.
   //
-  // If this reintroduces the unshare-net hang on CI, drop the Promise.then
-  // line — the snapshot alone still keeps release binaries functional offline.
-  Promise.resolve().then(() => ModelsDev.refresh().catch(() => {}))
-  setInterval(async () => {
-    await ModelsDev.refresh()
-  }, 60 * 60 * 1000).unref()
+  // An earlier revision tried to narrow that window with
+  // `Promise.resolve().then(() => ModelsDev.refresh())`, reasoning that a
+  // microtask cannot keep Bun alive. The microtask cannot — but the `fetch()`
+  // it starts can, and that is the whole failure. On a cold cache `refresh()`
+  // reaches `fetchApi()`, whose `AbortSignal.timeout(10000)` still cannot
+  // cancel a blocking `getaddrinfo()`. That is the D14 shape exactly, so the
+  // eager refresh is gone rather than rescheduled.
+  setInterval(
+    async () => {
+      await ModelsDev.refresh()
+    },
+    60 * 60 * 1000,
+  ).unref()
   // altimate_change end
 }

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -152,18 +152,33 @@ export namespace ModelsDev {
 }
 
 if (!Flag.OPENCODE_DISABLE_MODELS_FETCH && !process.argv.includes("--get-yargs-completions")) {
-  // altimate_change start — upstream_fix: bridge merge removed the setTimeout(...,0)
-  // wrapper. Defer the initial refresh past the current microtask so that
-  // Installation.USER_AGENT (used inside refresh()) is fully initialized — we hit
-  // a circular-dep issue on cold start without this. See altimate commit 980efaab64.
-  setTimeout(() => {
-    ModelsDev.refresh()
-    setInterval(
-      async () => {
-        await ModelsDev.refresh()
-      },
-      60 * 1000 * 60,
-    ).unref()
-  }, 0)
+  // altimate_change start — #1052 D14: drop the eager import-time ModelsDev.refresh().
+  //
+  // The previous `setTimeout(() => ModelsDev.refresh(), 0)` fired a fetch to
+  // https://models.dev/api.json at module import. Its `AbortSignal.timeout(10000)`
+  // cannot cancel a synchronous `getaddrinfo()` — under Linux `unshare --net`
+  // (Verdaccio sanity Phase 3 [10/10] on Ubuntu CI runners) the DNS call blocked
+  // long enough that the pending fetch held the event loop past command
+  // completion and SIGTERM landed before any bytes flushed. That blocked the
+  // v0.9.4 release.
+  //
+  // Callers that need model data use `ModelsDev.Data()`, which resolves in this
+  // priority order: (1) local disk cache, (2) bundled snapshot at
+  // `models-snapshot.ts` (always embedded in release binaries, regenerated at
+  // each build), (3) `Flock.withLock(...) → fetchApi()` only when both are
+  // absent. The bundled snapshot means release-binary users always have model
+  // metadata even on a cold-start with no network. Long-running processes
+  // (TUI, serve) still receive updates via the hourly `setInterval` below
+  // (`.unref()`'d so it never blocks exit). Short-lived commands rely on the
+  // snapshot's release-time freshness.
+  //
+  // Trade-off: models added to models.dev between releases do not appear in
+  // short-lived commands until the next release rebuild. Bounded by the release
+  // cadence (~weekly). Users needing bleeding-edge model metadata can run
+  // `altimate-code auth login` or open the TUI, both of which trigger the
+  // hourly interval on start-up rebase.
+  setInterval(async () => {
+    await ModelsDev.refresh()
+  }, 60 * 60 * 1000).unref()
   // altimate_change end
 }

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -108,9 +108,38 @@ export namespace ModelsDev {
     return { ok: result.ok, text: await result.text() }
   }
 
+  // altimate_change — bot-review fix (round 2): one validator for every path that
+  // can populate the cache. A 2xx body being valid JSON does not make it the
+  // catalog — `null`, `[]`, a scalar, and an object-shaped error payload
+  // (`{"error": "rate limited"}`) all survive `JSON.parse`, and a misconfigured
+  // proxy returns exactly those with a JSON content-type. Caching one poisons
+  // the disk cache for the whole TTL, and `Provider.state` then maps over it
+  // reading `provider.models` / `provider.id`.
+  //
+  // At least ONE value must validate as a Provider. Requiring ALL of them would
+  // let a single new upstream field empty the catalog, which is a worse failure
+  // than the one being prevented.
+  function isCatalog(value: unknown): value is Record<string, unknown> {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return false
+    const entries = Object.values(value)
+    if (entries.length === 0) return false
+    return entries.some((entry) => Provider.safeParse(entry).success)
+  }
+
+  function parseCatalog(text: string): Record<string, unknown> | undefined {
+    try {
+      const parsed: unknown = JSON.parse(text)
+      return isCatalog(parsed) ? parsed : undefined
+    } catch {
+      return undefined
+    }
+  }
+
   export const Data = lazy(async () => {
-    const result = await Filesystem.readJson(Flag.OPENCODE_MODELS_PATH ?? filepath).catch(() => {})
-    if (result) return result
+    // Bot-review fix: a cache poisoned by an older build must not be trusted on
+    // read either, or the bad entry survives until the TTL expires.
+    const cached: unknown = await Filesystem.readJson(Flag.OPENCODE_MODELS_PATH ?? filepath).catch(() => {})
+    if (isCatalog(cached)) return cached
     // @ts-ignore
     const snapshot = await import("./models-snapshot.js")
       .then((m) => m.snapshot as Record<string, unknown>)
@@ -118,8 +147,8 @@ export namespace ModelsDev {
     if (snapshot) return snapshot
     if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return {}
     return Flock.withLock(`models-dev:${filepath}`, async () => {
-      const result = await Filesystem.readJson(Flag.OPENCODE_MODELS_PATH ?? filepath).catch(() => {})
-      if (result) return result
+      const cachedUnderLock: unknown = await Filesystem.readJson(Flag.OPENCODE_MODELS_PATH ?? filepath).catch(() => {})
+      if (isCatalog(cachedUnderLock)) return cachedUnderLock
       const result2 = await fetchApi()
       // altimate_change — #1052 D14 review-fix (M3): fetchApi returning a non-2xx
       // (e.g. 5xx with an HTML error body) previously fell through to
@@ -136,25 +165,9 @@ export namespace ModelsDev {
       // parse failure, log and return empty — same graceful-degradation path
       // as the non-2xx branch, and we don't poison the disk cache with junk.
       if (!result2.ok) return {}
-      let parsed: unknown
-      try {
-        parsed = JSON.parse(result2.text)
-      } catch (e) {
-        log.error("models.dev returned non-JSON body; not caching", {
-          error: e,
-          firstBytes: result2.text.slice(0, 120),
-        })
-        return {}
-      }
-      // Bot-review follow-up: syntactically valid JSON is not necessarily the
-      // catalog. `null`, `[]` and scalars all survive JSON.parse — a shape a
-      // misconfigured proxy returns with a JSON content-type. Caching one of
-      // those poisons the disk cache for the whole TTL, and `get()` casts it to
-      // `Record<string, Provider>` for `fromModelsDevProvider` to iterate.
-      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-        log.error("models.dev returned JSON that is not a catalog object; not caching", {
-          firstBytes: result2.text.slice(0, 120),
-        })
+      const parsed = parseCatalog(result2.text)
+      if (!parsed) {
+        log.error("models.dev body is not a catalog; not caching", { firstBytes: result2.text.slice(0, 120) })
         return {}
       }
       await Filesystem.write(filepath, result2.text).catch((e) => {
@@ -175,6 +188,15 @@ export namespace ModelsDev {
       if (skip(force)) return ModelsDev.Data.reset()
       const result = await fetchApi()
       if (!result.ok) return
+      // Bot-review fix: this path wrote the body straight to the cache with no
+      // validation at all, so the hourly refresh could poison a cache the
+      // cold-fetch path was careful to protect.
+      if (!parseCatalog(result.text)) {
+        log.error("models.dev refresh body is not a catalog; not caching", {
+          firstBytes: result.text.slice(0, 120),
+        })
+        return
+      }
       await Filesystem.write(filepath, result.text)
       ModelsDev.Data.reset()
     }).catch((e) => {

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -8,6 +8,7 @@ import { lazy } from "@/util/lazy"
 import { Filesystem } from "../util/filesystem"
 import { Flock } from "@/util/flock"
 import { Hash } from "@/util/hash"
+import { ModelsCatalog } from "./models-catalog"
 
 // Try to import bundled snapshot (generated at build time)
 // Falls back to undefined in dev mode when snapshot doesn't exist
@@ -108,32 +109,12 @@ export namespace ModelsDev {
     return { ok: result.ok, text: await result.text() }
   }
 
-  // altimate_change — bot-review fix (round 2): one validator for every path that
-  // can populate the cache. A 2xx body being valid JSON does not make it the
-  // catalog — `null`, `[]`, a scalar, and an object-shaped error payload
-  // (`{"error": "rate limited"}`) all survive `JSON.parse`, and a misconfigured
-  // proxy returns exactly those with a JSON content-type. Caching one poisons
-  // the disk cache for the whole TTL, and `Provider.state` then maps over it
-  // reading `provider.models` / `provider.id`.
-  //
-  // At least ONE value must validate as a Provider. Requiring ALL of them would
-  // let a single new upstream field empty the catalog, which is a worse failure
-  // than the one being prevented.
-  function isCatalog(value: unknown): value is Record<string, unknown> {
-    if (!value || typeof value !== "object" || Array.isArray(value)) return false
-    const entries = Object.values(value)
-    if (entries.length === 0) return false
-    return entries.some((entry) => Provider.safeParse(entry).success)
-  }
-
-  function parseCatalog(text: string): Record<string, unknown> | undefined {
-    try {
-      const parsed: unknown = JSON.parse(text)
-      return isCatalog(parsed) ? parsed : undefined
-    } catch {
-      return undefined
-    }
-  }
+  // altimate_change start — bot-review fix: catalog validation lives in
+  // ./models-catalog so it can be tested directly; see that file for why it is
+  // structural rather than schema-based.
+  const isCatalog = ModelsCatalog.isCatalog
+  const parseCatalog = ModelsCatalog.parseCatalog
+  // altimate_change end
 
   export const Data = lazy(async () => {
     // Bot-review fix: a cache poisoned by an older build must not be trusted on

--- a/packages/opencode/test/install/smoke-test-binary.test.ts
+++ b/packages/opencode/test/install/smoke-test-binary.test.ts
@@ -163,6 +163,7 @@ type BuildStamp = {
   version: string
   aggregate: string
   roots?: string[]
+  rootGlobs?: string[]
   inputs: Array<{ path: string; sha256: string }>
 }
 // Bot-review fix: `as BuildStamp` is a compile-time claim, not a runtime check.
@@ -175,9 +176,16 @@ const readProp = (value: unknown, key: string): unknown =>
 function isStampShape(value: unknown): value is BuildStamp {
   const inputs = readProp(value, "inputs")
   if (!Array.isArray(inputs) || inputs.length === 0) return false
-  return inputs.every(
-    (entry) => typeof readProp(entry, "path") === "string" && typeof readProp(entry, "sha256") === "string",
-  )
+  if (!inputs.every((e) => typeof readProp(e, "path") === "string" && typeof readProp(e, "sha256") === "string"))
+    return false
+  // `roots` gets the same treatment as `inputs`: a non-array value would throw
+  // in the for-of below, and because this runs at module load inside describe(),
+  // that fails the whole file instead of degrading to the mtime fallback.
+  const roots = readProp(value, "roots")
+  if (roots !== undefined && (!Array.isArray(roots) || !roots.every((r) => typeof r === "string"))) return false
+  const globs = readProp(value, "rootGlobs")
+  if (globs !== undefined && (!Array.isArray(globs) || !globs.every((g) => typeof g === "string"))) return false
+  return true
 }
 function readBuildStamp(binaryPath: string): BuildStamp | undefined {
   const stampPath = path.join(path.dirname(binaryPath), "build-inputs.json")
@@ -214,7 +222,23 @@ function isBinaryStaleFromStamp(binaryPath: string): boolean | "no-stamp" {
   // the roots the build walked, using the same shared rules, and treat an
   // unrecorded file as stale.
   const recorded = new Set(stamp.inputs.map((i) => i.path))
-  for (const rel of stamp.roots ?? []) {
+  const roots = [...(stamp.roots ?? [])]
+  // Concrete roots only cover packages that existed at build time. Re-expanding
+  // the recorded globs catches a whole package (or a new `src/`) added since —
+  // otherwise the first build after adding one reports fresh forever.
+  for (const glob of stamp.rootGlobs ?? []) {
+    const [prefix, suffix] = glob.split("/*/")
+    if (!suffix) continue
+    const parent = path.join(REPO_ROOT, prefix)
+    let entries: string[] = []
+    try {
+      entries = fs.readdirSync(parent, { withFileTypes: true }).flatMap((e) => (e.isDirectory() ? [e.name] : []))
+    } catch {
+      entries = []
+    }
+    for (const entry of entries) roots.push(path.join(prefix, entry, suffix))
+  }
+  for (const rel of new Set(roots)) {
     for (const abs of walkInputs(path.join(REPO_ROOT, rel))) {
       if (!recorded.has(path.relative(REPO_ROOT, abs))) return true
     }

--- a/packages/opencode/test/install/smoke-test-binary.test.ts
+++ b/packages/opencode/test/install/smoke-test-binary.test.ts
@@ -185,9 +185,11 @@ function sha256File(absPath: string): string | undefined {
 function isBinaryStaleFromStamp(binaryPath: string): boolean | "no-stamp" {
   const stamp = readBuildStamp(binaryPath)
   if (!stamp) return "no-stamp"
-  // Stamp paths are relative to packages/opencode (= PKG_DIR).
+  // altimate_change — #1052 D10 review-fix (M2): stamp paths are now REPO_ROOT-
+  // relative so entries under packages/tui, packages/core, workspace-root
+  // package.json, bun.lock, etc. resolve correctly without further munging.
   for (const { path: rel, sha256 } of stamp.inputs) {
-    const abs = path.join(PKG_DIR, rel)
+    const abs = path.join(REPO_ROOT, rel)
     const current = sha256File(abs)
     if (current === undefined) return true // input vanished → binary can't reflect current tree
     if (current !== sha256) return true

--- a/packages/opencode/test/install/smoke-test-binary.test.ts
+++ b/packages/opencode/test/install/smoke-test-binary.test.ts
@@ -22,6 +22,7 @@ import fs from "fs"
 // altimate_change — #1052 D10: sha256 for stamp-based staleness check.
 import { createHash } from "node:crypto"
 import { tmpdir } from "../fixture/fixture"
+import { walkInputs } from "../../script/stamp-inputs"
 
 const PKG_DIR = path.resolve(import.meta.dir, "../..")
 const REPO_ROOT = path.resolve(PKG_DIR, "../..")
@@ -37,8 +38,7 @@ function findLocalBinary(): string | undefined {
   if (!fs.existsSync(distDir)) return undefined
 
   // node `process.platform` → build's `<os>` slug.
-  const hostOsSlug =
-    process.platform === "win32" ? "windows" : process.platform === "darwin" ? "darwin" : "linux"
+  const hostOsSlug = process.platform === "win32" ? "windows" : process.platform === "darwin" ? "darwin" : "linux"
   // Build only emits arm64 / x64.
   const hostArchSlug = process.arch === "arm64" ? "arm64" : "x64"
 
@@ -162,15 +162,29 @@ type BuildStamp = {
   target: string
   version: string
   aggregate: string
+  roots?: string[]
   inputs: Array<{ path: string; sha256: string }>
+}
+// Bot-review fix: `as BuildStamp` is a compile-time claim, not a runtime check.
+// A stamp of `{"inputs":"x"}` passed the old `parsed?.inputs?.length` guard
+// (a string has a length), then destructured characters in the loop below and
+// threw on `path.join(REPO_ROOT, undefined)`. Validate the shape instead.
+const readProp = (value: unknown, key: string): unknown =>
+  value !== null && typeof value === "object" && key in value ? Reflect.get(value, key) : undefined
+
+function isStampShape(value: unknown): value is BuildStamp {
+  const inputs = readProp(value, "inputs")
+  if (!Array.isArray(inputs) || inputs.length === 0) return false
+  return inputs.every(
+    (entry) => typeof readProp(entry, "path") === "string" && typeof readProp(entry, "sha256") === "string",
+  )
 }
 function readBuildStamp(binaryPath: string): BuildStamp | undefined {
   const stampPath = path.join(path.dirname(binaryPath), "build-inputs.json")
   try {
     if (!fs.existsSync(stampPath)) return undefined
-    const parsed = JSON.parse(fs.readFileSync(stampPath, "utf-8")) as BuildStamp
-    if (!parsed?.inputs?.length) return undefined
-    return parsed
+    const parsed: unknown = JSON.parse(fs.readFileSync(stampPath, "utf-8"))
+    return isStampShape(parsed) ? parsed : undefined
   } catch {
     return undefined
   }
@@ -194,6 +208,17 @@ function isBinaryStaleFromStamp(binaryPath: string): boolean | "no-stamp" {
     if (current === undefined) return true // input vanished → binary can't reflect current tree
     if (current !== sha256) return true
   }
+  // Bot-review fix: rehashing the recorded inputs only catches CHANGED and
+  // DELETED files. A source file ADDED after the build is in neither list, so
+  // the binary is stale while every recorded hash still matches. Re-enumerate
+  // the roots the build walked, using the same shared rules, and treat an
+  // unrecorded file as stale.
+  const recorded = new Set(stamp.inputs.map((i) => i.path))
+  for (const rel of stamp.roots ?? []) {
+    for (const abs of walkInputs(path.join(REPO_ROOT, rel))) {
+      if (!recorded.has(path.relative(REPO_ROOT, abs))) return true
+    }
+  }
   return false
 }
 // altimate_change end
@@ -204,22 +229,14 @@ describe("compiled binary smoke test", () => {
   // back to the mtime walk when the stamp is absent (older `bun run build:local`
   // runs, or targets built before the stamp landed).
   const stampVerdict = binary ? isBinaryStaleFromStamp(binary) : ("no-stamp" as const)
-  const stale =
-    binary === undefined
-      ? false
-      : stampVerdict === "no-stamp"
-        ? isBinaryStale(binary)
-        : stampVerdict
+  const stale = binary === undefined ? false : stampVerdict === "no-stamp" ? isBinaryStale(binary) : stampVerdict
   const skip = !binary || stale
   const runTest = skip ? test.skip : test
 
   if (!binary) {
     test.skip("no local build found — run `bun run build:local` first", () => {})
   } else if (stale) {
-    test.skip(
-      "local binary is stale (build-inputs stamp mismatch or newer src/script mtime) — run `bun run build:local` to refresh",
-      () => {},
-    )
+    test.skip("local binary is stale (build-inputs stamp mismatch or newer src/script mtime) — run `bun run build:local` to refresh", () => {})
   }
 
   runTest("binary starts and prints version", () => {

--- a/packages/opencode/test/install/smoke-test-binary.test.ts
+++ b/packages/opencode/test/install/smoke-test-binary.test.ts
@@ -19,6 +19,8 @@ import { describe, test, expect } from "bun:test"
 import { spawnSync, execFileSync } from "child_process"
 import path from "path"
 import fs from "fs"
+// altimate_change — #1052 D10: sha256 for stamp-based staleness check.
+import { createHash } from "node:crypto"
 import { tmpdir } from "../fixture/fixture"
 
 const PKG_DIR = path.resolve(import.meta.dir, "../..")
@@ -148,16 +150,74 @@ function isBinaryStale(binaryPath: string): boolean {
 }
 // altimate_change end
 
+// altimate_change start — #1052 D10: stamp-based staleness check.
+// build.ts emits `dist/<target>/bin/build-inputs.json` next to each binary,
+// listing every file the binary embedded (CHANGELOG, migrations, skills,
+// models-snapshot, parser worker, altimate-core prebuild, src/, script/) with
+// sha256. This function rehashes each listed input; any mismatch means the
+// binary no longer reflects the current sources. Falls back to the mtime walk
+// above when the stamp is missing (older builds, or fallback for `--single`
+// runs before the stamp landed).
+type BuildStamp = {
+  target: string
+  version: string
+  aggregate: string
+  inputs: Array<{ path: string; sha256: string }>
+}
+function readBuildStamp(binaryPath: string): BuildStamp | undefined {
+  const stampPath = path.join(path.dirname(binaryPath), "build-inputs.json")
+  try {
+    if (!fs.existsSync(stampPath)) return undefined
+    const parsed = JSON.parse(fs.readFileSync(stampPath, "utf-8")) as BuildStamp
+    if (!parsed?.inputs?.length) return undefined
+    return parsed
+  } catch {
+    return undefined
+  }
+}
+function sha256File(absPath: string): string | undefined {
+  try {
+    return createHash("sha256").update(fs.readFileSync(absPath)).digest("hex")
+  } catch {
+    return undefined
+  }
+}
+function isBinaryStaleFromStamp(binaryPath: string): boolean | "no-stamp" {
+  const stamp = readBuildStamp(binaryPath)
+  if (!stamp) return "no-stamp"
+  // Stamp paths are relative to packages/opencode (= PKG_DIR).
+  for (const { path: rel, sha256 } of stamp.inputs) {
+    const abs = path.join(PKG_DIR, rel)
+    const current = sha256File(abs)
+    if (current === undefined) return true // input vanished → binary can't reflect current tree
+    if (current !== sha256) return true
+  }
+  return false
+}
+// altimate_change end
+
 describe("compiled binary smoke test", () => {
   const binary = findLocalBinary()
-  const stale = binary ? isBinaryStale(binary) : false
+  // altimate_change — #1052 D10: prefer the stamp-based staleness check; fall
+  // back to the mtime walk when the stamp is absent (older `bun run build:local`
+  // runs, or targets built before the stamp landed).
+  const stampVerdict = binary ? isBinaryStaleFromStamp(binary) : ("no-stamp" as const)
+  const stale =
+    binary === undefined
+      ? false
+      : stampVerdict === "no-stamp"
+        ? isBinaryStale(binary)
+        : stampVerdict
   const skip = !binary || stale
   const runTest = skip ? test.skip : test
 
   if (!binary) {
     test.skip("no local build found — run `bun run build:local` first", () => {})
   } else if (stale) {
-    test.skip("local binary is older than the newest src/ or script/ file — run `bun run build:local` to refresh", () => {})
+    test.skip(
+      "local binary is stale (build-inputs stamp mismatch or newer src/script mtime) — run `bun run build:local` to refresh",
+      () => {},
+    )
   }
 
   runTest("binary starts and prints version", () => {

--- a/packages/opencode/test/lib/cli-process.ts
+++ b/packages/opencode/test/lib/cli-process.ts
@@ -47,7 +47,9 @@ const prebuiltCli = process.env.OPENCODE_TEST_CLI ? path.resolve(process.env.OPE
 // does not complete in the isolated test env (it hangs without exiting), while `bun run src` handles them
 // in ~1s. Those tests opt in via `bunRun: true`; everything else uses the fast prebuilt binary.
 function cliCommand(args: string[], bunRun = false): string[] {
-  return prebuiltCli && !bunRun ? [prebuiltCli, ...args] : [bunExecutable, "run", "--conditions=browser", cliEntry, ...args]
+  return prebuiltCli && !bunRun
+    ? [prebuiltCli, ...args]
+    : [bunExecutable, "run", "--conditions=browser", cliEntry, ...args]
 }
 
 export const testModelID = "test/test-model"
@@ -330,8 +332,13 @@ export function withCliFixture<A, E>(
                 .filter((e) => /^opencode.*\.db(-wal|-shm)?$/.test(e))
                 .map((e) => fsPromises.rm(path.join(dbDir, e), { force: true })),
             )
-          } catch {
-            // Directory absent or unreadable — nothing to clean. Retry proceeds.
+          } catch (error) {
+            // Bot-review fix: this used to swallow everything, so a permission
+            // error or a failed removal let the retry start on half-written
+            // SQLite state — the exact condition the scrub exists to prevent.
+            // A missing directory is the one benign case: nothing to clean.
+            const code = error && typeof error === "object" && "code" in error ? Reflect.get(error, "code") : undefined
+            if (code !== "ENOENT") throw error
           }
         })
         const elapsed = Date.now() - startedAt

--- a/packages/opencode/test/lib/cli-process.ts
+++ b/packages/opencode/test/lib/cli-process.ts
@@ -24,6 +24,8 @@ import { Deferred, Duration, Effect, Layer, Queue, Scope, Stream } from "effect"
 import { FetchHttpClient, HttpClient } from "effect/unstable/http"
 import { ChildProcess } from "effect/unstable/process"
 import path from "node:path"
+// altimate_change — #1052 D11: fsPromises for the pre-retry DB scrub.
+import * as fsPromises from "node:fs/promises"
 import { TestLLMServer } from "./llm-server"
 import { testProviderConfig } from "./test-provider"
 import { it } from "./effect"
@@ -293,6 +295,16 @@ export function withCliFixture<A, E>(
       // 60s spawn on top of the first (CodeRabbit v0.9.4 review finding).
       // Cap the retry at max(remaining, 15s) — enough for a warm-cache spawn
       // + cold-SQLite open without granting an unbounded second window.
+      //
+      // Before retrying, clean the SQLite state the first attempt may have
+      // written before hitting the lock (#1052 D11). `opencode run` writes
+      // session + tracing state at boot; if the first attempt got as far as
+      // opening the DB and taking a partial write before the WAL checkpoint
+      // collision, a naive retry would either see the partial state or
+      // double-write. Nuke the DB files (they live under this fixture's
+      // isolated XDG_DATA_HOME) so the second attempt starts from a clean
+      // slate. Other fixture state (config, home files) is preserved so
+      // tests that inject setup into `home` still see it.
       return Effect.gen(function* () {
         const startedAt = Date.now()
         const originalTimeoutMs = opts?.timeoutMs ?? 60_000
@@ -307,6 +319,21 @@ export function withCliFixture<A, E>(
           `[cli-process] child hit \`database is locked\` on first attempt (exit=${first.exitCode}); retrying once. ` +
             `If you see this often, the SQLite WAL/checkpoint contention has moved from transient to systematic.`,
         )
+        // Scrub SQLite state so the retry is idempotent (see block comment above).
+        // The DB path pattern matches the CLI's own file layout under XDG_DATA_HOME.
+        yield* Effect.promise(async () => {
+          const dbDir = path.join(home, ".local/share/altimate-code")
+          try {
+            const entries = await fsPromises.readdir(dbDir)
+            await Promise.all(
+              entries
+                .filter((e) => /^opencode.*\.db(-wal|-shm)?$/.test(e))
+                .map((e) => fsPromises.rm(path.join(dbDir, e), { force: true })),
+            )
+          } catch {
+            // Directory absent or unreadable — nothing to clean. Retry proceeds.
+          }
+        })
         const elapsed = Date.now() - startedAt
         const remaining = Math.max(originalTimeoutMs - elapsed, 15_000)
         const second = yield* spawn(argv, { ...opts, timeoutMs: remaining })

--- a/packages/opencode/test/provider/models-catalog.test.ts
+++ b/packages/opencode/test/provider/models-catalog.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test"
+import { ModelsCatalog } from "../../src/provider/models-catalog"
+import { snapshot } from "../../src/provider/models-snapshot"
+
+// altimate_change — bot-review fix: pin the models.dev catalog validator.
+//
+// A review asked for cached bodies to be validated with `Provider.safeParse`.
+// That looked right and was wrong: the schema requires a `Model.options` record
+// real models.dev entries do not carry, so it rejected 0 of the 144 providers
+// in our own bundled snapshot. Nothing was ever cached and every load fell
+// through to a network fetch, which hangs in sandboxed CI — a 60s timeout in an
+// unrelated CLI smoke test was the only signal. The first case below is the
+// guard that would have caught it.
+describe("ModelsCatalog.isCatalog", () => {
+  test("accepts the real bundled catalog", () => {
+    expect(ModelsCatalog.isCatalog(snapshot)).toBe(true)
+  })
+
+  test("accepts a minimal catalog-shaped record", () => {
+    expect(ModelsCatalog.isCatalog({ acme: { id: "acme", models: { "acme/one": {} } } })).toBe(true)
+  })
+
+  for (const [label, value] of [
+    ["an object-shaped error payload", { error: "rate limited" }],
+    ["a record whose values are strings", { acme: "nope" }],
+    ["a provider without a models map", { acme: { id: "acme" } }],
+    ["a JSON array", []],
+    ["a JSON scalar", 5],
+    ["null", null],
+    ["an empty object", {}],
+  ] as const) {
+    test(`rejects ${label}`, () => {
+      expect(ModelsCatalog.isCatalog(value)).toBe(false)
+    })
+  }
+})
+
+describe("ModelsCatalog.parseCatalog", () => {
+  test("returns the catalog for a real body", () => {
+    expect(Object.keys(ModelsCatalog.parseCatalog(JSON.stringify(snapshot)) ?? {}).length).toBe(
+      Object.keys(snapshot).length,
+    )
+  })
+
+  test("returns undefined for non-JSON, so an HTML error page is never cached", () => {
+    expect(ModelsCatalog.parseCatalog("<html>502 Bad Gateway</html>")).toBeUndefined()
+  })
+
+  test("returns undefined for JSON that is not a catalog", () => {
+    expect(ModelsCatalog.parseCatalog('{"error":"rate limited"}')).toBeUndefined()
+  })
+})

--- a/packages/opencode/test/skill/tracker-leak-check.test.ts
+++ b/packages/opencode/test/skill/tracker-leak-check.test.ts
@@ -12,6 +12,10 @@
 // source. Grep the repo for `\bAI-\d+` and this file returns nothing.
 
 import { describe, expect, test } from "bun:test"
+import { spawnSync } from "child_process"
+import fs from "fs"
+import os from "os"
+import path from "path"
 import { RULES } from "../../../../script/check-tracker-leaks"
 
 const jiraRule = RULES.find((r) => r.name.startsWith("Jira ticket key"))!
@@ -104,5 +108,91 @@ describe("Atlassian URL regex", () => {
   test("does not match unrelated atlassian hosts", () => {
     expect(matches(urlRule.pattern, "acme.atlassian.net")).toEqual([])
     expect(matches(urlRule.pattern, "docs.atlassian.com")).toEqual([])
+  })
+})
+
+// altimate_change — bot-review fix: end-to-end coverage of the scanner's git
+// behaviour, not just its regexes. These run the real script against throwaway
+// repositories, because the failures the reviewers found were all in how the
+// scanner picks WHAT to scan, which the regex tests cannot see. The script is
+// invoked as a subprocess rather than importing its internals, so nothing has
+// to be exported purely for tests. Leak fixtures still come from `key()`, so no
+// tracker-shaped literal enters this file.
+describe("scanner end-to-end (git behaviour)", () => {
+  const SCRIPT = path.resolve(import.meta.dir, "../../../../script/check-tracker-leaks.ts")
+  const ZERO = "0".repeat(40)
+
+  function repo(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tracker-e2e-"))
+    const git = (...args: string[]) => spawnSync("git", args, { cwd: dir, encoding: "utf-8" })
+    git("init", "-q", "-b", "main", ".")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "test")
+    return dir
+  }
+  const git = (dir: string, ...args: string[]) => spawnSync("git", args, { cwd: dir, encoding: "utf-8" })
+  function run(dir: string, stdin?: string) {
+    return spawnSync("bun", [SCRIPT], { cwd: dir, encoding: "utf-8", input: stdin ?? "" })
+  }
+  function commit(dir: string, text: string, message: string) {
+    fs.appendFileSync(path.join(dir, "f.txt"), text + "\n")
+    git(dir, "add", "-A")
+    git(dir, "commit", "-qm", message)
+  }
+  function baseline(dir: string) {
+    commit(dir, "base", "init")
+    git(dir, "update-ref", "refs/remotes/origin/main", "HEAD")
+  }
+
+  test("a repository with no commits is a clean scan, not a hard failure", () => {
+    // `rev-parse --abbrev-ref HEAD` exits 128 on an unborn HEAD; failing loud
+    // there contradicted the documented brand-new-repo path.
+    expect(run(repo()).status).toBe(0)
+  })
+
+  test("a clean branch passes silently", () => {
+    const dir = repo()
+    baseline(dir)
+    git(dir, "checkout", "-qb", "feature")
+    commit(dir, "nothing to see", "clean work")
+    const r = run(dir)
+    expect(r.status).toBe(0)
+    expect(r.stderr).toBe("")
+  })
+
+  test("a tracker reference in an added line fails the scan", () => {
+    const dir = repo()
+    baseline(dir)
+    git(dir, "checkout", "-qb", "feature")
+    commit(dir, `see ${key(1234)} for context`, "leaky work")
+    const r = run(dir)
+    expect(r.status).toBe(1)
+    expect(r.stderr).toContain(key(1234))
+  })
+
+  test("scans the ref being pushed, not the checked-out branch", () => {
+    // git hands a pre-push hook `<local ref> <local sha> <remote ref> <remote sha>`.
+    // Scanning HEAD regardless let `git push origin dirty:other` approve a ref
+    // nobody had looked at.
+    const dir = repo()
+    baseline(dir)
+    git(dir, "checkout", "-qb", "dirty")
+    commit(dir, `hidden ${key(9999)}`, "leaky work")
+    const dirtySha = git(dir, "rev-parse", "dirty").stdout.trim()
+    git(dir, "checkout", "-q", "main") // HEAD is now clean
+
+    expect(run(dir).status).toBe(0) // no stdin → HEAD only → misses it
+    const pushed = run(dir, `refs/heads/dirty ${dirtySha} refs/heads/other ${ZERO}\n`)
+    expect(pushed.status).toBe(1)
+    expect(pushed.stderr).toContain(key(9999))
+  })
+
+  test("a deletion-only push scans nothing rather than falling back to HEAD", () => {
+    const dir = repo()
+    baseline(dir)
+    git(dir, "checkout", "-qb", "dirty")
+    commit(dir, `hidden ${key(4242)}`, "leaky work") // HEAD is dirty on purpose
+    const r = run(dir, `(delete) ${ZERO} refs/heads/gone ${"1".repeat(40)}\n`)
+    expect(r.status).toBe(0)
   })
 })

--- a/packages/opencode/test/skill/tracker-leak-check.test.ts
+++ b/packages/opencode/test/skill/tracker-leak-check.test.ts
@@ -1,22 +1,31 @@
-// #1052 D8 review-fix (M6): self-test for the tracker-leak scanner's regexes.
-// The scanner is the sole guard against internal-tracker refs landing on the
-// public repo. If its regex regresses, the whole hook is silently useless. The
-// original `\bAI-\d+\b` had exactly that bug — it missed `AI-1234foo` /
-// `AI-1234_bar` because a trailing word char defeats the ending word-boundary.
-// Consensus review flagged this as CRITICAL. These tests pin the regex
-// against the specific suffix classes it must catch, plus the negative cases
+// Self-test for the tracker-leak scanner's regexes. See
+// `script/check-tracker-leaks.ts`. The scanner is the sole guard against
+// internal-tracker references landing on this public repo — if its regex
+// regresses, the guard silently stops working. These tests pin the regex
+// against representative suffix classes it must catch plus the negatives
 // that must remain clean.
 //
-// If you edit `script/check-tracker-leaks.ts` RULES and this test still passes,
-// you probably didn't regress the guard. If a case here starts failing, either
-// the regex changed intentionally (update the test) or the regex broke silently
-// (the whole point of this file).
+// Fixture note: this file is on a public repo that forbids concrete
+// project-prefixed tracker keys in source. Test inputs are therefore built
+// at runtime from a helper — `key(1234, "foo")` produces the exact string
+// the regex needs to see, but the literal never appears in git-searchable
+// source. Grep the repo for `\bAI-\d+` and this file returns nothing.
 
 import { describe, expect, test } from "bun:test"
 import { RULES } from "../../../../script/check-tracker-leaks"
 
 const jiraRule = RULES.find((r) => r.name.startsWith("Jira ticket key"))!
 const urlRule = RULES.find((r) => r.name.startsWith("Atlassian instance URL"))!
+
+// Build a Jira-key-shaped fixture without embedding the literal in source.
+// PREFIX + "-" + digits produces the exact string at runtime; the scanner's
+// regex sees whatever the test passes to `matches()`. Splitting the two
+// letters + hyphen defeats a naïve `grep -RE 'AI-\d+' .` sweep of this file.
+const PREFIX = "A" + "I"
+const key = (n: number, suffix = ""): string => `${PREFIX}-${n}${suffix}`
+
+// Same treatment for the Atlassian host used in the URL tests below.
+const HOST = "altimate" + "ai.atlassian.net"
 
 function matches(pattern: RegExp, text: string): string[] {
   // Fresh regex per call — global flag state would otherwise leak between calls.
@@ -26,58 +35,58 @@ function matches(pattern: RegExp, text: string): string[] {
 
 describe("Jira-key regex — positive cases (MUST match)", () => {
   test.each([
-    ["bare key at end of line", "See AI-1234"],
-    ["key followed by period", "See AI-1234."],
-    ["key followed by comma", "See AI-1234, next item"],
-    ["key in parentheses", "Fix (AI-1234) landed"],
-    ["key at branch-name boundary", "feature/AI-1234-fix"],
-    ["key followed by hyphen-word", "AI-1234-branch"],
-    ["key followed by slash", "AI-1234/subtask"],
-    ["key followed by colon", "AI-1234: title"],
-    ["key at start of line", "AI-1234 is the ticket"],
-    ["key on its own line", "AI-1234"],
-    ["key followed by whitespace + newline", "AI-1234\nnext"],
-  ])("matches: %s (%s)", (_label, text) => {
+    ["bare key at end of line", `See ${key(1234)}`],
+    ["key followed by period", `See ${key(1234)}.`],
+    ["key followed by comma", `See ${key(1234)}, next item`],
+    ["key in parentheses", `Fix (${key(1234)}) landed`],
+    ["key at branch-name boundary", `feature/${key(1234, "-fix")}`],
+    ["key followed by hyphen-word", key(1234, "-branch")],
+    ["key followed by slash", `${key(1234)}/subtask`],
+    ["key followed by colon", `${key(1234)}: title`],
+    ["key at start of line", `${key(1234)} is the ticket`],
+    ["key on its own line", key(1234)],
+    ["key followed by whitespace + newline", `${key(1234)}\nnext`],
+  ])("matches: %s", (_label, text) => {
     const hits = matches(jiraRule.pattern, text)
-    expect(hits).toContain("AI-1234")
+    expect(hits).toContain(key(1234))
   })
 
-  // The consensus-review M1 fix specifically — these MUST match after the
-  // pattern was loosened (dropped trailing \b). The original `\bAI-\d+\b`
-  // missed all of these because a trailing word char defeats the ending \b.
+  // The consensus-review fix specifically — these MUST match after the
+  // pattern was loosened (dropped trailing \b). The original required a
+  // trailing word boundary, which fails when a word char follows the digits.
   test.each([
-    ["suffix letter directly", "AI-1234foo", "AI-1234"],
-    ["suffix underscore", "AI-1234_bar", "AI-1234"],
-    ["suffix mixed word chars", "AI-1234thing", "AI-1234"],
-    ["branch with underscore", "feature/AI-1234_bug", "AI-1234"],
-    ["path prefix + suffix underscore", "docs/AI-1234_notes.md", "AI-1234"],
-  ])("catches suffix-adjacent leak: %s (%s) → %s", (_label, text, expected) => {
+    ["suffix letter directly", key(1234, "foo"), key(1234)],
+    ["suffix underscore", key(1234, "_bar"), key(1234)],
+    ["suffix mixed word chars", key(1234, "thing"), key(1234)],
+    ["branch with underscore", `feature/${key(1234, "_bug")}`, key(1234)],
+    ["path prefix + suffix underscore", `docs/${key(1234, "_notes.md")}`, key(1234)],
+  ])("catches suffix-adjacent leak: %s", (_label, text, expected) => {
     const hits = matches(jiraRule.pattern, text)
     expect(hits).toContain(expected)
   })
 })
 
 describe("Jira-key regex — known blind spots (documented)", () => {
-  // No leading `\b` = no match. Camel-cased pastes where AI immediately
-  // follows another word char remain a known blind spot. Realistic leak
-  // surface (branch names, commit messages, path fragments, doc text) is
-  // delimited so this doesn't hit in practice.
+  // No leading word-boundary = no match. Camel-cased pastes where the
+  // prefix immediately follows another word char remain a known blind spot.
+  // Realistic leak surface (branch names, commit messages, path fragments,
+  // doc text) is delimited so this doesn't hit in practice.
   test("does NOT catch camelCase paste without separator", () => {
-    expect(matches(jiraRule.pattern, "handleAI-1234thing")).toEqual([])
+    expect(matches(jiraRule.pattern, `handle${key(1234, "thing")}`)).toEqual([])
   })
 })
 
 describe("Jira-key regex — negative cases (MUST NOT match)", () => {
   test.each([
-    ["prefix word char", "prefixAI-1234"],
-    ["prefix underscore", "_AI-1234"],
+    ["prefix word char", `prefix${key(1234)}`],
+    ["prefix underscore", `_${key(1234)}`],
     ["different project prefix", "ML-1234"],
-    ["no dash", "AI1234"],
-    ["dash but no digits", "AI-"],
-    ["ordinary word AI", "the AI is here"],
+    ["no dash", `${PREFIX}1234`],
+    ["dash but no digits", `${PREFIX}-`],
+    ["ordinary word AI", `the ${PREFIX} is here`],
     ["url with 'ai-'", "https://example.com/ai-features"],
     ["lowercase", "ai-1234"],
-  ])("doesn't match: %s (%s)", (_label, text) => {
+  ])("doesn't match: %s", (_label, text) => {
     const hits = matches(jiraRule.pattern, text)
     expect(hits).toEqual([])
   })
@@ -85,15 +94,11 @@ describe("Jira-key regex — negative cases (MUST NOT match)", () => {
 
 describe("Atlassian URL regex", () => {
   test("matches the bare host", () => {
-    expect(matches(urlRule.pattern, "altimateai.atlassian.net")).toEqual([
-      "altimateai.atlassian.net",
-    ])
+    expect(matches(urlRule.pattern, HOST)).toEqual([HOST])
   })
 
   test("matches inside a URL", () => {
-    expect(
-      matches(urlRule.pattern, "https://altimateai.atlassian.net/browse/AI-1"),
-    ).toContain("altimateai.atlassian.net")
+    expect(matches(urlRule.pattern, `https://${HOST}/browse/${key(1)}`)).toContain(HOST)
   })
 
   test("does not match unrelated atlassian hosts", () => {

--- a/packages/opencode/test/skill/tracker-leak-check.test.ts
+++ b/packages/opencode/test/skill/tracker-leak-check.test.ts
@@ -11,7 +11,7 @@
 // the regex needs to see, but the literal never appears in git-searchable
 // source. Grep the repo for `\bAI-\d+` and this file returns nothing.
 
-import { describe, expect, test } from "bun:test"
+import { afterAll, describe, expect, test } from "bun:test"
 import { spawnSync } from "child_process"
 import fs from "fs"
 import os from "os"
@@ -122,8 +122,16 @@ describe("scanner end-to-end (git behaviour)", () => {
   const SCRIPT = path.resolve(import.meta.dir, "../../../../script/check-tracker-leaks.ts")
   const ZERO = "0".repeat(40)
 
+  // These repositories contain tracker-key fixtures, so they are removed rather
+  // than left in tmp for the next person to grep.
+  const created: string[] = []
+  afterAll(() => {
+    for (const dir of created) fs.rmSync(dir, { recursive: true, force: true })
+  })
+
   function repo(): string {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tracker-e2e-"))
+    created.push(dir)
     const git = (...args: string[]) => spawnSync("git", args, { cwd: dir, encoding: "utf-8" })
     git("init", "-q", "-b", "main", ".")
     git("config", "user.email", "test@example.com")
@@ -185,6 +193,17 @@ describe("scanner end-to-end (git behaviour)", () => {
     const pushed = run(dir, `refs/heads/dirty ${dirtySha} refs/heads/other ${ZERO}\n`)
     expect(pushed.status).toBe(1)
     expect(pushed.stderr).toContain(key(9999))
+  })
+
+  test("scans the destination ref name, which need not match the source", () => {
+    // `git push origin main:refs/heads/<tracker-key>` publishes a tracker-shaped
+    // branch while the source branch and every line of its content are clean.
+    const dir = repo()
+    baseline(dir)
+    const mainSha = git(dir, "rev-parse", "main").stdout.trim()
+    const r = run(dir, `refs/heads/main ${mainSha} refs/heads/${key(7777)} ${ZERO}\n`)
+    expect(r.status).toBe(1)
+    expect(r.stderr).toContain(key(7777))
   })
 
   test("a deletion-only push scans nothing rather than falling back to HEAD", () => {

--- a/packages/opencode/test/skill/tracker-leak-check.test.ts
+++ b/packages/opencode/test/skill/tracker-leak-check.test.ts
@@ -1,0 +1,103 @@
+// #1052 D8 review-fix (M6): self-test for the tracker-leak scanner's regexes.
+// The scanner is the sole guard against internal-tracker refs landing on the
+// public repo. If its regex regresses, the whole hook is silently useless. The
+// original `\bAI-\d+\b` had exactly that bug — it missed `AI-1234foo` /
+// `AI-1234_bar` because a trailing word char defeats the ending word-boundary.
+// Consensus review flagged this as CRITICAL. These tests pin the regex
+// against the specific suffix classes it must catch, plus the negative cases
+// that must remain clean.
+//
+// If you edit `script/check-tracker-leaks.ts` RULES and this test still passes,
+// you probably didn't regress the guard. If a case here starts failing, either
+// the regex changed intentionally (update the test) or the regex broke silently
+// (the whole point of this file).
+
+import { describe, expect, test } from "bun:test"
+import { RULES } from "../../../../script/check-tracker-leaks"
+
+const jiraRule = RULES.find((r) => r.name.startsWith("Jira ticket key"))!
+const urlRule = RULES.find((r) => r.name.startsWith("Atlassian instance URL"))!
+
+function matches(pattern: RegExp, text: string): string[] {
+  // Fresh regex per call — global flag state would otherwise leak between calls.
+  const rx = new RegExp(pattern.source, pattern.flags)
+  return [...text.matchAll(rx)].map((m) => m[0])
+}
+
+describe("Jira-key regex — positive cases (MUST match)", () => {
+  test.each([
+    ["bare key at end of line", "See AI-1234"],
+    ["key followed by period", "See AI-1234."],
+    ["key followed by comma", "See AI-1234, next item"],
+    ["key in parentheses", "Fix (AI-1234) landed"],
+    ["key at branch-name boundary", "feature/AI-1234-fix"],
+    ["key followed by hyphen-word", "AI-1234-branch"],
+    ["key followed by slash", "AI-1234/subtask"],
+    ["key followed by colon", "AI-1234: title"],
+    ["key at start of line", "AI-1234 is the ticket"],
+    ["key on its own line", "AI-1234"],
+    ["key followed by whitespace + newline", "AI-1234\nnext"],
+  ])("matches: %s (%s)", (_label, text) => {
+    const hits = matches(jiraRule.pattern, text)
+    expect(hits).toContain("AI-1234")
+  })
+
+  // The consensus-review M1 fix specifically — these MUST match after the
+  // pattern was loosened (dropped trailing \b). The original `\bAI-\d+\b`
+  // missed all of these because a trailing word char defeats the ending \b.
+  test.each([
+    ["suffix letter directly", "AI-1234foo", "AI-1234"],
+    ["suffix underscore", "AI-1234_bar", "AI-1234"],
+    ["suffix mixed word chars", "AI-1234thing", "AI-1234"],
+    ["branch with underscore", "feature/AI-1234_bug", "AI-1234"],
+    ["path prefix + suffix underscore", "docs/AI-1234_notes.md", "AI-1234"],
+  ])("catches suffix-adjacent leak: %s (%s) → %s", (_label, text, expected) => {
+    const hits = matches(jiraRule.pattern, text)
+    expect(hits).toContain(expected)
+  })
+})
+
+describe("Jira-key regex — known blind spots (documented)", () => {
+  // No leading `\b` = no match. Camel-cased pastes where AI immediately
+  // follows another word char remain a known blind spot. Realistic leak
+  // surface (branch names, commit messages, path fragments, doc text) is
+  // delimited so this doesn't hit in practice.
+  test("does NOT catch camelCase paste without separator", () => {
+    expect(matches(jiraRule.pattern, "handleAI-1234thing")).toEqual([])
+  })
+})
+
+describe("Jira-key regex — negative cases (MUST NOT match)", () => {
+  test.each([
+    ["prefix word char", "prefixAI-1234"],
+    ["prefix underscore", "_AI-1234"],
+    ["different project prefix", "ML-1234"],
+    ["no dash", "AI1234"],
+    ["dash but no digits", "AI-"],
+    ["ordinary word AI", "the AI is here"],
+    ["url with 'ai-'", "https://example.com/ai-features"],
+    ["lowercase", "ai-1234"],
+  ])("doesn't match: %s (%s)", (_label, text) => {
+    const hits = matches(jiraRule.pattern, text)
+    expect(hits).toEqual([])
+  })
+})
+
+describe("Atlassian URL regex", () => {
+  test("matches the bare host", () => {
+    expect(matches(urlRule.pattern, "altimateai.atlassian.net")).toEqual([
+      "altimateai.atlassian.net",
+    ])
+  })
+
+  test("matches inside a URL", () => {
+    expect(
+      matches(urlRule.pattern, "https://altimateai.atlassian.net/browse/AI-1"),
+    ).toContain("altimateai.atlassian.net")
+  })
+
+  test("does not match unrelated atlassian hosts", () => {
+    expect(matches(urlRule.pattern, "acme.atlassian.net")).toEqual([])
+    expect(matches(urlRule.pattern, "docs.atlassian.com")).toEqual([])
+  })
+})

--- a/packages/tui/test/util/phase-label.test.ts
+++ b/packages/tui/test/util/phase-label.test.ts
@@ -1,0 +1,61 @@
+// #1052 D12 — deterministic replacement for the deleted phase-label.tui-e2e.test.ts.
+//
+// The original test spawned a PTY, dispatched a real `session.phase` event through
+// the SSE bridge, and polled the rendered output. It flaked because the poll cadence
+// (50ms) raced against the phase-emit → store-set → render pipeline; a fast bootstrap
+// phase could finish before the poll caught it. That test was `test.skip` under `CI=true`
+// so PR #1053 deleted it rather than keeping deadweight.
+//
+// Deterministic coverage of the same chain now lives in three places:
+//
+//   1. Server-side publish + subscribe wiring — asserted by string-shape in
+//      `packages/opencode/test/upstream/fork-feature-guards.test.ts`.
+//   2. Store-mutation handler in `packages/tui/src/context/sync.tsx` (case
+//      "session.phase") — covered by the fork-feature-guards test above.
+//   3. THIS FILE — the last-mile lookup that renders the user-facing label from
+//      the stored phase name. This is the part most likely to silently break if
+//      someone edits `phase-label.ts` without updating the caller.
+//
+// A future extension of D12 would mount a full component + inject a Bus event
+// synchronously and assert the rendered text. Deferred because the event-injection
+// scaffolding does not yet exist as a reusable fixture; adding it is a separate
+// piece of work that is not gated on this file.
+
+import { describe, expect, test } from "bun:test"
+import { phaseLabel } from "../../src/util/phase-label"
+
+describe("phaseLabel", () => {
+  test("returns the mapped label for every bootstrap phase the backend emits", () => {
+    // These five span names are emitted by SessionPrompt.traceSpan on cold-start
+    // (see packages/opencode/src/session/prompt.ts). If backend changes a name
+    // without updating PHASE_LABELS, users see the "Thinking..." fallback instead
+    // of the honest phase — silent regression this test catches.
+    expect(phaseLabel("bootstrap.session-get")).toBe("Loading session...")
+    expect(phaseLabel("bootstrap.config-get")).toBe("Loading config...")
+    expect(phaseLabel("bootstrap.fingerprint-detect")).toBe("Detecting project shape...")
+    expect(phaseLabel("bootstrap.telemetry-init")).toBe("Preparing telemetry...")
+    expect(phaseLabel("bootstrap.resolve-tools")).toBe("Discovering tools...")
+  })
+
+  test("falls back to 'Thinking...' for an unknown phase name", () => {
+    // Any span the backend emits without a matching entry should render the safe
+    // default rather than the raw span name (which would leak internal shape).
+    expect(phaseLabel("turn.resolve-tools")).toBe("Thinking...")
+    expect(phaseLabel("bootstrap.some-future-phase")).toBe("Thinking...")
+    expect(phaseLabel("literally-anything-else")).toBe("Thinking...")
+  })
+
+  test("falls back to 'Thinking...' when no phase is active", () => {
+    // The store slot is `string | undefined` — undefined means no phase currently
+    // set (bootstrap complete, no per-turn span in progress). Renderer receives
+    // undefined and must show the neutral default.
+    expect(phaseLabel(undefined)).toBe("Thinking...")
+  })
+
+  test("does not surface an empty string as a label", () => {
+    // Defensive: if an empty string ever reaches the label function (e.g. from a
+    // reset that stored "" instead of undefined), the fallback should still apply
+    // rather than rendering an empty label next to the spinner.
+    expect(phaseLabel("")).toBe("Thinking...")
+  })
+})

--- a/script/check-tracker-leaks.ts
+++ b/script/check-tracker-leaks.ts
@@ -43,7 +43,8 @@ export const RULES = [
   {
     name: "Jira ticket key (AI-<digits>)",
     pattern: /\bAI-\d+/g,
-    remediation: "Rename branch / rewrite commit / delete text. Track work via GitHub issues on AltimateAI/altimate-code.",
+    remediation:
+      "Rename branch / rewrite commit / delete text. Track work via GitHub issues on AltimateAI/altimate-code.",
   },
   {
     name: "Atlassian instance URL",
@@ -75,10 +76,7 @@ type Hit = {
 // "expected empty result" (mergeBase against a diverged history) from
 // "unexpected failure" (git binary missing, corrupt index) so the latter
 // fails loud rather than reporting the branch as clean.
-async function git(
-  args: string[],
-  opts: { failOnError?: boolean } = { failOnError: true },
-): Promise<string> {
+async function git(args: string[], opts: { failOnError?: boolean } = { failOnError: true }): Promise<string> {
   const r = await $`git ${args}`.quiet().nothrow()
   if (r.exitCode !== 0) {
     if (opts.failOnError) {
@@ -122,25 +120,72 @@ async function main() {
     process.exit(2)
   }
 
-  const branch = await git(["rev-parse", "--abbrev-ref", "HEAD"])
-  // merge-base can legitimately return empty (no shared history) — don't fail loud on that.
-  const mergeBase = await git(["merge-base", "HEAD", base], { failOnError: false })
+  // Bot-review fix: git hands a pre-push hook one line per ref being pushed on
+  // stdin (`<local ref> <local sha> <remote ref> <remote sha>`). Scanning HEAD
+  // regardless meant `git push origin feature:other` — or pushing any branch
+  // that is not the checked-out one — approved refs nobody had looked at.
+  // Prefer the pushed tips when stdin gives them; fall back to HEAD otherwise
+  // (manual runs, CI).
+  const pushed = await readPushedRefs()
+  // Distinguish "git handed us refs" from "no stdin" (manual run / CI). A push
+  // made up only of deletions yields refs but no tips to scan, and must NOT
+  // fall back to HEAD — HEAD is unrelated to the ref being deleted, and would
+  // fail a push that adds no content at all.
+  if (pushed.hadInput && pushed.tips.length === 0) return
+  const tips = pushed.hadInput ? pushed.tips : [{ ref: "HEAD", sha: "HEAD" }]
+
+  // Bot-review fix: an unborn HEAD (freshly `git init`, zero commits) makes
+  // `rev-parse --abbrev-ref HEAD` exit 128. Failing loud there contradicted the
+  // documented "brand-new repo → silent success" path below, so this one lookup
+  // tolerates failure while every other git call still fails hard.
+  const branch = await git(["rev-parse", "--abbrev-ref", "HEAD"], { failOnError: false })
+
+  const hits: Hit[] = []
+  if (branch) scanText(branch, "branch name", hits)
+  for (const tip of tips) await scanTip(tip, base, hits)
+  reportAndExit(hits)
+}
+
+/** One `<local ref> <local sha> <remote ref> <remote sha>` line per pushed ref. */
+async function readPushedRefs(): Promise<{ hadInput: boolean; tips: Array<{ ref: string; sha: string }> }> {
+  if (process.stdin.isTTY) return { hadInput: false, tips: [] }
+  try {
+    const raw = await new Response(Bun.stdin.stream()).text()
+    const rows = raw
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .map((l) => l.split(/\s+/))
+      .filter((parts) => parts.length >= 2 && /^[0-9a-f]{40}$/i.test(parts[1]))
+    return {
+      hadInput: rows.length > 0,
+      // An all-zero local sha means the ref is being DELETED — no content to scan.
+      tips: rows.filter((parts) => !/^0{40}$/.test(parts[1])).map((parts) => ({ ref: parts[0], sha: parts[1] })),
+    }
+  } catch {
+    return { hadInput: false, tips: [] }
+  }
+}
+
+async function scanTip(tip: { ref: string; sha: string }, base: string, hits: Hit[]) {
+  const mergeBase = await git(["merge-base", tip.sha, base], { failOnError: false })
   if (!mergeBase) {
-    // No shared history with base — either brand-new repo or base doesn't exist locally.
-    // Silent success: nothing to check.
+    // No shared history with base — brand-new repo, or base missing locally
+    // (common on a shallow clone). Bot-review fix: say so on stderr instead of
+    // exiting silently, so a guard that has disabled itself is visible rather
+    // than looking like a clean scan.
+    process.stderr.write(
+      `tracker-leak check: no merge-base between ${tip.ref} and ${base}; skipping content scan. ` +
+        `Fetch the base ref (\`git fetch origin main\`) or pass --base=<ref> to enable it.\n`,
+    )
     return
   }
 
-  const ahead = Number(await git(["rev-list", "--count", `${mergeBase}..HEAD`]))
-  const hits: Hit[] = []
-
-  // 1. Branch name
-  scanText(branch, "branch name", hits)
-
+  const ahead = Number(await git(["rev-list", "--count", `${mergeBase}..${tip.sha}`]))
   if (ahead > 0) {
     // 2. Commit messages of local commits
-    const messages = await git(["log", `${mergeBase}..HEAD`, "--format=%B%x00"])
-    scanText(messages, `${ahead} commit message(s) ahead of ${base}`, hits)
+    const messages = await git(["log", `${mergeBase}..${tip.sha}`, "--format=%B%x00"])
+    scanText(messages, `${ahead} commit message(s) on ${tip.ref} ahead of ${base}`, hits)
 
     // 3. Added lines in the pushed diff. `--unified=0` narrows context; only
     //    real content additions count. Every diff line starting with `+`
@@ -151,14 +196,16 @@ async function main() {
     //    filter matches the file header exactly: `+++ ` (with the trailing
     //    space or tab), so content lines whose first non-plus is anything
     //    else — including tracker-shaped strings — still get scanned.
-    const diff = await git(["diff", "--unified=0", `${mergeBase}...HEAD`])
+    const diff = await git(["diff", "--unified=0", `${mergeBase}...${tip.sha}`])
     const added = diff
       .split("\n")
       .filter((l) => l.startsWith("+") && !l.startsWith("+++ ") && !l.startsWith("+++\t"))
       .join("\n")
-    scanText(added, `${ahead}-commit diff vs ${base} (added lines)`, hits)
+    scanText(added, `${tip.ref}: ${ahead}-commit diff vs ${base} (added lines)`, hits)
   }
+}
 
+function reportAndExit(hits: Hit[]) {
   if (hits.length === 0) {
     // Silent on clean runs — pre-push hooks should be quiet on success.
     return

--- a/script/check-tracker-leaks.ts
+++ b/script/check-tracker-leaks.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env bun
+/**
+ * Scans the local diff, branch name, and commit messages against `origin/main`
+ * for internal-tracker references that must not land on this public repo:
+ *
+ *   - Bare Jira keys of the form `AI-<digits>` (project prefix).
+ *   - The internal Atlassian instance host `altimateai.atlassian.net`.
+ *
+ * Exits 1 on any hit with a clear, per-source report. Exits 0 clean.
+ *
+ * Sources scanned:
+ *   1. Current branch name.
+ *   2. Commit messages of local commits ahead of `origin/main`.
+ *   3. `git diff origin/main...HEAD` — content of the pushed diff, added lines only.
+ *
+ * Base ref override via `--base=<ref>` (defaults to `origin/main`) — CI passes the
+ * PR base. When no commits are ahead of the base, the script is a no-op success.
+ *
+ * NOTE: this only checks pushed content. Historical commits already on main are
+ * intentionally out of scope — rewriting main history is destructive and not the
+ * job of a pre-push guard.
+ */
+
+import { $ } from "bun"
+
+const RULES = [
+  {
+    name: "Jira ticket key (AI-<digits>)",
+    pattern: /\bAI-\d+\b/g,
+    remediation: "Rename branch / rewrite commit / delete text. Track work via GitHub issues on AltimateAI/altimate-code.",
+  },
+  {
+    name: "Atlassian instance URL",
+    pattern: /\baltimateai\.atlassian\.net\b/g,
+    remediation: "Replace with the corresponding GitHub issue link or drop the reference.",
+  },
+]
+
+type Hit = {
+  rule: string
+  source: string
+  match: string
+  line?: string
+  remediation: string
+}
+
+async function shOK(cmd: string): Promise<string> {
+  try {
+    const r = await $`sh -c ${cmd}`.quiet()
+    return r.text().trim()
+  } catch {
+    return ""
+  }
+}
+
+function scanText(text: string, source: string, hits: Hit[]) {
+  for (const rule of RULES) {
+    const seen = new Set<string>()
+    for (const m of text.matchAll(rule.pattern)) {
+      if (seen.has(m[0])) continue
+      seen.add(m[0])
+      // Try to find the line the match sits on for context.
+      const before = text.slice(0, m.index ?? 0)
+      const lineStart = before.lastIndexOf("\n") + 1
+      const lineEnd = text.indexOf("\n", m.index ?? 0)
+      const line = text.slice(lineStart, lineEnd === -1 ? undefined : lineEnd).trim()
+      hits.push({ rule: rule.name, source, match: m[0], line, remediation: rule.remediation })
+    }
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  const baseArg = args.find((a) => a.startsWith("--base="))
+  const base = baseArg ? baseArg.slice("--base=".length) : "origin/main"
+
+  const branch = await shOK("git rev-parse --abbrev-ref HEAD")
+  const mergeBase = await shOK(`git merge-base HEAD ${base}`)
+  if (!mergeBase) {
+    // No shared history with base — either brand-new repo or base doesn't exist locally.
+    // Silent success: nothing to check.
+    return
+  }
+
+  const ahead = Number(await shOK(`git rev-list --count ${mergeBase}..HEAD`))
+  const hits: Hit[] = []
+
+  // 1. Branch name
+  scanText(branch, "branch name", hits)
+
+  if (ahead > 0) {
+    // 2. Commit messages of local commits
+    const messages = await shOK(`git log ${mergeBase}..HEAD --format=%B%x00`)
+    scanText(messages, `${ahead} commit message(s) ahead of ${base}`, hits)
+
+    // 3. Added lines in the pushed diff. `--unified=0` narrows context; grep for
+    //    added lines keeps the check focused on new content, not unmodified surroundings.
+    const diff = await shOK(`git diff --unified=0 ${mergeBase}...HEAD`)
+    const added = diff
+      .split("\n")
+      .filter((l) => l.startsWith("+") && !l.startsWith("+++"))
+      .join("\n")
+    scanText(added, `${ahead}-commit diff vs ${base} (added lines)`, hits)
+  }
+
+  if (hits.length === 0) {
+    // Silent on clean runs — pre-push hooks should be quiet on success.
+    return
+  }
+
+  process.stderr.write("\n\x1b[31m✗ tracker-leak check failed\x1b[0m\n\n")
+  process.stderr.write(`This repo is public. Internal tracker references cannot land here.\n\n`)
+  const bySource: Record<string, Hit[]> = {}
+  for (const h of hits) (bySource[h.source] ??= []).push(h)
+  for (const [source, list] of Object.entries(bySource)) {
+    process.stderr.write(`  in ${source}:\n`)
+    for (const h of list) {
+      process.stderr.write(`    - ${h.rule}: \x1b[33m${h.match}\x1b[0m\n`)
+      if (h.line && h.line !== h.match) {
+        const preview = h.line.length > 100 ? h.line.slice(0, 97) + "..." : h.line
+        process.stderr.write(`      line: ${preview}\n`)
+      }
+    }
+    process.stderr.write("\n")
+  }
+  const uniqueRemediations = new Set(hits.map((h) => h.remediation))
+  process.stderr.write("Remediation:\n")
+  for (const r of uniqueRemediations) process.stderr.write(`  - ${r}\n`)
+  process.stderr.write("\nBypass (emergencies only): SKIP_TRACKER_CHECK=1 git push ...\n\n")
+  process.exit(1)
+}
+
+if (process.env.SKIP_TRACKER_CHECK === "1") {
+  process.stderr.write("tracker-leak check skipped via SKIP_TRACKER_CHECK=1\n")
+} else {
+  await main()
+}

--- a/script/check-tracker-leaks.ts
+++ b/script/check-tracker-leaks.ts
@@ -141,13 +141,29 @@ async function main() {
   const branch = await git(["rev-parse", "--abbrev-ref", "HEAD"], { failOnError: false })
 
   const hits: Hit[] = []
-  if (branch) scanText(branch, "branch name", hits)
+  if (pushed.hadInput) {
+    // Bot-review fix: scan the ref NAMES being pushed, both ends. The
+    // destination is the one that becomes public, and it need not match the
+    // source — `git push origin main:refs/heads/<tracker-key>` publishes a
+    // tracker-shaped branch while `main` and its contents are perfectly clean.
+    // Tags go the same way. Only fall back to the checked-out branch name when
+    // git gave us nothing (manual run, CI).
+    for (const tip of tips) {
+      scanText(tip.ref, `pushed ref name (${tip.ref})`, hits)
+      if (tip.remote && tip.remote !== tip.ref) scanText(tip.remote, `destination ref name (${tip.remote})`, hits)
+    }
+  } else if (branch) {
+    scanText(branch, "branch name", hits)
+  }
   for (const tip of tips) await scanTip(tip, base, hits)
   reportAndExit(hits)
 }
 
 /** One `<local ref> <local sha> <remote ref> <remote sha>` line per pushed ref. */
-async function readPushedRefs(): Promise<{ hadInput: boolean; tips: Array<{ ref: string; sha: string }> }> {
+async function readPushedRefs(): Promise<{
+  hadInput: boolean
+  tips: Array<{ ref: string; sha: string; remote?: string }>
+}> {
   if (process.stdin.isTTY) return { hadInput: false, tips: [] }
   try {
     const raw = await new Response(Bun.stdin.stream()).text()
@@ -160,7 +176,9 @@ async function readPushedRefs(): Promise<{ hadInput: boolean; tips: Array<{ ref:
     return {
       hadInput: rows.length > 0,
       // An all-zero local sha means the ref is being DELETED — no content to scan.
-      tips: rows.filter((parts) => !/^0{40}$/.test(parts[1])).map((parts) => ({ ref: parts[0], sha: parts[1] })),
+      tips: rows
+        .filter((parts) => !/^0{40}$/.test(parts[1]))
+        .map((parts) => ({ ref: parts[0], sha: parts[1], remote: parts[2] })),
     }
   } catch {
     return { hadInput: false, tips: [] }

--- a/script/check-tracker-leaks.ts
+++ b/script/check-tracker-leaks.ts
@@ -1,10 +1,9 @@
 #!/usr/bin/env bun
 /**
  * Scans the local diff, branch name, and commit messages against `origin/main`
- * for internal-tracker references that must not land on this public repo:
- *
- *   - Bare Jira keys of the form `AI-<digits>` (project prefix).
- *   - The internal Atlassian instance host `altimateai.atlassian.net`.
+ * for internal-tracker references that must not land on this public repo.
+ * The exact patterns live in the `RULES` array below — read there for what
+ * gets flagged.
  *
  * Exits 1 on any hit with a clear, per-source report. Exits 0 clean.
  *
@@ -23,24 +22,23 @@
 
 import { $ } from "bun"
 
-// altimate_change — #1052 D8 review-fix (M1): drop the trailing word-boundary
-// from the Jira-key regex so the guard catches suffix-adjacent leaks like
-// `AI-1234foo`, `AI-1234_bar`, `feature/AI-1234_bug`.
+// altimate_change — #1052 D8 review-fix: drop the trailing word-boundary from
+// the Jira-key regex so the guard catches suffix-adjacent leaks (letter,
+// underscore, or another word char immediately after the digits). The
+// original required a trailing `\b`, which fails when a word char follows —
+// exactly the class of typo and paste-through the scrubber exists to prevent.
 //
-// The original `\bAI-\d+\b` required `\b` after the digits, which fails when a
-// word char (letter, digit, underscore) follows — exactly the class the guard
-// must catch. Naïve fixes (negative lookahead like `(?![a-zA-Z0-9_])`) don't
-// help: the regex engine backtracks `\d+`, but every backtrack position still
-// has a digit as the "next char" and the lookahead keeps failing. The correct
-// fix is no trailing boundary at all — just `\bAI-\d+` — which matches greedily
-// through the digits, stops when a non-digit appears, and reports the `AI-<n>`
-// prefix regardless of what follows.
+// Naïve fixes (negative lookahead like `(?![a-zA-Z0-9_])`) don't help: the
+// regex engine backtracks the digit run, but every position still has a digit
+// as the "next char" so the lookahead keeps failing. The correct fix is no
+// trailing boundary at all — the pattern matches greedily through the digits,
+// stops at the first non-digit, and reports the prefix regardless of what
+// follows.
 //
-// Caveat: `handleAI-1234thing` still escapes because there's no `\b` at the
-// start of `AI` (both `e` and `A` are word chars). Camel-cased pastes with no
-// separator before `AI` remain a known blind spot — accept it; the realistic
-// leak surface is branch names, commit messages, comments, and doc text where
-// `AI-…` is delimited by whitespace, punctuation, or a path separator.
+// Caveat: pastes with no separator before the prefix (no leading `\b`) are
+// not caught. Camel-cased inputs remain a known blind spot — accepted; the
+// realistic leak surface is branches, commits, comments, and doc text where
+// the reference is delimited by whitespace, punctuation, or a path separator.
 export const RULES = [
   {
     name: "Jira ticket key (AI-<digits>)",
@@ -111,8 +109,9 @@ async function main() {
     const messages = await shOK(`git log ${mergeBase}..HEAD --format=%B%x00`)
     scanText(messages, `${ahead} commit message(s) ahead of ${base}`, hits)
 
-    // 3. Added lines in the pushed diff. `--unified=0` narrows context; grep for
-    //    added lines keeps the check focused on new content, not unmodified surroundings.
+    // 3. Added lines in the pushed diff. `--unified=0` narrows context; grep
+    //    for added lines keeps the check focused on new content, not
+    //    unmodified surroundings.
     const diff = await shOK(`git diff --unified=0 ${mergeBase}...HEAD`)
     const added = diff
       .split("\n")

--- a/script/check-tracker-leaks.ts
+++ b/script/check-tracker-leaks.ts
@@ -60,13 +60,36 @@ type Hit = {
   remediation: string
 }
 
-async function shOK(cmd: string): Promise<string> {
-  try {
-    const r = await $`sh -c ${cmd}`.quiet()
-    return r.text().trim()
-  } catch {
+// altimate_change — bot-review fix: replace the `sh -c ${cmd}` helper.
+// Two problems it had:
+//   (a) `sh -c ${cmd}` collapsed the whole command string into one shell arg,
+//       which the shell then re-parsed — so a caller-supplied value (e.g.
+//       `--base=$(rm -rf ~)`) would execute as shell. Cubic P1.
+//   (b) `catch { return "" }` swallowed real errors (missing ref, corrupted
+//       repo). A failed git command would look identical to a clean scan.
+//
+// `git` is invoked directly via Bun.$ (no shell). Args are passed through the
+// tagged-template interpolation which quotes each interpolation as a single
+// argv element — no shell parsing anywhere. `.nothrow()` lets us inspect the
+// exit code instead of catching an exception. `exitOnFailure` distinguishes
+// "expected empty result" (mergeBase against a diverged history) from
+// "unexpected failure" (git binary missing, corrupt index) so the latter
+// fails loud rather than reporting the branch as clean.
+async function git(
+  args: string[],
+  opts: { failOnError?: boolean } = { failOnError: true },
+): Promise<string> {
+  const r = await $`git ${args}`.quiet().nothrow()
+  if (r.exitCode !== 0) {
+    if (opts.failOnError) {
+      process.stderr.write(
+        `\ntracker-leak check: \`git ${args.join(" ")}\` exited ${r.exitCode}\n${r.stderr.toString().trim()}\n\n`,
+      )
+      process.exit(2)
+    }
     return ""
   }
+  return r.text().trim()
 }
 
 function scanText(text: string, source: string, hits: Hit[]) {
@@ -90,15 +113,25 @@ async function main() {
   const baseArg = args.find((a) => a.startsWith("--base="))
   const base = baseArg ? baseArg.slice("--base=".length) : "origin/main"
 
-  const branch = await shOK("git rev-parse --abbrev-ref HEAD")
-  const mergeBase = await shOK(`git merge-base HEAD ${base}`)
+  // altimate_change — bot-review fix: validate --base looks like a git ref
+  // (defense in depth on top of the shell-safe git wrapper). Refs allow
+  // alnum + `/_.@{}~^-`, so a value containing `$`, backticks, spaces, etc.
+  // is definitely not a ref and should be rejected loudly.
+  if (!/^[A-Za-z0-9/_.@{}~^-]+$/.test(base)) {
+    process.stderr.write(`tracker-leak check: refusing suspicious --base value: ${JSON.stringify(base)}\n`)
+    process.exit(2)
+  }
+
+  const branch = await git(["rev-parse", "--abbrev-ref", "HEAD"])
+  // merge-base can legitimately return empty (no shared history) — don't fail loud on that.
+  const mergeBase = await git(["merge-base", "HEAD", base], { failOnError: false })
   if (!mergeBase) {
     // No shared history with base — either brand-new repo or base doesn't exist locally.
     // Silent success: nothing to check.
     return
   }
 
-  const ahead = Number(await shOK(`git rev-list --count ${mergeBase}..HEAD`))
+  const ahead = Number(await git(["rev-list", "--count", `${mergeBase}..HEAD`]))
   const hits: Hit[] = []
 
   // 1. Branch name
@@ -106,16 +139,22 @@ async function main() {
 
   if (ahead > 0) {
     // 2. Commit messages of local commits
-    const messages = await shOK(`git log ${mergeBase}..HEAD --format=%B%x00`)
+    const messages = await git(["log", `${mergeBase}..HEAD`, "--format=%B%x00"])
     scanText(messages, `${ahead} commit message(s) ahead of ${base}`, hits)
 
-    // 3. Added lines in the pushed diff. `--unified=0` narrows context; grep
-    //    for added lines keeps the check focused on new content, not
-    //    unmodified surroundings.
-    const diff = await shOK(`git diff --unified=0 ${mergeBase}...HEAD`)
+    // 3. Added lines in the pushed diff. `--unified=0` narrows context; only
+    //    real content additions count. Every diff line starting with `+`
+    //    that is NOT the `+++ b/path` file-header line is added content —
+    //    filtering by `!startsWith("+++")` also drops legitimate content
+    //    lines beginning with `++` (an added line whose text starts with
+    //    two plus signs renders as `+++...` in unified-diff). The safe
+    //    filter matches the file header exactly: `+++ ` (with the trailing
+    //    space or tab), so content lines whose first non-plus is anything
+    //    else — including tracker-shaped strings — still get scanned.
+    const diff = await git(["diff", "--unified=0", `${mergeBase}...HEAD`])
     const added = diff
       .split("\n")
-      .filter((l) => l.startsWith("+") && !l.startsWith("+++"))
+      .filter((l) => l.startsWith("+") && !l.startsWith("+++ ") && !l.startsWith("+++\t"))
       .join("\n")
     scanText(added, `${ahead}-commit diff vs ${base} (added lines)`, hits)
   }

--- a/script/check-tracker-leaks.ts
+++ b/script/check-tracker-leaks.ts
@@ -23,10 +23,28 @@
 
 import { $ } from "bun"
 
-const RULES = [
+// altimate_change — #1052 D8 review-fix (M1): drop the trailing word-boundary
+// from the Jira-key regex so the guard catches suffix-adjacent leaks like
+// `AI-1234foo`, `AI-1234_bar`, `feature/AI-1234_bug`.
+//
+// The original `\bAI-\d+\b` required `\b` after the digits, which fails when a
+// word char (letter, digit, underscore) follows — exactly the class the guard
+// must catch. Naïve fixes (negative lookahead like `(?![a-zA-Z0-9_])`) don't
+// help: the regex engine backtracks `\d+`, but every backtrack position still
+// has a digit as the "next char" and the lookahead keeps failing. The correct
+// fix is no trailing boundary at all — just `\bAI-\d+` — which matches greedily
+// through the digits, stops when a non-digit appears, and reports the `AI-<n>`
+// prefix regardless of what follows.
+//
+// Caveat: `handleAI-1234thing` still escapes because there's no `\b` at the
+// start of `AI` (both `e` and `A` are word chars). Camel-cased pastes with no
+// separator before `AI` remain a known blind spot — accept it; the realistic
+// leak surface is branch names, commit messages, comments, and doc text where
+// `AI-…` is delimited by whitespace, punctuation, or a path separator.
+export const RULES = [
   {
     name: "Jira ticket key (AI-<digits>)",
-    pattern: /\bAI-\d+\b/g,
+    pattern: /\bAI-\d+/g,
     remediation: "Rename branch / rewrite commit / delete text. Track work via GitHub issues on AltimateAI/altimate-code.",
   },
   {
@@ -130,8 +148,14 @@ async function main() {
   process.exit(1)
 }
 
-if (process.env.SKIP_TRACKER_CHECK === "1") {
-  process.stderr.write("tracker-leak check skipped via SKIP_TRACKER_CHECK=1\n")
-} else {
-  await main()
+// altimate_change — #1052 D8 review-fix (M6 companion): gate side-effectful
+// main() so RULES can be imported by the self-test file without triggering a
+// scanner run at test-collection time. Bun sets `import.meta.main = true` only
+// when this file is the entrypoint.
+if (import.meta.main) {
+  if (process.env.SKIP_TRACKER_CHECK === "1") {
+    process.stderr.write("tracker-leak check skipped via SKIP_TRACKER_CHECK=1\n")
+  } else {
+    await main()
+  }
 }


### PR DESCRIPTION
### Issue for this PR

Closes #1052 (partial — see "Not in this PR" below)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes 5 of 13 deferred items from #1052 (the v0.9.4 post-release cleanup tracking issue), plus 3 review-fixes flagged by a 6-model consensus code review on the initial 5 commits, plus one follow-up scrub.

**Scope:** the deferred items trace back to my own commits, so the split here is by size rather than by ownership. This batch takes the five that are self-contained enough to review together — D8, D10, D11, D12 and D14. The rest each want a change of their own: D9 crosses TUI + auth + manifest storage, D13 is a gateway-protocol change rather than a CLI patch, and D2–D6 span server-side validation, bundle slimming, Windows path handling and the `/event` contract. Bundling those in would bury the work that is here.

### Commits (bottom-up, oldest first)

Original D-item fixes:
1. `chore(hygiene): [#1052 D8] pre-push scan for internal-tracker refs` — scanner + hook + docs. CI mirror deferred to a follow-up PR (needs `workflow`-scoped token).
2. `test(build): [#1052 D10] stamp-based staleness guard for the smoke test` — build.ts emits `dist/<target>/bin/build-inputs.json` with sha256s; smoke test compares against it.
3. `test(harness): [#1052 D11] idempotent retry in cli-process.run()` — scrub `opencode*.db*` before the SQLite-lock retry so the second attempt starts clean.
4. `test(tui): [#1052 D12] deterministic regression test for phaseLabel()` — util-level unit test replacing the flaky PTY e2e.
5. `fix(models): [#1052 D14] drop eager import-time ModelsDev.refresh()` — the fetch was holding the event loop under `unshare --net` on CI. Snapshot covers cold-start.

Review-fixes (from a 6-model consensus code review of the above):
6. `fix(hygiene): [#1052 D8 review-fix M1] catch suffix-adjacent tracker leaks + self-test` — regex missed `<prefix>-<n><suffix>` (5/6 reviewers flagged, some as CRITICAL). Also adds a 28-case self-test file for the RULES.
7. `test(build): [#1052 D10 review-fix M2] widen stamp to workspace packages + lockfile` — the original stamp missed `packages/{tui,core,util,plugin,...}/src`, the workspace-root `package.json`, and `bun.lock`. Now walks each workspace `src/` and hashes those files.
8. `fix(models): [#1052 D14 review-fix M3] don't crash on non-JSON error body + fire refresh at boot` — pre-existing `JSON.parse(<HTML>)` crash on 5xx from models.dev + a fire-and-forget `Promise.resolve().then(refresh)` so short-lived commands still warm the cache without holding the loop.
9. `fix(hygiene): [#1052 D8 review-fix follow-up] scrub example strings from scanner source` — the M1 commit accidentally embedded concrete tracker-key literals in its own test file + doc comments. Fixtures now build the strings at runtime; scanner source drops the verbatim examples.

### Not in this PR (still open on #1052)

- **D1** — Interactive activation-menu picker. Design decision, not mechanical.
- **D2, D3, D4, D5, D6** — deferred on size, not ownership. Each sits in its own area (Question pending-registry, server-side shell-arg validation, manifest slimming, Windows long paths, `/event` dedup) and is better reviewed on its own.
- **D7** — pruned (false positive) at v0.9.4 review time.
- **D9** — `useConnected()` regression detector. Crosses TUI + auth + manifest storage; deserves its own PR.
- **D13** — SSH port-forwarding / device-code flow. Gateway-protocol change, not a CLI patch.
- **CI mirror for D8** — the `.github/workflows/tracker-leak-check.yml` file was in the local branch but this session's token lacks the `workflow` scope; add it in a follow-up PR.

### Test plan

- [x] `bun turbo typecheck` — 13/13 clean
- [x] `bun test packages/opencode/test/skill/tracker-leak-check.test.ts` — 28/28 (scanner RULES)
- [x] `bun test packages/tui/test/util/phase-label.test.ts` — 4/4 (phaseLabel util)
- [x] `bun script/check-tracker-leaks.ts` on the branch itself — silent (no leaks)
- [x] `bun run --cwd packages/opencode --conditions=browser ./src/index.ts --version` — exits in ~1s, no hang
- [ ] Full pre-release sanity (Verdaccio Phase 3 [10/10] no-internet check) — will run in CI. Note: D14's fire-and-forget refresh may reintroduce the sanity hang; if it does, the fix is dropping one line (documented in the D14 review-fix commit body).

### D14 caveat worth explicit reviewer attention

Commit 8 adds `Promise.resolve().then(() => ModelsDev.refresh().catch(() => {}))` alongside the hourly interval. A microtask doesn't itself keep Bun alive, and the fetch it schedules will just be abandoned at process-exit if unresolved — but if this reintroduces the original v0.9.4 blocker (sanity Phase 3 [10/10] under Linux `unshare --net`), the fix is to delete that one line and take the "snapshot-only cold-start" trade-off documented in commit 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8FGy89Qpr39k8nCSpCcK2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes five deferred items from #1052 and hardens release safety: blocks tracker leaks on push, makes binary staleness detection accurate across all embedded inputs, and prevents models.dev cache poisoning or boot-time hangs.

- Pre-push tracker check: `script/check-tracker-leaks.ts` now scans the refs actually being pushed (reads pre-push stdin) including source and destination ref names, commit messages ahead of base, and added diff lines only. Skips deletion-only pushes, tolerates unborn HEAD, warns when base is missing, validates `--base`, and uses shell-free `git` calls with a precise diff filter. Hook runs from `.husky/pre-push` after typecheck (bypass with `SKIP_TRACKER_CHECK=1`).
- Build staleness guard: `packages/opencode/script/build.ts` writes `dist/<target>/bin/build-inputs.json` with sha256 for all embedded inputs (CHANGELOG, migrations, bundled skills, models snapshot, parser worker, per-target native prebuild, `packages/*/src` including `.mp3`, each workspace `package.json`, workspace-root `package.json`, `bun.lock`, and `packages/opencode/tsconfig.json`). Paths are repo-root-relative and the stamp records walked roots and `packages/*/src` globs. The smoke test rehashes these and re-enumerates the roots to catch newly added files; falls back to the old mtime walk if no stamp is present. Shared walker lives in `packages/opencode/script/stamp-inputs.ts`.
- Models cache: drop the eager import-time refresh; keep the hourly `.unref()` refresh. `ModelsDev.Data()` parses and validates before caching, returns empty on non-2xx or invalid JSON, and rejects non-catalog objects; the disk cache is validated on read to avoid poisoning.
- Tests/docs: the CLI retry scrubs `opencode*.db{,-wal,-shm}` before a single retry and rethrows non-ENOENT errors; a deterministic unit test replaces the flaky PTY-based phase label test; end-to-end tests cover scanner behavior; `CONTRIBUTING.md` notes the pre-push scan and bypass.

<sup>Written for commit cafdcf4500d90db567336c864aa7d9fe9662bcc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/1085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated checks to detect sensitive tracker references before code is pushed.
  * Added build integrity checks to identify stale or changed build inputs.

* **Bug Fixes**
  * Improved handling of unavailable, invalid, or incomplete model catalogs.
  * Improved retry behavior when local database files are locked.
  * Reduced unnecessary model-catalog refresh activity during startup.

* **Documentation**
  * Documented pre-push validation checks and the optional bypass.

* **Tests**
  * Added coverage for tracker detection, build freshness, database retries, and startup phase labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



