### PR TITLE
feat: post-scan Workspaces prompt + `altimate-code link` subcommand

### DIFF
--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -66,8 +66,13 @@ export const Flag = {
   // altimate_change start — pilot flag for the Workspaces feature (post-scan prompt +
   // altimate link subcommand). Read as a getter so tests and the runtime `--` middleware
   // can flip it between plugin activation and command execution.
+  //
+  // Opt-in only — deliberately does NOT inherit ``OPENCODE_EXPERIMENTAL`` (as
+  // ``enabledByExperimental`` would). The pilot ships behind its own explicit
+  // gate so users already opted into other experimental features don't get
+  // this one turned on for them. (Kilo cycle 6.)
   get ALTIMATE_WORKSPACE() {
-    return enabledByExperimental("ALTIMATE_WORKSPACE")
+    return truthy("ALTIMATE_WORKSPACE")
   },
   // altimate_change end
 

--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -63,6 +63,14 @@ export const Flag = {
   OPENCODE_WORKSPACE_ID: process.env["OPENCODE_WORKSPACE_ID"],
   OPENCODE_EXPERIMENTAL_WORKSPACES: enabledByExperimental("OPENCODE_EXPERIMENTAL_WORKSPACES"),
 
+  // altimate_change start — pilot flag for the Workspaces feature (post-scan prompt +
+  // altimate link subcommand). Read as a getter so tests and the runtime `--` middleware
+  // can flip it between plugin activation and command execution.
+  get ALTIMATE_WORKSPACE() {
+    return enabledByExperimental("ALTIMATE_WORKSPACE")
+  },
+  // altimate_change end
+
   // Evaluated at access time (not module load) because tests, the CLI, and
   // external tooling set these env vars at runtime.
   get OPENCODE_DISABLE_PROJECT_CONFIG() {

--- a/packages/opencode/src/altimate/plugin/onboarding-telemetry.ts
+++ b/packages/opencode/src/altimate/plugin/onboarding-telemetry.ts
@@ -44,46 +44,59 @@ const workspaceLog = Log.create({ service: "altimate-workspace" })
  */
 const pendingWorkspacePromptSessions = new Set<string>()
 let workspacePromptUnsubscribe: (() => void) | null = null
+// Guard against two concurrent scans passing the ``!workspacePromptUnsubscribe``
+// check before either install completes — both would then install a listener
+// and the later assignment would overwrite the first disposer, leaking the
+// first listener for the process lifetime. Store the in-flight install as a
+// shared promise so concurrent callers await the same result. (CR round 2.)
+let workspacePromptInstall: Promise<void> | null = null
 
 async function armWorkspacePromptOnSessionIdle(sessionID: string): Promise<void> {
   pendingWorkspacePromptSessions.add(sessionID)
   if (workspacePromptUnsubscribe) return
-  try {
-    const unsubscribe = await AppRuntime.runPromise(
-      EventV2Bridge.Service.use((events) =>
-        events.listen((event) =>
-          Effect.gen(function* () {
-            if (event.type !== SessionEvent.Idle.type) return
-            const sid = (event.data as { sessionID?: string } | undefined)?.sessionID
-            if (!sid || !pendingWorkspacePromptSessions.has(sid)) return
-            pendingWorkspacePromptSessions.delete(sid)
-            yield* events.publish(TuiEvent.CommandExecute, {
-              command: "altimate.workspace.postScan",
-            })
-            // Once the Set drains, tear the listener down. A later scan
-            // that adds a new pending session re-arms it from scratch.
-            if (pendingWorkspacePromptSessions.size === 0 && workspacePromptUnsubscribe) {
-              const teardown = workspacePromptUnsubscribe
-              workspacePromptUnsubscribe = null
-              try {
-                teardown()
-              } catch (err) {
-                workspaceLog.warn("session-idle listener teardown failed", {
-                  err: String(err),
-                })
+  if (workspacePromptInstall) return workspacePromptInstall
+
+  workspacePromptInstall = (async () => {
+    try {
+      const unsubscribe = await AppRuntime.runPromise(
+        EventV2Bridge.Service.use((events) =>
+          events.listen((event) =>
+            Effect.gen(function* () {
+              if (event.type !== SessionEvent.Idle.type) return
+              const sid = (event.data as { sessionID?: string } | undefined)?.sessionID
+              if (!sid || !pendingWorkspacePromptSessions.has(sid)) return
+              pendingWorkspacePromptSessions.delete(sid)
+              yield* events.publish(TuiEvent.CommandExecute, {
+                command: "altimate.workspace.postScan",
+              })
+              // Once the Set drains, tear the listener down. A later scan
+              // that adds a new pending session re-arms it from scratch.
+              if (pendingWorkspacePromptSessions.size === 0 && workspacePromptUnsubscribe) {
+                const teardown = workspacePromptUnsubscribe
+                workspacePromptUnsubscribe = null
+                try {
+                  teardown()
+                } catch (err) {
+                  workspaceLog.warn("session-idle listener teardown failed", {
+                    err: String(err),
+                  })
+                }
               }
-            }
-          }),
+            }),
+          ),
         ),
-      ),
-    )
-    workspacePromptUnsubscribe = unsubscribe as unknown as () => void
-  } catch (err) {
-    // Install failed — drop the pending session so the next scan retries
-    // from scratch instead of accumulating a stale id that will never fire.
-    pendingWorkspacePromptSessions.delete(sessionID)
-    workspaceLog.warn("session-idle listener install failed", { err: String(err) })
-  }
+      )
+      workspacePromptUnsubscribe = unsubscribe as unknown as () => void
+    } catch (err) {
+      // Install failed — drop the pending session so the next scan retries
+      // from scratch instead of accumulating a stale id that will never fire.
+      pendingWorkspacePromptSessions.delete(sessionID)
+      workspaceLog.warn("session-idle listener install failed", { err: String(err) })
+    } finally {
+      workspacePromptInstall = null
+    }
+  })()
+  return workspacePromptInstall
 }
 // altimate_change end
 

--- a/packages/opencode/src/altimate/plugin/onboarding-telemetry.ts
+++ b/packages/opencode/src/altimate/plugin/onboarding-telemetry.ts
@@ -74,6 +74,13 @@ async function armWorkspacePromptOnSessionIdle(sessionID: string): Promise<void>
         EventV2Bridge.Service.use((events) =>
           events.listen((event) =>
             Effect.gen(function* () {
+              // NOTE: ``SessionEvent`` here is the module-local alias for
+              // ``Event`` imported from ``@/session/status`` (see imports
+              // above) — the MODERN ``EventV2.define`` API, not the
+              // deprecated ``LegacyEvent.Idle`` under ``BusEvent.define``.
+              // Grep the file for ``import { Event as SessionEvent }`` to
+              // confirm. Bots flagging this as "deprecated API" are
+              // false-positive matching on the token ``SessionEvent``.
               if (event.type !== SessionEvent.Idle.type) return
               const sid = (event.data as { sessionID?: string } | undefined)?.sessionID
               if (!sid || !pendingWorkspacePromptSessions.has(sid)) return

--- a/packages/opencode/src/altimate/plugin/onboarding-telemetry.ts
+++ b/packages/opencode/src/altimate/plugin/onboarding-telemetry.ts
@@ -16,11 +16,53 @@ import * as OnboardingTelemetry from "../telemetry/onboarding"
 // EventV2 bridge the server/routes/tui.ts uses to publish TuiEvent.CommandExecute
 // so the workspace TuiPlugin (packages/opencode/src/plugin/tui/altimate/workspace.tsx)
 // runs its post-scan flow. Feature-flagged via Flag.ALTIMATE_WORKSPACE.
+import { Effect } from "effect"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { AltimateApi } from "@/altimate/api/client"
 import { AppRuntime } from "@/effect/app-runtime"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { TuiEvent } from "@/server/tui-event"
+import { Event as SessionEvent } from "@/session/status"
+
+/**
+ * Publish the workspace-postScan command AFTER the session goes idle, not on
+ * `project_scan`'s tool.execute.after. Rationale: project_scan tool RETURNS while
+ * the LLM is still generating the activation-menu text; the dialog paints in
+ * that window but user interactions queue behind the streaming. Waiting for
+ * session.idle costs a few seconds of latency but sidesteps the race entirely —
+ * the dialog appears once things are quiet.
+ *
+ * One-shot per sessionID: the listener unregisters as soon as the target
+ * session emits idle. A pending arm is dropped if a second project_scan fires
+ * in the same session (unlikely but handled).
+ */
+const pendingWorkspacePromptSessions = new Set<string>()
+let workspacePromptListenerArmed = false
+
+async function armWorkspacePromptOnSessionIdle(sessionID: string): Promise<void> {
+  pendingWorkspacePromptSessions.add(sessionID)
+  if (workspacePromptListenerArmed) return
+  workspacePromptListenerArmed = true
+  await AppRuntime.runPromise(
+    EventV2Bridge.Service.use((events) =>
+      events.listen((event) =>
+        Effect.gen(function* () {
+          if (event.type !== SessionEvent.Idle.type) return
+          const sid = (event.data as { sessionID?: string } | undefined)?.sessionID
+          if (!sid || !pendingWorkspacePromptSessions.has(sid)) return
+          pendingWorkspacePromptSessions.delete(sid)
+          yield* events.publish(TuiEvent.CommandExecute, {
+            command: "altimate.workspace.postScan",
+          })
+        }),
+      ),
+    ),
+  ).catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error("[altimate-workspace] session-idle listener install failed:", err)
+    workspacePromptListenerArmed = false
+  })
+}
 // altimate_change end
 
 const ONBOARD_CONNECT = "onboard-connect"
@@ -145,25 +187,11 @@ export async function OnboardingTelemetryPlugin(_input: PluginInput): Promise<Ho
           input.sessionID,
         )
         // altimate_change start — AI-8398 workspaces post-scan prompt trigger.
-        // Fires the TUI plugin's altimate.workspace.postScan command once the scan
-        // completes AND the CLI has real Altimate credentials (BYOK users skip this
-        // path entirely — no place to send them). All the state (Skip latch, cache,
-        // server pre-check) is plugin-side so the trigger stays a fire-and-forget
-        // signal here; a retry would just re-enter the plugin's idempotent runFlow.
+        // ARM (don't publish yet) — the dialog fires when the session goes idle,
+        // not the moment project_scan returns. See armWorkspacePromptOnSessionIdle
+        // above for why the immediate publish raced the LLM's ongoing streaming.
         if (Flag.ALTIMATE_WORKSPACE && (await AltimateApi.isConfigured().catch(() => false))) {
-          void AppRuntime.runPromise(
-            EventV2Bridge.Service.use((events) =>
-              events.publish(TuiEvent.CommandExecute, {
-                command: "altimate.workspace.postScan",
-              }),
-            ),
-          ).catch((err) => {
-            // Never block onboarding on a publish failure — worst case the
-            // user picks up the workspace on their next launch or via the
-            // /altimate.workspace.link palette command.
-            // eslint-disable-next-line no-console
-            console.error("[altimate-workspace] postScan trigger failed:", err)
-          })
+          void armWorkspacePromptOnSessionIdle(input.sessionID)
         }
         // altimate_change end
         return

--- a/packages/opencode/src/altimate/plugin/onboarding-telemetry.ts
+++ b/packages/opencode/src/altimate/plugin/onboarding-telemetry.ts
@@ -23,6 +23,9 @@ import { AppRuntime } from "@/effect/app-runtime"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { TuiEvent } from "@/server/tui-event"
 import { Event as SessionEvent } from "@/session/status"
+import { Log } from "@/altimate/util/log"
+
+const workspaceLog = Log.create({ service: "altimate-workspace" })
 
 /**
  * Publish the workspace-postScan command AFTER the session goes idle, not on
@@ -32,36 +35,55 @@ import { Event as SessionEvent } from "@/session/status"
  * session.idle costs a few seconds of latency but sidesteps the race entirely —
  * the dialog appears once things are quiet.
  *
- * One-shot per sessionID: the listener unregisters as soon as the target
- * session emits idle. A pending arm is dropped if a second project_scan fires
- * in the same session (unlikely but handled).
+ * One-shot per sessionID: pending sessions live in a Set, and when a session
+ * emits idle its id is removed. When the Set drains, the EventV2 listener is
+ * torn down via the unsubscribe returned by ``events.listen()`` so a
+ * permanently-installed no-op handler isn't left behind for the process
+ * lifetime (m4 in the consensus review). A pending arm is dropped if a
+ * second project_scan fires in the same session.
  */
 const pendingWorkspacePromptSessions = new Set<string>()
-let workspacePromptListenerArmed = false
+let workspacePromptUnsubscribe: (() => void) | null = null
 
 async function armWorkspacePromptOnSessionIdle(sessionID: string): Promise<void> {
   pendingWorkspacePromptSessions.add(sessionID)
-  if (workspacePromptListenerArmed) return
-  workspacePromptListenerArmed = true
-  await AppRuntime.runPromise(
-    EventV2Bridge.Service.use((events) =>
-      events.listen((event) =>
-        Effect.gen(function* () {
-          if (event.type !== SessionEvent.Idle.type) return
-          const sid = (event.data as { sessionID?: string } | undefined)?.sessionID
-          if (!sid || !pendingWorkspacePromptSessions.has(sid)) return
-          pendingWorkspacePromptSessions.delete(sid)
-          yield* events.publish(TuiEvent.CommandExecute, {
-            command: "altimate.workspace.postScan",
-          })
-        }),
+  if (workspacePromptUnsubscribe) return
+  try {
+    const unsubscribe = await AppRuntime.runPromise(
+      EventV2Bridge.Service.use((events) =>
+        events.listen((event) =>
+          Effect.gen(function* () {
+            if (event.type !== SessionEvent.Idle.type) return
+            const sid = (event.data as { sessionID?: string } | undefined)?.sessionID
+            if (!sid || !pendingWorkspacePromptSessions.has(sid)) return
+            pendingWorkspacePromptSessions.delete(sid)
+            yield* events.publish(TuiEvent.CommandExecute, {
+              command: "altimate.workspace.postScan",
+            })
+            // Once the Set drains, tear the listener down. A later scan
+            // that adds a new pending session re-arms it from scratch.
+            if (pendingWorkspacePromptSessions.size === 0 && workspacePromptUnsubscribe) {
+              const teardown = workspacePromptUnsubscribe
+              workspacePromptUnsubscribe = null
+              try {
+                teardown()
+              } catch (err) {
+                workspaceLog.warn("session-idle listener teardown failed", {
+                  err: String(err),
+                })
+              }
+            }
+          }),
+        ),
       ),
-    ),
-  ).catch((err) => {
-    // eslint-disable-next-line no-console
-    console.error("[altimate-workspace] session-idle listener install failed:", err)
-    workspacePromptListenerArmed = false
-  })
+    )
+    workspacePromptUnsubscribe = unsubscribe as unknown as () => void
+  } catch (err) {
+    // Install failed — drop the pending session so the next scan retries
+    // from scratch instead of accumulating a stale id that will never fire.
+    pendingWorkspacePromptSessions.delete(sessionID)
+    workspaceLog.warn("session-idle listener install failed", { err: String(err) })
+  }
 }
 // altimate_change end
 

--- a/packages/opencode/src/altimate/plugin/onboarding-telemetry.ts
+++ b/packages/opencode/src/altimate/plugin/onboarding-telemetry.ts
@@ -12,6 +12,16 @@
 // session loop.
 import type { Hooks, PluginInput } from "@opencode-ai/plugin"
 import * as OnboardingTelemetry from "../telemetry/onboarding"
+// altimate_change start — AI-8398 workspaces trigger. Reaches into the same
+// EventV2 bridge the server/routes/tui.ts uses to publish TuiEvent.CommandExecute
+// so the workspace TuiPlugin (packages/opencode/src/plugin/tui/altimate/workspace.tsx)
+// runs its post-scan flow. Feature-flagged via Flag.ALTIMATE_WORKSPACE.
+import { Flag } from "@opencode-ai/core/flag/flag"
+import { AltimateApi } from "@/altimate/api/client"
+import { AppRuntime } from "@/effect/app-runtime"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { TuiEvent } from "@/server/tui-event"
+// altimate_change end
 
 const ONBOARD_CONNECT = "onboard-connect"
 
@@ -134,6 +144,28 @@ export async function OnboardingTelemetryPlugin(_input: PluginInput): Promise<Ho
           },
           input.sessionID,
         )
+        // altimate_change start — AI-8398 workspaces post-scan prompt trigger.
+        // Fires the TUI plugin's altimate.workspace.postScan command once the scan
+        // completes AND the CLI has real Altimate credentials (BYOK users skip this
+        // path entirely — no place to send them). All the state (Skip latch, cache,
+        // server pre-check) is plugin-side so the trigger stays a fire-and-forget
+        // signal here; a retry would just re-enter the plugin's idempotent runFlow.
+        if (Flag.ALTIMATE_WORKSPACE && (await AltimateApi.isConfigured().catch(() => false))) {
+          void AppRuntime.runPromise(
+            EventV2Bridge.Service.use((events) =>
+              events.publish(TuiEvent.CommandExecute, {
+                command: "altimate.workspace.postScan",
+              }),
+            ),
+          ).catch((err) => {
+            // Never block onboarding on a publish failure — worst case the
+            // user picks up the workspace on their next launch or via the
+            // /altimate.workspace.link palette command.
+            // eslint-disable-next-line no-console
+            console.error("[altimate-workspace] postScan trigger failed:", err)
+          })
+        }
+        // altimate_change end
         return
       }
 

--- a/packages/opencode/src/altimate/plugin/onboarding-telemetry.ts
+++ b/packages/opencode/src/altimate/plugin/onboarding-telemetry.ts
@@ -43,7 +43,12 @@ const workspaceLog = Log.create({ service: "altimate-workspace" })
  * second project_scan fires in the same session.
  */
 const pendingWorkspacePromptSessions = new Set<string>()
-let workspacePromptUnsubscribe: (() => void) | null = null
+/** The unsubscribe returned by ``events.listen()`` is an Effect (not a plain
+ * function) — running it removes the listener. Store the Effect and execute
+ * it through ``AppRuntime.runPromise`` on teardown; earlier code cast it to
+ * ``() => void`` and called it directly, which threw because Effects are not
+ * callable as functions. (cubic-dev-ai round 3.) */
+let workspacePromptUnsubscribe: Effect.Effect<void, never, never> | null = null
 // Guard against two concurrent scans passing the ``!workspacePromptUnsubscribe``
 // check before either install completes — both would then install a listener
 // and the later assignment would overwrite the first disposer, leaking the
@@ -55,6 +60,13 @@ async function armWorkspacePromptOnSessionIdle(sessionID: string): Promise<void>
   pendingWorkspacePromptSessions.add(sessionID)
   if (workspacePromptUnsubscribe) return
   if (workspacePromptInstall) return workspacePromptInstall
+
+  // Capture the set of pending sessions at install-time so an install
+  // failure drains EVERY caller that awaited this install, not just the
+  // one whose sessionID we happen to be handling. Later waiters would
+  // otherwise see success from the shared promise and stop retrying,
+  // leaving permanently-stale entries in the pending set. (cubic round 3.)
+  const armingSessions = new Set(pendingWorkspacePromptSessions)
 
   workspacePromptInstall = (async () => {
     try {
@@ -71,26 +83,29 @@ async function armWorkspacePromptOnSessionIdle(sessionID: string): Promise<void>
               })
               // Once the Set drains, tear the listener down. A later scan
               // that adds a new pending session re-arms it from scratch.
+              // ``teardown`` is an Effect — run it through the app runtime,
+              // don't call it as a function. (cubic round 3.)
               if (pendingWorkspacePromptSessions.size === 0 && workspacePromptUnsubscribe) {
                 const teardown = workspacePromptUnsubscribe
                 workspacePromptUnsubscribe = null
-                try {
-                  teardown()
-                } catch (err) {
+                AppRuntime.runPromise(teardown).catch((err) => {
                   workspaceLog.warn("session-idle listener teardown failed", {
                     err: String(err),
                   })
-                }
+                })
               }
             }),
           ),
         ),
       )
-      workspacePromptUnsubscribe = unsubscribe as unknown as () => void
+      workspacePromptUnsubscribe = unsubscribe
     } catch (err) {
-      // Install failed — drop the pending session so the next scan retries
-      // from scratch instead of accumulating a stale id that will never fire.
-      pendingWorkspacePromptSessions.delete(sessionID)
+      // Install failed — drop every session that was waiting on this install
+      // so the next scan retries from scratch. Dropping only the current
+      // caller's ID would leave later waiters (already resolved by the
+      // shared install promise) with permanently-stale pending entries.
+      // (cubic round 3.)
+      for (const sid of armingSessions) pendingWorkspacePromptSessions.delete(sid)
       workspaceLog.warn("session-idle listener install failed", { err: String(err) })
     } finally {
       workspacePromptInstall = null

--- a/packages/opencode/src/altimate/plugin/onboarding-telemetry.ts
+++ b/packages/opencode/src/altimate/plugin/onboarding-telemetry.ts
@@ -61,28 +61,25 @@ async function armWorkspacePromptOnSessionIdle(sessionID: string): Promise<void>
   if (workspacePromptUnsubscribe) return
   if (workspacePromptInstall) return workspacePromptInstall
 
-  // Capture the set of pending sessions at install-time so an install
-  // failure drains EVERY caller that awaited this install, not just the
-  // one whose sessionID we happen to be handling. Later waiters would
-  // otherwise see success from the shared promise and stop retrying,
-  // leaving permanently-stale entries in the pending set. (cubic round 3.)
-  const armingSessions = new Set(pendingWorkspacePromptSessions)
-
   workspacePromptInstall = (async () => {
     try {
       const unsubscribe = await AppRuntime.runPromise(
         EventV2Bridge.Service.use((events) =>
           events.listen((event) =>
             Effect.gen(function* () {
-              // NOTE: ``SessionEvent`` here is the module-local alias for
-              // ``Event`` imported from ``@/session/status`` (see imports
-              // above) — the MODERN ``EventV2.define`` API, not the
-              // deprecated ``LegacyEvent.Idle`` under ``BusEvent.define``.
-              // Grep the file for ``import { Event as SessionEvent }`` to
-              // confirm. Bots flagging this as "deprecated API" are
-              // false-positive matching on the token ``SessionEvent``.
-              if (event.type !== SessionEvent.Idle.type) return
-              const sid = (event.data as { sessionID?: string } | undefined)?.sessionID
+              // Subscribe to ``Event.Status`` (session/status.ts:42, defined
+              // via ``EventV2.define``) rather than ``Event.Idle`` — the
+              // latter is marked ``// deprecated`` at session/status.ts:49
+              // and is only kept around for the legacy Bus SSE mirror at
+              // session/status.ts:176. Filtering ``event.data.status.type
+              // === "idle"`` gives us the same trigger without riding the
+              // deprecated event. (harness-bot round 8.)
+              if (event.type !== SessionEvent.Status.type) return
+              const data = event.data as
+                | { sessionID?: string; status?: { type?: string } }
+                | undefined
+              if (data?.status?.type !== "idle") return
+              const sid = data.sessionID
               if (!sid || !pendingWorkspacePromptSessions.has(sid)) return
               pendingWorkspacePromptSessions.delete(sid)
               yield* events.publish(TuiEvent.CommandExecute, {
@@ -107,12 +104,12 @@ async function armWorkspacePromptOnSessionIdle(sessionID: string): Promise<void>
       )
       workspacePromptUnsubscribe = unsubscribe
     } catch (err) {
-      // Install failed — drop every session that was waiting on this install
-      // so the next scan retries from scratch. Dropping only the current
-      // caller's ID would leave later waiters (already resolved by the
-      // shared install promise) with permanently-stale pending entries.
-      // (cubic round 3.)
-      for (const sid of armingSessions) pendingWorkspacePromptSessions.delete(sid)
+      // Install failed — drain EVERY pending session, not just the ones
+      // snapshotted at install-time. A late-arriving ``armWorkspacePromptOn
+      // SessionIdle`` between the snapshot and the failure would otherwise
+      // be a permanent orphan (its sessionID stays in the pending set but
+      // no listener will ever fire for it). (harness-bot round 8.)
+      pendingWorkspacePromptSessions.clear()
       workspaceLog.warn("session-idle listener install failed", { err: String(err) })
     } finally {
       workspacePromptInstall = null

--- a/packages/opencode/src/altimate/tools/project-scan.ts
+++ b/packages/opencode/src/altimate/tools/project-scan.ts
@@ -173,8 +173,13 @@ export async function detectGit(): Promise<GitInfo> {
  * SSH-form remotes (`git@github.com:owner/repo.git`) have no userinfo
  * concept and are left untouched. URLs we can't parse are dropped to
  * undefined (better to lose the breadcrumb than leak creds).
+ *
+ * Exported so the workspace TuiPlugin (packages/opencode/src/plugin/tui/
+ * altimate/workspace.tsx) can reuse the exact same scrubbing rules when
+ * deriving the project's git remote for the post-scan prompt — the alt
+ * of duplicating the logic risks the two callers drifting.
  */
-function stripGitRemoteCredentials(url: string): string | undefined {
+export function stripGitRemoteCredentials(url: string): string | undefined {
   if (!url) return undefined
   // SSH form: `git@host:path` — no creds to strip.
   if (/^[\w.-]+@[\w.-]+:/.test(url) && !url.includes("://")) return url

--- a/packages/opencode/src/altimate/workspace/api-client.ts
+++ b/packages/opencode/src/altimate/workspace/api-client.ts
@@ -1,0 +1,231 @@
+// altimate_change - new file
+//
+// Wire client for the workspace-binding endpoints in altimate-backend
+// (/datamate-project-bindings/*, added by AI-8398). Shared between the TUI
+// plugin (packages/opencode/src/plugin/tui/altimate/workspace.tsx) and the
+// `altimate link` CLI subcommand (packages/opencode/src/cli/cmd/link.ts) so
+// the two entry points can't drift on request shape / error handling.
+//
+// Reads AltimateApi credentials on every call so an account switch is picked
+// up immediately without a plugin restart. All FastAPI HTTPException.detail
+// bodies come out as `{"detail": <string|object>}` — we parse the object form
+// for 409/412 and surface it as a typed error rather than a bare status code.
+import { AltimateApi } from "@/altimate/api/client"
+
+const REQUEST_TIMEOUT_MS = 15_000
+
+export interface DatamateRef {
+  id: number
+  name: string
+}
+
+export interface Binding {
+  id: number
+  datamate_id: number
+  datamate_name: string
+  repo_remote: string
+  created_at?: string
+}
+
+export interface CreateAndBindResponse {
+  datamate: DatamateRef
+  binding: Binding
+  manage_url: string
+}
+
+export interface BindingResponse {
+  binding: Binding
+}
+
+export interface GetBindingResponse {
+  binding: Binding
+  datamate: DatamateRef
+}
+
+export interface ConflictDetail {
+  message: string
+  existing_datamate_id?: number
+  existing_datamate_name?: string | null
+  repo_remote?: string
+}
+
+export interface PreconditionDetail {
+  message: string
+  actual_current_datamate_id?: number
+  expected_current_datamate_id?: number
+}
+
+export class NotConfiguredError extends Error {
+  constructor() {
+    super("Altimate credentials not configured — sign in first.")
+    this.name = "NotConfiguredError"
+  }
+}
+
+export class ConflictError extends Error {
+  constructor(public readonly detail: ConflictDetail) {
+    super(detail.message)
+    this.name = "ConflictError"
+  }
+}
+
+export class PreconditionFailedError extends Error {
+  constructor(public readonly detail: PreconditionDetail) {
+    super(detail.message)
+    this.name = "PreconditionFailedError"
+  }
+}
+
+export class NotFoundError extends Error {
+  constructor(msg = "Not found") {
+    super(msg)
+    this.name = "NotFoundError"
+  }
+}
+
+export class ForbiddenError extends Error {
+  constructor(msg = "Forbidden") {
+    super(msg)
+    this.name = "ForbiddenError"
+  }
+}
+
+export class WorkspaceApiError extends Error {
+  constructor(
+    msg: string,
+    public readonly status?: number,
+  ) {
+    super(msg)
+    this.name = "WorkspaceApiError"
+  }
+}
+
+async function creds(): Promise<{ url: string; instance: string; apiKey: string }> {
+  if (!(await AltimateApi.isConfigured())) throw new NotConfiguredError()
+  const c = await AltimateApi.getCredentials()
+  return { url: c.altimateUrl, instance: c.altimateInstanceName, apiKey: c.altimateApiKey }
+}
+
+async function req<T>(
+  method: string,
+  subpath: string,
+  opts: { body?: unknown; query?: Record<string, string> } = {},
+): Promise<T> {
+  const { url, instance, apiKey } = await creds()
+  const qs = opts.query ? "?" + new URLSearchParams(opts.query).toString() : ""
+  const target = `${url}/datamate-project-bindings${subpath}${qs}`
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  let res: Response
+  try {
+    res = await fetch(target, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+        "x-tenant": instance,
+      },
+      signal: controller.signal,
+      ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new WorkspaceApiError(`Cannot reach ${target}: ${msg}`)
+  } finally {
+    clearTimeout(timeout)
+  }
+  let json: unknown = undefined
+  const text = await res.text().catch(() => "")
+  if (text) {
+    try {
+      json = JSON.parse(text)
+    } catch {
+      /* non-JSON body — surface as opaque via status code below */
+    }
+  }
+  const detail = (json as { detail?: unknown } | undefined)?.detail
+  if (res.status === 404) throw new NotFoundError(typeof detail === "string" ? detail : "Not found")
+  if (res.status === 403) throw new ForbiddenError(typeof detail === "string" ? detail : "Forbidden")
+  if (res.status === 409) {
+    const d =
+      typeof detail === "object" && detail !== null
+        ? (detail as ConflictDetail)
+        : { message: typeof detail === "string" ? detail : "Conflict" }
+    throw new ConflictError(d)
+  }
+  if (res.status === 412) {
+    const d =
+      typeof detail === "object" && detail !== null
+        ? (detail as PreconditionDetail)
+        : { message: typeof detail === "string" ? detail : "Precondition failed" }
+    throw new PreconditionFailedError(d)
+  }
+  if (!res.ok) {
+    throw new WorkspaceApiError(
+      typeof detail === "string" ? detail : `Request failed with status ${res.status}`,
+      res.status,
+    )
+  }
+  return json as T
+}
+
+export namespace WorkspaceApi {
+  /** Server-authoritative pre-check: is this remote already bound in this tenant? */
+  export async function getBindingForRemote(remote: string): Promise<GetBindingResponse | null> {
+    try {
+      return await req<GetBindingResponse>("GET", "/by-remote", { query: { repo_remote: remote } })
+    } catch (err) {
+      if (err instanceof NotFoundError) return null
+      throw err
+    }
+  }
+
+  export async function createAndBind(input: {
+    name: string
+    repoRemote: string
+    description?: string
+  }): Promise<CreateAndBindResponse> {
+    return req<CreateAndBindResponse>("POST", "/", {
+      body: {
+        name: input.name,
+        repo_remote: input.repoRemote,
+        description: input.description ?? null,
+      },
+    })
+  }
+
+  export async function bindExisting(datamateId: number, remote: string): Promise<BindingResponse> {
+    return req<BindingResponse>("POST", "/bind", {
+      body: { datamate_id: datamateId, repo_remote: remote },
+    })
+  }
+
+  export async function rebindByRemote(input: {
+    remote: string
+    targetDatamateId: number
+    expectedCurrentDatamateId?: number
+  }): Promise<BindingResponse> {
+    return req<BindingResponse>("PUT", "/by-remote", {
+      body: {
+        repo_remote: input.remote,
+        target_datamate_id: input.targetDatamateId,
+        ...(input.expectedCurrentDatamateId !== undefined
+          ? { expected_current_datamate_id: input.expectedCurrentDatamateId }
+          : {}),
+      },
+    })
+  }
+
+  /** Populates the "link to existing workspace" picker. Reuses the existing
+   * /datamates/ list endpoint on the datamates_router. */
+  export async function listDatamates(): Promise<DatamateRef[]> {
+    const { url, instance, apiKey } = await creds()
+    const res = await fetch(`${url}/datamates/`, {
+      headers: { Authorization: `Bearer ${apiKey}`, "x-tenant": instance },
+    })
+    if (!res.ok)
+      throw new WorkspaceApiError(`Failed to list workspaces (status ${res.status})`, res.status)
+    const body = (await res.json()) as { datamates?: Array<{ id: number | string; name: string }> }
+    return (body.datamates ?? []).map((d) => ({ id: Number(d.id), name: d.name }))
+  }
+}

--- a/packages/opencode/src/altimate/workspace/api-client.ts
+++ b/packages/opencode/src/altimate/workspace/api-client.ts
@@ -215,8 +215,11 @@ async function req<T>(
   // ``.manage_url``), so silently handing back ``undefined as T`` produces a
   // ``TypeError`` inside caller code that the typed-error switches can't
   // classify. Surface it as a WorkspaceApiError instead — unless the caller
-  // opted in via ``allowEmptyBody`` (e.g. 204 endpoints). (m7)
-  if (json === undefined && !opts.allowEmptyBody) {
+  // opted in via ``allowEmptyBody`` (e.g. 204 endpoints). Use ``== null`` so a
+  // literal ``JSON.parse("null")`` (which sets json to null, not undefined)
+  // is treated as an empty body too — otherwise ``null as T`` reaches callers
+  // and .foo throws in a way the typed switches can't classify. (m7 + CR)
+  if (json == null && !opts.allowEmptyBody) {
     throw new WorkspaceApiError(
       `Empty ${res.status} body from ${target} — expected JSON payload`,
       res.status,

--- a/packages/opencode/src/altimate/workspace/api-client.ts
+++ b/packages/opencode/src/altimate/workspace/api-client.ts
@@ -152,6 +152,7 @@ async function req<T>(
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
   let res: Response
+  let text: string
   try {
     res = await fetch(target, {
       method,
@@ -163,10 +164,16 @@ async function req<T>(
       signal: controller.signal,
       ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
     })
+    // Keep the AbortController timeout ACTIVE while we read the response body.
+    // ``fetch()`` resolves after headers arrive; a server can send headers then
+    // stall the body stream indefinitely, so pulling the body inside the same
+    // try/finally is the difference between our 15s cap and hanging until TCP
+    // gives up. (CR bot-review round 2.)
+    text = await res.text().catch(() => "")
   } catch (err) {
     // Distinguish "we hit our 15s abort" from "network stack failed" so the
     // caller can decide differently (retry, longer timeout, offline banner).
-    // (m8 in the consensus review.)
+    // The abort fires equally when it kills the fetch OR the body read. (m8)
     const name = (err as { name?: string } | undefined)?.name
     if (name === "AbortError") {
       throw new WorkspaceApiError(
@@ -179,7 +186,6 @@ async function req<T>(
     clearTimeout(timeout)
   }
   let json: unknown = undefined
-  const text = await res.text().catch(() => "")
   if (text) {
     try {
       json = JSON.parse(text)

--- a/packages/opencode/src/altimate/workspace/api-client.ts
+++ b/packages/opencode/src/altimate/workspace/api-client.ts
@@ -168,8 +168,11 @@ async function req<T>(
     // ``fetch()`` resolves after headers arrive; a server can send headers then
     // stall the body stream indefinitely, so pulling the body inside the same
     // try/finally is the difference between our 15s cap and hanging until TCP
-    // gives up. (CR bot-review round 2.)
-    text = await res.text().catch(() => "")
+    // gives up. (CR round 2.) Do NOT wrap in ``.catch(() => "")`` — that
+    // swallows the AbortError from the timeout firing during the body read
+    // and turns a stalled response into a false "empty body". Rejection
+    // rethrows into the outer catch and is classified there. (cubic round 3.)
+    text = await res.text()
   } catch (err) {
     // Distinguish "we hit our 15s abort" from "network stack failed" so the
     // caller can decide differently (retry, longer timeout, offline banner).
@@ -343,13 +346,24 @@ export namespace WorkspaceApi {
    * doesn't reach the picker as a "NaN" label that the caller then binds
    * against. */
   export async function listDatamates(): Promise<DatamateRef[]> {
-    const body = await req<{ datamates?: Array<{ id: number | string; name: string }> }>(
-      "GET",
-      "/",
-      { base: "/datamates" },
-    )
-    return (body.datamates ?? [])
+    // Accept THREE response envelopes — today's ``{datamates: [...]}``, a
+    // bare ``[...]``, and a generic ``{data: [...]}`` — so a backend
+    // contract change (or compat layer) doesn't silently empty the picker.
+    // (cubic-dev-ai round 3.)
+    type Row = { id: number | string; name: string }
+    const body = await req<Row[] | { datamates?: Row[]; data?: Row[] }>("GET", "/", {
+      base: "/datamates",
+    })
+    let rows: Row[]
+    if (Array.isArray(body)) {
+      rows = body
+    } else if (body && typeof body === "object") {
+      rows = body.datamates ?? body.data ?? []
+    } else {
+      rows = []
+    }
+    return rows
       .map((d) => ({ id: Number(d.id), name: d.name }))
-      .filter((d) => Number.isInteger(d.id) && d.id > 0)
+      .filter((d) => Number.isInteger(d.id) && d.id > 0 && typeof d.name === "string")
   }
 }

--- a/packages/opencode/src/altimate/workspace/api-client.ts
+++ b/packages/opencode/src/altimate/workspace/api-client.ts
@@ -358,7 +358,15 @@ export namespace WorkspaceApi {
     if (Array.isArray(body)) {
       rows = body
     } else if (body && typeof body === "object") {
-      rows = body.datamates ?? body.data ?? []
+      // Guard each envelope field with Array.isArray — a non-array
+      // ``datamates`` or ``data`` value (object / string / null) would
+      // otherwise slip through and throw on ``.map`` below, taking the
+      // picker down before it renders. (cubic round 4.)
+      rows = Array.isArray(body.datamates)
+        ? body.datamates
+        : Array.isArray(body.data)
+          ? body.data
+          : []
     } else {
       rows = []
     }

--- a/packages/opencode/src/altimate/workspace/api-client.ts
+++ b/packages/opencode/src/altimate/workspace/api-client.ts
@@ -370,7 +370,14 @@ export namespace WorkspaceApi {
     } else {
       rows = []
     }
+    // Filter valid row objects BEFORE map (Kilo cycle 5) — a single ``null``
+    // (or non-object) element in an otherwise-valid array would otherwise
+    // throw ``TypeError: Cannot read properties of null`` on ``d.id`` before
+    // the post-map filter can drop it. That's the exact picker-down failure
+    // the round-3/4 envelope guards were added to prevent, just from a
+    // per-element rather than per-envelope malformed value.
     return rows
+      .filter((d): d is Row => d !== null && typeof d === "object")
       .map((d) => ({ id: Number(d.id), name: d.name }))
       .filter((d) => Number.isInteger(d.id) && d.id > 0 && typeof d.name === "string")
   }

--- a/packages/opencode/src/altimate/workspace/api-client.ts
+++ b/packages/opencode/src/altimate/workspace/api-client.ts
@@ -52,6 +52,17 @@ export interface GetBindingResponse {
   datamate: DatamateRef
 }
 
+/** Which identifier arm the pre-check lookup actually matched on. Callers use
+ * this to pick the correct rebind endpoint (``/by-remote`` vs ``/by-path``)
+ * regardless of what the CURRENT identifier has — a repo whose remote was
+ * renamed still resolves via its ``project_path``, and a later ``rebindByRemote``
+ * would 404 because no binding exists under the new remote. (M3) */
+export type MatchedIdentifier = "remote" | "path"
+
+export interface ProjectBindingLookup extends GetBindingResponse {
+  matchedBy: MatchedIdentifier
+}
+
 export interface ConflictDetail {
   message: string
   existing_datamate_id?: number
@@ -120,11 +131,24 @@ async function creds(): Promise<{ url: string; instance: string; apiKey: string 
 async function req<T>(
   method: string,
   subpath: string,
-  opts: { body?: unknown; query?: Record<string, string> } = {},
+  opts: {
+    body?: unknown
+    query?: Record<string, string>
+    /** Override the base path prefix. Defaults to
+     * ``/datamate-project-bindings`` (this module's namespace). Pass e.g.
+     * ``/datamates`` to hit the sibling datamates_router through the same
+     * timeout / typed-error / empty-body machinery. */
+    base?: string
+    /** If true, a 2xx with an empty body returns ``undefined`` typed as T
+     * instead of throwing. Only set for endpoints known to return 204 or a
+     * bare 200 with no payload. */
+    allowEmptyBody?: boolean
+  } = {},
 ): Promise<T> {
   const { url, instance, apiKey } = await creds()
   const qs = opts.query ? "?" + new URLSearchParams(opts.query).toString() : ""
-  const target = `${url}/datamate-project-bindings${subpath}${qs}`
+  const basePath = opts.base ?? "/datamate-project-bindings"
+  const target = `${url}${basePath}${subpath}${qs}`
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
   let res: Response
@@ -140,6 +164,15 @@ async function req<T>(
       ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
     })
   } catch (err) {
+    // Distinguish "we hit our 15s abort" from "network stack failed" so the
+    // caller can decide differently (retry, longer timeout, offline banner).
+    // (m8 in the consensus review.)
+    const name = (err as { name?: string } | undefined)?.name
+    if (name === "AbortError") {
+      throw new WorkspaceApiError(
+        `Request to ${target} timed out after ${Math.round(REQUEST_TIMEOUT_MS / 1000)}s`,
+      )
+    }
     const msg = err instanceof Error ? err.message : String(err)
     throw new WorkspaceApiError(`Cannot reach ${target}: ${msg}`)
   } finally {
@@ -177,6 +210,18 @@ async function req<T>(
       res.status,
     )
   }
+  // A 2xx with an empty (or unparseable) body is not the same as a resource.
+  // Callers dereference the return immediately (``.binding``, ``.datamate``,
+  // ``.manage_url``), so silently handing back ``undefined as T`` produces a
+  // ``TypeError`` inside caller code that the typed-error switches can't
+  // classify. Surface it as a WorkspaceApiError instead — unless the caller
+  // opted in via ``allowEmptyBody`` (e.g. 204 endpoints). (m7)
+  if (json === undefined && !opts.allowEmptyBody) {
+    throw new WorkspaceApiError(
+      `Empty ${res.status} body from ${target} — expected JSON payload`,
+      res.status,
+    )
+  }
   return json as T
 }
 
@@ -203,15 +248,18 @@ export namespace WorkspaceApi {
   }
 
   /** Tries remote first (stronger identity), then path. Returns the first hit
-   * or null. Both fields on the identifier are optional but at least one must
-   * be present. */
-  export async function getBindingForProject(id: ProjectIdentifier): Promise<GetBindingResponse | null> {
+   * TAGGED with which identifier matched, so a caller that later rebinds
+   * picks the right endpoint even if the current identifier's remote has
+   * changed since the binding was created (M3). Both fields on the
+   * identifier are optional but at least one must be present. */
+  export async function getBindingForProject(id: ProjectIdentifier): Promise<ProjectBindingLookup | null> {
     if (id.repoRemote) {
       const hit = await getBindingForRemote(id.repoRemote)
-      if (hit) return hit
+      if (hit) return { ...hit, matchedBy: "remote" }
     }
     if (id.projectPath) {
-      return await getBindingForPath(id.projectPath)
+      const hit = await getBindingForPath(id.projectPath)
+      if (hit) return { ...hit, matchedBy: "path" }
     }
     return null
   }
@@ -279,15 +327,20 @@ export namespace WorkspaceApi {
   }
 
   /** Populates the "link to existing workspace" picker. Reuses the existing
-   * /datamates/ list endpoint on the datamates_router. */
+   * ``/datamates/`` list endpoint on the datamates_router — routed through
+   * the shared ``req()`` machinery so it inherits the 15s abort, typed
+   * error mapping, empty-body guard, and detail-parsing everyone else
+   * gets. (M5) Filters out non-integer / non-positive ids so a corrupt row
+   * doesn't reach the picker as a "NaN" label that the caller then binds
+   * against. */
   export async function listDatamates(): Promise<DatamateRef[]> {
-    const { url, instance, apiKey } = await creds()
-    const res = await fetch(`${url}/datamates/`, {
-      headers: { Authorization: `Bearer ${apiKey}`, "x-tenant": instance },
-    })
-    if (!res.ok)
-      throw new WorkspaceApiError(`Failed to list workspaces (status ${res.status})`, res.status)
-    const body = (await res.json()) as { datamates?: Array<{ id: number | string; name: string }> }
-    return (body.datamates ?? []).map((d) => ({ id: Number(d.id), name: d.name }))
+    const body = await req<{ datamates?: Array<{ id: number | string; name: string }> }>(
+      "GET",
+      "/",
+      { base: "/datamates" },
+    )
+    return (body.datamates ?? [])
+      .map((d) => ({ id: Number(d.id), name: d.name }))
+      .filter((d) => Number.isInteger(d.id) && d.id > 0)
   }
 }

--- a/packages/opencode/src/altimate/workspace/api-client.ts
+++ b/packages/opencode/src/altimate/workspace/api-client.ts
@@ -23,8 +23,18 @@ export interface Binding {
   id: number
   datamate_id: number
   datamate_name: string
-  repo_remote: string
+  /** Either ``repo_remote`` OR ``project_path`` is populated (at least one). */
+  repo_remote: string | null
+  project_path: string | null
   created_at?: string
+}
+
+/** Project identifier passed to create/bind endpoints. At least one field is
+ * required by the backend's CHECK constraint; the CLI's resolveProjectIdentifier
+ * always populates ``projectPath`` and populates ``repoRemote`` when available. */
+export interface ProjectIdentifier {
+  repoRemote?: string
+  projectPath?: string
 }
 
 export interface CreateAndBindResponse {
@@ -47,6 +57,7 @@ export interface ConflictDetail {
   existing_datamate_id?: number
   existing_datamate_name?: string | null
   repo_remote?: string
+  project_path?: string
 }
 
 export interface PreconditionDetail {
@@ -170,7 +181,7 @@ async function req<T>(
 }
 
 export namespace WorkspaceApi {
-  /** Server-authoritative pre-check: is this remote already bound in this tenant? */
+  /** Server-authoritative pre-check by git remote. Returns null on 404. */
   export async function getBindingForRemote(remote: string): Promise<GetBindingResponse | null> {
     try {
       return await req<GetBindingResponse>("GET", "/by-remote", { query: { repo_remote: remote } })
@@ -180,23 +191,56 @@ export namespace WorkspaceApi {
     }
   }
 
+  /** Symmetric pre-check by absolute project directory path (for projects
+   * without a git remote). Returns null on 404. */
+  export async function getBindingForPath(projectPath: string): Promise<GetBindingResponse | null> {
+    try {
+      return await req<GetBindingResponse>("GET", "/by-path", { query: { project_path: projectPath } })
+    } catch (err) {
+      if (err instanceof NotFoundError) return null
+      throw err
+    }
+  }
+
+  /** Tries remote first (stronger identity), then path. Returns the first hit
+   * or null. Both fields on the identifier are optional but at least one must
+   * be present. */
+  export async function getBindingForProject(id: ProjectIdentifier): Promise<GetBindingResponse | null> {
+    if (id.repoRemote) {
+      const hit = await getBindingForRemote(id.repoRemote)
+      if (hit) return hit
+    }
+    if (id.projectPath) {
+      return await getBindingForPath(id.projectPath)
+    }
+    return null
+  }
+
   export async function createAndBind(input: {
     name: string
-    repoRemote: string
+    identifier: ProjectIdentifier
     description?: string
   }): Promise<CreateAndBindResponse> {
     return req<CreateAndBindResponse>("POST", "/", {
       body: {
         name: input.name,
-        repo_remote: input.repoRemote,
+        repo_remote: input.identifier.repoRemote ?? null,
+        project_path: input.identifier.projectPath ?? null,
         description: input.description ?? null,
       },
     })
   }
 
-  export async function bindExisting(datamateId: number, remote: string): Promise<BindingResponse> {
+  export async function bindExisting(
+    datamateId: number,
+    identifier: ProjectIdentifier,
+  ): Promise<BindingResponse> {
     return req<BindingResponse>("POST", "/bind", {
-      body: { datamate_id: datamateId, repo_remote: remote },
+      body: {
+        datamate_id: datamateId,
+        repo_remote: identifier.repoRemote ?? null,
+        project_path: identifier.projectPath ?? null,
+      },
     })
   }
 
@@ -208,6 +252,24 @@ export namespace WorkspaceApi {
     return req<BindingResponse>("PUT", "/by-remote", {
       body: {
         repo_remote: input.remote,
+        target_datamate_id: input.targetDatamateId,
+        ...(input.expectedCurrentDatamateId !== undefined
+          ? { expected_current_datamate_id: input.expectedCurrentDatamateId }
+          : {}),
+      },
+    })
+  }
+
+  /** Path-identified rebind — symmetric to ``rebindByRemote`` for projects
+   * without a git remote. */
+  export async function rebindByPath(input: {
+    projectPath: string
+    targetDatamateId: number
+    expectedCurrentDatamateId?: number
+  }): Promise<BindingResponse> {
+    return req<BindingResponse>("PUT", "/by-path", {
+      body: {
+        project_path: input.projectPath,
         target_datamate_id: input.targetDatamateId,
         ...(input.expectedCurrentDatamateId !== undefined
           ? { expected_current_datamate_id: input.expectedCurrentDatamateId }

--- a/packages/opencode/src/altimate/workspace/detect.ts
+++ b/packages/opencode/src/altimate/workspace/detect.ts
@@ -9,6 +9,8 @@
 // form of `https://<userinfo>@github.com/...`) never reaches the server or
 // the local cache in clear.
 import { spawnSync } from "node:child_process"
+import { realpathSync } from "node:fs"
+import path from "node:path"
 import { stripGitRemoteCredentials } from "../tools/project-scan"
 
 export function detectProjectRemote(directory: string): string | undefined {
@@ -25,6 +27,30 @@ export function detectProjectRemote(directory: string): string | undefined {
   }
 }
 
+/** Project identity for the binding system. Prefers ``repo_remote`` when the
+ * project has a git remote (stronger identity — survives directory moves); falls
+ * back to ``project_path`` (absolute, symlink-resolved directory path) for
+ * projects without one (materialized sample scaffolds, fresh scratch dirs).
+ *
+ * Both fields can be populated simultaneously; callers pick which to use for
+ * lookup or send both to create/bind (server uses whichever it needs for its
+ * partial unique index). At least one field is always populated — falling back
+ * to the raw ``directory`` argument keeps the "no remote AND unresolvable path"
+ * degenerate case from returning empty. */
+export function resolveProjectIdentifier(directory: string): {
+  repoRemote?: string
+  projectPath: string
+} {
+  const repoRemote = detectProjectRemote(directory)
+  let projectPath: string
+  try {
+    projectPath = realpathSync(path.resolve(directory))
+  } catch {
+    projectPath = path.resolve(directory)
+  }
+  return repoRemote ? { repoRemote, projectPath } : { projectPath }
+}
+
 /** Sensible default workspace name from a remote URL — best-effort. Used to
  * prefill the workspace-name prompt in the CreateDialog and `altimate link`.
  * ``github.com/foo/bar.git`` → ``bar`` ; ``git@github.com:foo/bar.git`` → ``bar``. */
@@ -32,4 +58,11 @@ export function projectNameFromRemote(remote: string): string {
   const trimmed = remote.replace(/\.git$/, "").replace(/\/$/, "")
   const parts = trimmed.split(/[/:]/)
   return parts[parts.length - 1] || "workspace"
+}
+
+/** Fallback name source when the project has no git remote — uses the directory's
+ * basename (e.g. ``/Users/x/sample-dbt-project`` → ``sample-dbt-project``). */
+export function projectNameFromPath(projectPath: string): string {
+  const base = path.basename(projectPath.replace(/\/$/, ""))
+  return base || "workspace"
 }

--- a/packages/opencode/src/altimate/workspace/detect.ts
+++ b/packages/opencode/src/altimate/workspace/detect.ts
@@ -1,0 +1,35 @@
+// altimate_change - new file
+//
+// Cheap, sync git-remote detection for the workspace-binding flow. Shared by
+// the TuiPlugin (packages/opencode/src/plugin/tui/altimate/workspace.tsx) and
+// the `altimate link` CLI subcommand so both entry points identify projects
+// identically. Reuses the credential-scrubbing helper the ProjectScan tool
+// exports (../tools/project-scan.ts) so an HTTPS remote with basic-auth
+// embedded in the RFC 3986 userinfo component (e.g. the `<userinfo>@host`
+// form of `https://<userinfo>@github.com/...`) never reaches the server or
+// the local cache in clear.
+import { spawnSync } from "node:child_process"
+import { stripGitRemoteCredentials } from "../tools/project-scan"
+
+export function detectProjectRemote(directory: string): string | undefined {
+  try {
+    const r = spawnSync("git", ["remote", "get-url", "origin"], {
+      cwd: directory,
+      encoding: "utf8",
+      timeout: 3000,
+    })
+    if (r.status !== 0 || !r.stdout) return undefined
+    return stripGitRemoteCredentials(r.stdout.trim())
+  } catch {
+    return undefined
+  }
+}
+
+/** Sensible default workspace name from a remote URL — best-effort. Used to
+ * prefill the workspace-name prompt in the CreateDialog and `altimate link`.
+ * ``github.com/foo/bar.git`` → ``bar`` ; ``git@github.com:foo/bar.git`` → ``bar``. */
+export function projectNameFromRemote(remote: string): string {
+  const trimmed = remote.replace(/\.git$/, "").replace(/\/$/, "")
+  const parts = trimmed.split(/[/:]/)
+  return parts[parts.length - 1] || "workspace"
+}

--- a/packages/opencode/src/altimate/workspace/detect.ts
+++ b/packages/opencode/src/altimate/workspace/detect.ts
@@ -53,9 +53,17 @@ export function resolveProjectIdentifier(directory: string): {
 
 /** Sensible default workspace name from a remote URL — best-effort. Used to
  * prefill the workspace-name prompt in the CreateDialog and `altimate link`.
- * ``github.com/foo/bar.git`` → ``bar`` ; ``git@github.com:foo/bar.git`` → ``bar``. */
+ * ``github.com/foo/bar.git`` → ``bar`` ; ``git@github.com:foo/bar.git`` → ``bar`` ;
+ * ``https://x/foo/bar.git/`` (trailing slash after .git) → ``bar``. */
 export function projectNameFromRemote(remote: string): string {
-  const trimmed = remote.replace(/\.git$/, "").replace(/\/$/, "")
+  // Strip trailing slashes FIRST, then the ``.git`` suffix, then any
+  // trailing slashes the suffix strip exposed. Order matters — the
+  // previous ``.git$`` → ``/$`` pipeline missed ``.git/`` because the
+  // final ``/`` wasn't ``.git`` any more. (cubic round 3.)
+  const trimmed = remote
+    .replace(/[/]+$/, "")
+    .replace(/\.git$/, "")
+    .replace(/[/]+$/, "")
   const parts = trimmed.split(/[/:]/)
   return parts[parts.length - 1] || "workspace"
 }

--- a/packages/opencode/src/altimate/workspace/launch-resolve.ts
+++ b/packages/opencode/src/altimate/workspace/launch-resolve.ts
@@ -1,0 +1,71 @@
+// altimate_change - new file
+//
+// Launch-time --workspace <name> resolver. Runs once per process, on the
+// TUI's main thread (from ``cli/cmd/tui.ts``) before the worker subprocess
+// starts, so its ``UI.println`` messages reach the user's terminal cleanly.
+//
+// Contract (matches AI-8504 Item #1 wording):
+// - The flag is same-directory-only. Resolution walks THIS directory's
+//   local binding and nothing else — no backend-wide workspace-name search,
+//   no fuzzy match. An unresolvable name is an honest printed error, never
+//   a silent fallback to a different workspace.
+// - If the requested name doesn't match this directory's linked workspace,
+//   print a note and continue with the currently-linked one anyway (the
+//   ticket calls this out explicitly). A mismatch is a warning, not a
+//   session abort.
+// - MUST NEVER block launch. Every failure path (missing binding, network
+//   failure inside readLocalBinding, malformed cache) prints and returns —
+//   nothing here calls ``process.exit`` or throws past the caller.
+//
+// Drift detection at launch (AI-8504 Item #2) is deliberately NOT
+// implemented here; that ships separately once the backend PATCH-binding
+// endpoint lands.
+import { Flag } from "@opencode-ai/core/flag/flag"
+import { UI } from "@/cli/ui"
+import { readLocalBinding, type CachedBinding } from "@/altimate/workspace/state"
+import { setResolvedWorkspaceId } from "@/altimate/workspace/session-context"
+
+/** Case-insensitive, whitespace-trimmed match of the CLI's ``--workspace``
+ * argument against the binding's stored workspace name. No fuzzy match; a
+ * shorter substring is not a hit. */
+export function nameMatches(name: string, binding: CachedBinding): boolean {
+  const needle = name.trim().toLowerCase()
+  return binding.datamateName.toLowerCase() === needle
+}
+
+export async function resolveWorkspaceForLaunch(
+  directory: string,
+  explicitName: string | undefined,
+): Promise<void> {
+  // Gate on the pilot flag so the flag is invisible to non-opted-in users
+  // even if they discover it via ``--help``. Silent when opted out — no
+  // error message that would leak the pilot's existence.
+  if (!Flag.ALTIMATE_WORKSPACE) return
+  if (explicitName === undefined) return
+
+  const binding = await readLocalBinding(directory).catch(() => null)
+  if (!binding) {
+    // Can't attach to what isn't linked. Fail-fast with a message pointing at
+    // the fix; do NOT set the env var (consumers will fall through to their
+    // default resolution).
+    UI.error(
+      `No workspace is linked in this directory. Run \`altimate-code link\` ` +
+        `first, or drop --workspace to continue with default resolution.`,
+    )
+    return
+  }
+
+  if (!nameMatches(explicitName, binding)) {
+    // Per AI-8504 spec: print a note and continue with the currently-linked
+    // workspace rather than aborting. The flag is a sanity check, not a
+    // hard override.
+    UI.println(
+      `Note: --workspace "${explicitName}" was requested, but this directory ` +
+        `is linked to "${binding.datamateName}" — attaching to ` +
+        `"${binding.datamateName}" since that's what's linked here.`,
+    )
+  }
+
+  setResolvedWorkspaceId(binding.datamateId)
+  UI.println(`Attached to workspace "${binding.datamateName}".`)
+}

--- a/packages/opencode/src/altimate/workspace/session-context.ts
+++ b/packages/opencode/src/altimate/workspace/session-context.ts
@@ -1,0 +1,41 @@
+// altimate_change - new file
+//
+// Env-var handoff for the launch-time --workspace resolution result.
+//
+// The launch resolver runs on the TUI's MAIN thread (``cli/cmd/tui.ts``,
+// before ``new Worker(...)`` — it prints via ``UI.println`` and would need
+// stdout the worker owns). Consumers of "which workspace is this session
+// pinned to?" run inside the TUI worker subprocess (its own JS heap; a
+// module-level variable set on the main thread is invisible there).
+//
+// This codebase already solves the same problem for ``ALTIMATE_LAUNCH_ID``:
+// ``tui.ts`` spawns the worker with ``env: { ...process.env, ... }`` and
+// telemetry reads it back from ``process.env.ALTIMATE_LAUNCH_ID`` on either
+// side. Same mechanism here — ``setResolvedWorkspaceId`` mutates
+// ``process.env`` on the main thread; the existing worker-spawn env spread
+// carries it across for free; ``getResolvedWorkspaceId`` reads it back from
+// whichever thread calls it.
+const ENV_WORKSPACE_ID = "ALTIMATE_RESOLVED_WORKSPACE_ID"
+
+export function setResolvedWorkspaceId(id: number | null): void {
+  if (id === null) {
+    delete process.env[ENV_WORKSPACE_ID]
+    return
+  }
+  process.env[ENV_WORKSPACE_ID] = String(id)
+}
+
+/** Returns the launch-flag-selected workspace id when the session was
+ * started with ``--workspace <name>`` and the name resolved, else null.
+ * Consumers should fall back to the local binding cache
+ * (``readLocalBinding``) when this returns null. */
+export function getResolvedWorkspaceId(): number | null {
+  const raw = process.env[ENV_WORKSPACE_ID]
+  if (!raw) return null
+  // Guard against a malformed env var — a NaN would silently poison callers
+  // that then bind against workspace id NaN. Return null so callers fall
+  // through to their default resolution path.
+  const parsed = Number(raw)
+  if (!Number.isInteger(parsed) || parsed <= 0) return null
+  return parsed
+}

--- a/packages/opencode/src/altimate/workspace/state.ts
+++ b/packages/opencode/src/altimate/workspace/state.ts
@@ -64,6 +64,13 @@ function isValidCacheFile(raw: unknown): raw is CacheFile {
     if (typeof b.datamateName !== "string") return false
     if (b.repoRemote !== null && typeof b.repoRemote !== "string") return false
     if (b.projectPath !== null && typeof b.projectPath !== "string") return false
+    // At least one identity — otherwise the cached row can never be verified
+    // against a project and would surface as a "phantom" workspace on the
+    // offline-fallback render path. (cubic round 3.)
+    const hasIdentity =
+      (typeof b.repoRemote === "string" && b.repoRemote.length > 0) ||
+      (typeof b.projectPath === "string" && b.projectPath.length > 0)
+    if (!hasIdentity) return false
     if (typeof b.linkedAt !== "number") return false
   }
   return true
@@ -122,11 +129,23 @@ export async function recordApprovedBinding(
 ): Promise<void> {
   const key = await tenantKey()
   if (!key) return
-  const existing = readCache()
-  const cache: CacheFile =
-    existing && existing.tenant === key.tenant && existing.apiUrl === key.apiUrl
-      ? existing
-      : { version: CACHE_VERSION, tenant: key.tenant, apiUrl: key.apiUrl, bindings: {} }
-  cache.bindings[directory] = binding
-  writeCache(cache)
+  // Best-effort: cache persistence is a UX convenience, not the source of
+  // truth (the server-side binding is). If the state directory is read-only
+  // or the disk is full, callers otherwise report "link failed" and prompt
+  // duplicate retries against a workspace that IS bound server-side.
+  // (cubic round 3.)
+  try {
+    const existing = readCache()
+    const cache: CacheFile =
+      existing && existing.tenant === key.tenant && existing.apiUrl === key.apiUrl
+        ? existing
+        : { version: CACHE_VERSION, tenant: key.tenant, apiUrl: key.apiUrl, bindings: {} }
+    cache.bindings[directory] = binding
+    writeCache(cache)
+  } catch (err) {
+    log.warn("could not persist workspace binding cache", {
+      code: (err as NodeJS.ErrnoException)?.code,
+      err: String(err),
+    })
+  }
 }

--- a/packages/opencode/src/altimate/workspace/state.ts
+++ b/packages/opencode/src/altimate/workspace/state.ts
@@ -43,12 +43,38 @@ export function cachePath(): string {
   return path.join(Global.Path.state, "altimate-workspace-bindings.json")
 }
 
+/** Runtime shape check for a parsed cache file — the JSON blob comes from
+ * disk and could be anything (older CLI version, hand-edited, corrupted
+ * mid-write). The type assertion alone doesn't guard against e.g.
+ * ``{"version": 1, "bindings": null}`` which then throws on
+ * ``cache.bindings[k]``. Discard anything that fails the shape check so
+ * readers always get a valid ``CacheFile`` or null. (CR round 2.) */
+function isValidCacheFile(raw: unknown): raw is CacheFile {
+  if (!raw || typeof raw !== "object") return false
+  const r = raw as Record<string, unknown>
+  if (r.version !== CACHE_VERSION) return false
+  if (typeof r.tenant !== "string" || !r.tenant) return false
+  if (typeof r.apiUrl !== "string" || !r.apiUrl) return false
+  if (!r.bindings || typeof r.bindings !== "object" || Array.isArray(r.bindings)) return false
+  for (const [k, v] of Object.entries(r.bindings)) {
+    if (typeof k !== "string") return false
+    if (!v || typeof v !== "object") return false
+    const b = v as Record<string, unknown>
+    if (typeof b.datamateId !== "number" || !Number.isInteger(b.datamateId)) return false
+    if (typeof b.datamateName !== "string") return false
+    if (b.repoRemote !== null && typeof b.repoRemote !== "string") return false
+    if (b.projectPath !== null && typeof b.projectPath !== "string") return false
+    if (typeof b.linkedAt !== "number") return false
+  }
+  return true
+}
+
 function readCache(): CacheFile | null {
   const p = cachePath()
   if (!existsSync(p)) return null
   try {
-    const raw = JSON.parse(readFileSync(p, "utf8")) as CacheFile
-    if (!raw || raw.version !== CACHE_VERSION) return null
+    const raw = JSON.parse(readFileSync(p, "utf8")) as unknown
+    if (!isValidCacheFile(raw)) return null
     return raw
   } catch (err) {
     log.warn("workspace binding cache is corrupt, discarding", {

--- a/packages/opencode/src/altimate/workspace/state.ts
+++ b/packages/opencode/src/altimate/workspace/state.ts
@@ -24,7 +24,11 @@ const log = Log.create({ service: "altimate-workspace-state" })
 export interface CachedBinding {
   datamateId: number
   datamateName: string
-  repoRemote: string
+  /** Either ``repoRemote`` or ``projectPath`` is populated (at least one).
+   * Mirrors the server-side binding row, which is identified by whichever
+   * fields it has. */
+  repoRemote: string | null
+  projectPath: string | null
   linkedAt: number
 }
 

--- a/packages/opencode/src/altimate/workspace/state.ts
+++ b/packages/opencode/src/altimate/workspace/state.ts
@@ -1,0 +1,102 @@
+// altimate_change - new file
+//
+// Local binding cache — offline fallback for the server-authoritative
+// pre-check. Scoped to (tenant, apiUrl) at the top level so an account switch
+// silently invalidates every cached entry (the switched-to session never sees
+// another tenant's workspace names).
+//
+// Shared between the TuiPlugin and the `altimate link` CLI subcommand so both
+// entry points see the same view of local state. File lives under
+// ``Global.Path.state`` at 0o600 — chmod is applied post-write since
+// ``Filesystem.writeJsonAtomic`` does not chmod (see filesystem.ts:294 for
+// why; codex round-2 flagged this gap).
+import { chmodSync, existsSync, readFileSync } from "node:fs"
+import path from "node:path"
+import { AltimateApi } from "@/altimate/api/client"
+import { Global } from "@/global"
+import { Filesystem } from "@/util/filesystem"
+import { Log } from "@/altimate/util/log"
+
+const CACHE_VERSION = 1
+
+const log = Log.create({ service: "altimate-workspace-state" })
+
+export interface CachedBinding {
+  datamateId: number
+  datamateName: string
+  repoRemote: string
+  linkedAt: number
+}
+
+interface CacheFile {
+  version: 1
+  tenant: string
+  apiUrl: string
+  bindings: Record<string, CachedBinding>
+}
+
+export function cachePath(): string {
+  return path.join(Global.Path.state, "altimate-workspace-bindings.json")
+}
+
+function readCache(): CacheFile | null {
+  const p = cachePath()
+  if (!existsSync(p)) return null
+  try {
+    const raw = JSON.parse(readFileSync(p, "utf8")) as CacheFile
+    if (!raw || raw.version !== CACHE_VERSION) return null
+    return raw
+  } catch (err) {
+    log.warn("workspace binding cache is corrupt, discarding", {
+      code: (err as NodeJS.ErrnoException)?.code,
+    })
+    return null
+  }
+}
+
+function writeCache(cache: CacheFile): void {
+  const p = cachePath()
+  Filesystem.writeJsonAtomic(p, cache)
+  // Best-effort chmod — if the process dies before this line the file exists
+  // with umask perms, and the next successful write repairs it. Acceptable
+  // window given the cache holds workspace names, not credentials.
+  try {
+    chmodSync(p, 0o600)
+  } catch (err) {
+    log.warn("could not chmod workspace binding cache", {
+      code: (err as NodeJS.ErrnoException)?.code,
+    })
+  }
+}
+
+async function tenantKey(): Promise<{ tenant: string; apiUrl: string } | null> {
+  if (!(await AltimateApi.isConfigured())) return null
+  const c = await AltimateApi.getCredentials()
+  return { tenant: c.altimateInstanceName, apiUrl: c.altimateUrl }
+}
+
+/** Read the local binding for ``directory`` — only returns a hit when the
+ * cache's stored (tenant, apiUrl) matches the current credentials. */
+export async function readLocalBinding(directory: string): Promise<CachedBinding | null> {
+  const key = await tenantKey()
+  if (!key) return null
+  const cache = readCache()
+  if (!cache) return null
+  if (cache.tenant !== key.tenant || cache.apiUrl !== key.apiUrl) return null
+  return cache.bindings[directory] ?? null
+}
+
+export async function recordApprovedBinding(
+  directory: string,
+  binding: CachedBinding,
+): Promise<void> {
+  const key = await tenantKey()
+  if (!key) return
+  const existing = readCache()
+  const cache: CacheFile =
+    existing && existing.tenant === key.tenant && existing.apiUrl === key.apiUrl
+      ? existing
+      : { version: CACHE_VERSION, tenant: key.tenant, apiUrl: key.apiUrl, bindings: {} }
+  cache.bindings[directory] = binding
+  writeCache(cache)
+}

--- a/packages/opencode/src/altimate/workspace/state.ts
+++ b/packages/opencode/src/altimate/workspace/state.ts
@@ -107,9 +107,23 @@ function writeCache(cache: CacheFile): void {
 }
 
 async function tenantKey(): Promise<{ tenant: string; apiUrl: string } | null> {
-  if (!(await AltimateApi.isConfigured())) return null
-  const c = await AltimateApi.getCredentials()
-  return { tenant: c.altimateInstanceName, apiUrl: c.altimateUrl }
+  // Best-effort: ``AltimateApi.getCredentials`` can throw ``SyntaxError`` on
+  // a corrupt credentials JSON, ``ZodError`` on schema drift, or a raw
+  // ``Error`` on an unresolvable ``${env:...}`` reference — anything the
+  // credential-loader library can produce. This helper is the last gate
+  // between those errors and callers who treat their failures as fatal (the
+  // TUI's fire-and-forget bind path terminates on unhandled rejections), so
+  // swallow them and treat as "no credentials". (Kilo cycle 6.)
+  try {
+    if (!(await AltimateApi.isConfigured())) return null
+    const c = await AltimateApi.getCredentials()
+    return { tenant: c.altimateInstanceName, apiUrl: c.altimateUrl }
+  } catch (err) {
+    log.warn("could not resolve workspace credentials for cache scoping", {
+      err: String(err),
+    })
+    return null
+  }
 }
 
 /** Read the local binding for ``directory`` — only returns a hit when the

--- a/packages/opencode/src/altimate/workspace/state.ts
+++ b/packages/opencode/src/altimate/workspace/state.ts
@@ -10,7 +10,7 @@
 // ``Global.Path.state`` at 0o600 — chmod is applied post-write since
 // ``Filesystem.writeJsonAtomic`` does not chmod (see filesystem.ts:294 for
 // why; codex round-2 flagged this gap).
-import { chmodSync, existsSync, readFileSync } from "node:fs"
+import { chmodSync, existsSync, readFileSync, realpathSync } from "node:fs"
 import path from "node:path"
 import { AltimateApi } from "@/altimate/api/client"
 import { Global } from "@/global"
@@ -20,6 +20,24 @@ import { Log } from "@/altimate/util/log"
 const CACHE_VERSION = 1
 
 const log = Log.create({ service: "altimate-workspace-state" })
+
+/** Canonicalize a directory into a stable cache key so callers passing
+ * ``/tmp/foo``, ``/private/tmp/foo`` (macOS symlink), ``/tmp/foo/``, or a
+ * relative path all read/write the same row. Uses ``path.resolve`` first so
+ * relative inputs anchor to cwd, then ``realpathSync`` to collapse symlinks
+ * and trailing separators. Falls back to the resolved-only form when the
+ * path doesn't exist on disk (e.g. cache written for a repo that has since
+ * moved) — better a stable-if-unresolved key than an exception that skips
+ * the cache entirely. (cubic + kilo cycle 6 — different clients keyed the
+ * same project under different paths.) */
+function canonicalDirKey(directory: string): string {
+  const resolved = path.resolve(directory)
+  try {
+    return realpathSync(resolved)
+  } catch {
+    return resolved
+  }
+}
 
 export interface CachedBinding {
   datamateId: number
@@ -127,14 +145,15 @@ async function tenantKey(): Promise<{ tenant: string; apiUrl: string } | null> {
 }
 
 /** Read the local binding for ``directory`` — only returns a hit when the
- * cache's stored (tenant, apiUrl) matches the current credentials. */
+ * cache's stored (tenant, apiUrl) matches the current credentials. Directory
+ * is canonicalized so raw / symlink / trailing-slash variants collide. */
 export async function readLocalBinding(directory: string): Promise<CachedBinding | null> {
   const key = await tenantKey()
   if (!key) return null
   const cache = readCache()
   if (!cache) return null
   if (cache.tenant !== key.tenant || cache.apiUrl !== key.apiUrl) return null
-  return cache.bindings[directory] ?? null
+  return cache.bindings[canonicalDirKey(directory)] ?? null
 }
 
 export async function recordApprovedBinding(
@@ -154,7 +173,7 @@ export async function recordApprovedBinding(
       existing && existing.tenant === key.tenant && existing.apiUrl === key.apiUrl
         ? existing
         : { version: CACHE_VERSION, tenant: key.tenant, apiUrl: key.apiUrl, bindings: {} }
-    cache.bindings[directory] = binding
+    cache.bindings[canonicalDirKey(directory)] = binding
     writeCache(cache)
   } catch (err) {
     log.warn("could not persist workspace binding cache", {

--- a/packages/opencode/src/cli/cmd/link.ts
+++ b/packages/opencode/src/cli/cmd/link.ts
@@ -1,13 +1,15 @@
 // altimate_change - new file
 //
-// On-demand "link this project to a workspace" subcommand. Runs the same three-
-// way flow the TuiPlugin (packages/opencode/src/plugin/tui/altimate/workspace.tsx)
-// offers post-scan, but outside a TUI session — so a user who skipped the
-// post-scan offer (or skipped it 7+ days ago and wants to link now) has a
-// path back in.
+// On-demand "link this project to a workspace" subcommand. User invoked it
+// explicitly, so we skip the Create/Link/Skip funnel the post-scan trigger
+// uses and jump straight to a picker over the user's workspaces — the
+// currently-linked one is marked, and "＋ Create a new workspace" is the
+// first row. New workspaces are auto-named from the git repo (or directory
+// name for path-only projects) so the user never has to type anything.
 //
-// Deliberately shares the WorkspaceApi + state modules with the plugin so the
-// two entry points can't drift on request shape or error handling.
+// Deliberately shares the WorkspaceApi + state + detect modules with the
+// TuiPlugin so the two entry points can't drift on request shape, project
+// identity, or error handling.
 import { cmd } from "./cmd"
 import { UI } from "../ui"
 import * as prompts from "@clack/prompts"
@@ -21,9 +23,17 @@ import {
   NotFoundError,
   PreconditionFailedError,
   type DatamateRef,
+  type GetBindingResponse,
+  type ProjectIdentifier,
 } from "@/altimate/workspace/api-client"
-import { detectProjectRemote, projectNameFromRemote } from "@/altimate/workspace/detect"
+import {
+  projectNameFromPath,
+  projectNameFromRemote,
+  resolveProjectIdentifier,
+} from "@/altimate/workspace/detect"
 import { recordApprovedBinding } from "@/altimate/workspace/state"
+
+const CREATE_NEW_SENTINEL = "__create_new__"
 
 export const LinkCommand = cmd({
   command: "link",
@@ -36,8 +46,6 @@ export const LinkCommand = cmd({
       default: process.cwd(),
     }),
   handler: async (args) => {
-    // Bail early if the CLI has no Altimate credentials — there's no place to
-    // send them and no gateway to authenticate against.
     if (!(await AltimateApi.isConfigured())) {
       UI.error(
         "Not signed in to Altimate. Run the TUI (altimate-code) and sign in first, then re-run `altimate-code link`.",
@@ -46,22 +54,17 @@ export const LinkCommand = cmd({
       return
     }
 
-    const remote = detectProjectRemote(args.directory)
-    if (!remote) {
-      UI.error(
-        `No git remote found in ${args.directory}. A workspace is bound to a project via its git remote — initialize a repo and add a remote first.`,
-      )
-      process.exitCode = 1
-      return
-    }
+    const identifier = resolveProjectIdentifier(args.directory)
 
-    prompts.intro("Link workspace")
-    prompts.log.info(`Project remote: ${remote}`)
+    prompts.intro("Link this project to a workspace")
+    if (identifier.repoRemote) prompts.log.info(`Project remote: ${identifier.repoRemote}`)
+    else prompts.log.info(`Project path: ${identifier.projectPath} (no git remote)`)
 
-    // Server-authoritative pre-check.
-    let existing: Awaited<ReturnType<typeof WorkspaceApi.getBindingForRemote>> = null
+    // Pre-check for the currently-linked marker + workspace list. Both are
+    // fetched up-front so the picker can annotate the current binding.
+    let existing: GetBindingResponse | null = null
     try {
-      existing = await WorkspaceApi.getBindingForRemote(remote)
+      existing = await WorkspaceApi.getBindingForProject(identifier)
     } catch (err) {
       if (err instanceof NotConfiguredError) {
         UI.error(err.message)
@@ -69,92 +72,95 @@ export const LinkCommand = cmd({
         return
       }
       prompts.log.warn(
-        `Could not reach the workspace service (${err instanceof Error ? err.message : String(err)}). Continuing anyway.`,
+        `Could not reach the workspace service to look up existing bindings (${err instanceof Error ? err.message : String(err)}). Continuing without the currently-linked marker.`,
       )
     }
 
-    if (existing) {
-      const choice = await prompts.select<"attach" | "relink" | "cancel">({
-        message: `This project is already linked to workspace "${existing.datamate.name}".`,
-        options: [
-          { value: "attach", label: "Keep this binding (no changes)" },
-          { value: "relink", label: "Re-link to a different workspace" },
-          { value: "cancel", label: "Cancel" },
-        ],
-        initialValue: "attach",
-      })
-      if (prompts.isCancel(choice) || choice === "cancel" || choice === "attach") {
-        prompts.outro(choice === "attach" ? `Kept "${existing.datamate.name}".` : "No changes.")
-        return
-      }
-      await pickAndBind(remote, "relink", existing.datamate.id, args.directory)
+    const spin = prompts.spinner()
+    spin.start("Loading workspaces...")
+    let list: DatamateRef[]
+    try {
+      list = await WorkspaceApi.listDatamates()
+    } catch (err) {
+      spin.stop("Could not load workspaces.", 1)
+      prompts.log.error(err instanceof Error ? err.message : String(err))
+      process.exitCode = 1
       return
     }
+    spin.stop(`Found ${list.length} workspace${list.length === 1 ? "" : "s"}.`)
 
-    const choice = await prompts.select<"create" | "link" | "cancel">({
-      message: "Set up a workspace for this project?",
-      options: [
-        {
-          value: "create",
-          label: "Create a new workspace",
-          hint: "Opens a browser to configure integrations and knowledge.",
-        },
-        {
-          value: "link",
-          label: "Link to an existing workspace",
-          hint: "Attach this project to a workspace you already own.",
-        },
-        { value: "cancel", label: "Cancel" },
-      ],
-      initialValue: "create",
+    const autoName = identifier.repoRemote
+      ? projectNameFromRemote(identifier.repoRemote)
+      : projectNameFromPath(identifier.projectPath)
+    const currentId = existing?.datamate.id
+    const currentName = existing?.datamate.name
+
+    const options: Array<{ value: string; label: string; hint?: string }> = [
+      {
+        value: CREATE_NEW_SENTINEL,
+        label: `＋ Create a new workspace "${autoName}"`,
+        hint: "Named from this project; rename in the SaaS after.",
+      },
+      ...list.map((dm) => ({
+        value: String(dm.id),
+        label: dm.id === currentId ? `● ${dm.name}` : `  ${dm.name}`,
+        hint: dm.id === currentId ? "currently linked here" : undefined,
+      })),
+    ]
+
+    const pick = await prompts.select<string>({
+      message: existing
+        ? `Currently linked to "${currentName}". Pick a workspace (or create a new one):`
+        : "Pick a workspace to link (or create a new one):",
+      options,
+      initialValue: currentId !== undefined ? String(currentId) : CREATE_NEW_SENTINEL,
     })
-    if (prompts.isCancel(choice) || choice === "cancel") {
-      prompts.outro("No workspace was linked.")
+
+    if (prompts.isCancel(pick)) {
+      prompts.outro("No changes.")
       return
     }
 
-    if (choice === "create") {
-      await createAndBind(remote, args.directory)
+    if (pick === CREATE_NEW_SENTINEL) {
+      await createAndBind(identifier, autoName, args.directory)
       return
     }
-    await pickAndBind(remote, "attach", undefined, args.directory)
+
+    const targetId = Number(pick)
+    if (targetId === currentId) {
+      prompts.outro(`Kept "${currentName}" — nothing changed.`)
+      return
+    }
+
+    await bindOrRebind(identifier, targetId, currentId, args.directory)
   },
 })
 
-async function createAndBind(remote: string, directory: string): Promise<void> {
-  const defaultName = projectNameFromRemote(remote)
-  const nameInput = await prompts.text({
-    message: "Name this workspace",
-    placeholder: defaultName,
-    defaultValue: defaultName,
-  })
-  if (prompts.isCancel(nameInput)) {
-    prompts.outro("No workspace was created.")
-    return
-  }
-  const name = String(nameInput).trim() || defaultName
-
+async function createAndBind(
+  identifier: ProjectIdentifier,
+  name: string,
+  directory: string,
+): Promise<void> {
   const spin = prompts.spinner()
   spin.start(`Creating workspace "${name}"...`)
   try {
-    const res = await WorkspaceApi.createAndBind({ name, repoRemote: remote })
+    const res = await WorkspaceApi.createAndBind({ name, identifier })
     await recordApprovedBinding(directory, {
       datamateId: res.datamate.id,
       datamateName: res.datamate.name,
       repoRemote: res.binding.repo_remote,
+      projectPath: res.binding.project_path,
       linkedAt: Date.now(),
     })
     spin.stop(`Workspace "${res.datamate.name}" created and linked.`)
     prompts.log.info(`Manage it at: ${res.manage_url}`)
-    // Best-effort browser open — never blocks. If it fails the user has the
-    // URL above to copy manually.
     await open(res.manage_url).catch(() => undefined)
     prompts.outro("Done.")
   } catch (err) {
     spin.stop("Failed to create workspace.", 1)
     if (err instanceof ConflictError) {
       prompts.log.error(
-        `This project is already linked to "${err.detail.existing_datamate_name ?? "another workspace"}". Re-run \`altimate-code link\` and pick "Re-link" if you want to move it.`,
+        `This project is already linked to "${err.detail.existing_datamate_name ?? "another workspace"}". Re-run \`altimate-code link\` to switch.`,
       )
     } else {
       prompts.log.error(err instanceof Error ? err.message : String(err))
@@ -163,75 +169,57 @@ async function createAndBind(remote: string, directory: string): Promise<void> {
   }
 }
 
-async function pickAndBind(
-  remote: string,
-  mode: "attach" | "relink",
-  expectedCurrentDatamateId: number | undefined,
+async function bindOrRebind(
+  identifier: ProjectIdentifier,
+  targetDatamateId: number,
+  currentDatamateId: number | undefined,
   directory: string,
 ): Promise<void> {
+  const isRebind = currentDatamateId !== undefined
   const spin = prompts.spinner()
-  spin.start("Loading workspaces...")
-  let list: DatamateRef[]
+  spin.start(isRebind ? `Re-linking to workspace...` : `Linking to workspace...`)
   try {
-    list = await WorkspaceApi.listDatamates()
-  } catch (err) {
-    spin.stop("Could not load workspaces.", 1)
-    prompts.log.error(err instanceof Error ? err.message : String(err))
-    process.exitCode = 1
-    return
-  }
-  spin.stop(`Found ${list.length} workspace${list.length === 1 ? "" : "s"}.`)
-
-  if (list.length === 0) {
-    prompts.log.warn(
-      "You don't have any workspaces yet. Re-run and pick \"Create a new workspace\" instead.",
-    )
-    prompts.outro("No workspace to link.")
-    return
-  }
-
-  const pick = await prompts.select<number | "cancel">({
-    message: mode === "attach" ? "Pick a workspace to attach to" : "Pick a workspace to re-link to",
-    options: [
-      ...list.map((dm) => ({ value: dm.id as number | "cancel", label: dm.name })),
-      { value: "cancel" as const, label: "Cancel" },
-    ],
-  })
-  if (prompts.isCancel(pick) || pick === "cancel") {
-    prompts.outro("No changes.")
-    return
-  }
-
-  const target = list.find((dm) => dm.id === pick)!
-  const spin2 = prompts.spinner()
-  spin2.start(`${mode === "attach" ? "Linking" : "Re-linking"} to "${target.name}"...`)
-  try {
-    const res =
-      mode === "attach"
-        ? await WorkspaceApi.bindExisting(pick, remote)
-        : await WorkspaceApi.rebindByRemote({
-            remote,
-            targetDatamateId: pick,
-            expectedCurrentDatamateId,
-          })
+    const res = await (async () => {
+      if (isRebind) {
+        // Rebind endpoint depends on which identifier is present. Prefer remote
+        // (stronger identity — survives directory moves); fall back to path.
+        return identifier.repoRemote
+          ? WorkspaceApi.rebindByRemote({
+              remote: identifier.repoRemote,
+              targetDatamateId,
+              expectedCurrentDatamateId: currentDatamateId,
+            })
+          : WorkspaceApi.rebindByPath({
+              projectPath: identifier.projectPath!,
+              targetDatamateId,
+              expectedCurrentDatamateId: currentDatamateId,
+            })
+      }
+      return WorkspaceApi.bindExisting(targetDatamateId, identifier)
+    })()
     await recordApprovedBinding(directory, {
       datamateId: res.binding.datamate_id,
       datamateName: res.binding.datamate_name,
       repoRemote: res.binding.repo_remote,
+      projectPath: res.binding.project_path,
       linkedAt: Date.now(),
     })
-    spin2.stop(`${mode === "attach" ? "Linked" : "Re-linked"} to "${res.binding.datamate_name}".`)
+    spin.stop(
+      isRebind
+        ? `Re-linked to "${res.binding.datamate_name}".`
+        : `Linked to "${res.binding.datamate_name}".`,
+    )
     prompts.outro("Done.")
   } catch (err) {
-    spin2.stop(`${mode === "attach" ? "Link" : "Re-link"} failed.`, 1)
+    spin.stop(isRebind ? `Re-link failed.` : `Link failed.`, 1)
     if (err instanceof ConflictError) {
       prompts.log.error(
-        `Already linked to "${err.detail.existing_datamate_name ?? "another workspace"}". Re-run \`altimate-code link\` and pick "Re-link".`,
+        `Already linked to "${err.detail.existing_datamate_name ?? "another workspace"}".`,
       )
     } else if (err instanceof PreconditionFailedError) {
-      prompts.log.error("Someone else re-linked this project — reload and try again.")
+      prompts.log.error("Someone else re-linked this project — re-run and try again.")
     } else if (err instanceof NotFoundError) {
-      prompts.log.error("No existing binding to re-link. Try again and pick Create or Link.")
+      prompts.log.error("No existing binding to re-link. Re-run and pick again.")
     } else if (err instanceof ForbiddenError) {
       prompts.log.error("Only the workspace owner can attach projects to it.")
     } else {

--- a/packages/opencode/src/cli/cmd/link.ts
+++ b/packages/opencode/src/cli/cmd/link.ts
@@ -47,6 +47,23 @@ export const LinkCommand = cmd({
       default: process.cwd(),
     }),
   handler: async (args) => {
+    // Fail fast on non-TTY stdin — the whole subcommand is a series of
+    // ``@clack/prompts`` interactive selects (workspace picker, name prompt,
+    // confirm), so a piped or redirected stdin (``altimate-code link < /dev/null``,
+    // CI runner, background job) makes every prompt.select() block forever
+    // with no output — the user sees a hung process at 0% CPU. Bail with a
+    // clear message directing them to the alternative that actually works
+    // headless (the TUI plugin's palette command). (kilo cycle 6.)
+    if (!process.stdin.isTTY) {
+      UI.error(
+        "`altimate-code link` needs an interactive terminal (stdin must be a TTY). " +
+          "Run it directly in a shell, or use the TUI palette command " +
+          '"Link this project to a workspace".',
+      )
+      process.exitCode = 1
+      return
+    }
+
     if (!(await AltimateApi.isConfigured())) {
       UI.error(
         "Not signed in to Altimate. Run the TUI (altimate-code) and sign in first, then re-run `altimate-code link`.",

--- a/packages/opencode/src/cli/cmd/link.ts
+++ b/packages/opencode/src/cli/cmd/link.ts
@@ -211,8 +211,28 @@ async function createThenBindOrRebind(
     linkedAt: Date.now(),
   })
   prompts.log.info(`Manage it at: ${created.manage_url}`)
-  await open(created.manage_url).catch(() => undefined)
+  // Guard against a server that hands back a non-http(s) manage_url — ``open``
+  // delegates to the OS handler, so a rogue value could launch an unrelated
+  // application. Log a warning and skip the auto-open rather than trusting
+  // whatever protocol the URL parses to.
+  if (isSafeHttpUrl(created.manage_url)) {
+    await open(created.manage_url).catch(() => undefined)
+  } else {
+    prompts.log.warn(`Skipped auto-open: manage_url is not an http/https URL.`)
+  }
   prompts.outro("Done.")
+}
+
+/** True when the URL parses and its protocol is exactly ``http:`` or ``https:``.
+ * Used before handing a server-supplied URL to ``open()`` (which would otherwise
+ * dispatch to whatever OS scheme handler matches the protocol). */
+function isSafeHttpUrl(url: string): boolean {
+  try {
+    const u = new URL(url)
+    return u.protocol === "http:" || u.protocol === "https:"
+  } catch {
+    return false
+  }
 }
 
 async function bindOrRebind(

--- a/packages/opencode/src/cli/cmd/link.ts
+++ b/packages/opencode/src/cli/cmd/link.ts
@@ -23,7 +23,8 @@ import {
   NotFoundError,
   PreconditionFailedError,
   type DatamateRef,
-  type GetBindingResponse,
+  type MatchedIdentifier,
+  type ProjectBindingLookup,
   type ProjectIdentifier,
 } from "@/altimate/workspace/api-client"
 import {
@@ -62,7 +63,11 @@ export const LinkCommand = cmd({
 
     // Pre-check for the currently-linked marker + workspace list. Both are
     // fetched up-front so the picker can annotate the current binding.
-    let existing: GetBindingResponse | null = null
+    // ``preCheckOk = false`` means the pre-check itself failed (network,
+    // 5xx) rather than "not linked" — used later to retry a 409 as a rebind
+    // instead of surfacing "already linked to X" with no next step. (m10)
+    let existing: ProjectBindingLookup | null = null
+    let preCheckOk = true
     try {
       existing = await WorkspaceApi.getBindingForProject(identifier)
     } catch (err) {
@@ -71,6 +76,7 @@ export const LinkCommand = cmd({
         process.exitCode = 1
         return
       }
+      preCheckOk = false
       prompts.log.warn(
         `Could not reach the workspace service to look up existing bindings (${err instanceof Error ? err.message : String(err)}). Continuing without the currently-linked marker.`,
       )
@@ -99,7 +105,9 @@ export const LinkCommand = cmd({
       {
         value: CREATE_NEW_SENTINEL,
         label: `＋ Create a new workspace "${autoName}"`,
-        hint: "Named from this project; rename in the SaaS after.",
+        hint: existing
+          ? "Creates a new workspace and repoints this project to it."
+          : "Named from this project; rename in the SaaS after.",
       },
       ...list.map((dm) => ({
         value: String(dm.id),
@@ -122,7 +130,7 @@ export const LinkCommand = cmd({
     }
 
     if (pick === CREATE_NEW_SENTINEL) {
-      await createAndBind(identifier, autoName, args.directory)
+      await createThenBindOrRebind(identifier, autoName, args.directory, existing)
       return
     }
 
@@ -132,71 +140,136 @@ export const LinkCommand = cmd({
       return
     }
 
-    await bindOrRebind(identifier, targetId, currentId, args.directory)
+    await bindOrRebind(identifier, targetId, existing, preCheckOk, args.directory)
   },
 })
 
-async function createAndBind(
+/** "＋ Create a new workspace" flow. When the project is already linked, this
+ * MUST rebind after create — otherwise the new workspace is a real (billable)
+ * SaaS resource the CLI knows nothing about and the project is still bound to
+ * the old workspace (M2 in the consensus review). When rebind fails, the
+ * error message tells the user the workspace was created and how to recover;
+ * we do NOT silently swallow the orphan. */
+async function createThenBindOrRebind(
   identifier: ProjectIdentifier,
   name: string,
   directory: string,
+  existing: ProjectBindingLookup | null,
 ): Promise<void> {
   const spin = prompts.spinner()
   spin.start(`Creating workspace "${name}"...`)
+  let created: Awaited<ReturnType<typeof WorkspaceApi.createAndBind>>
   try {
-    const res = await WorkspaceApi.createAndBind({ name, identifier })
-    await recordApprovedBinding(directory, {
-      datamateId: res.datamate.id,
-      datamateName: res.datamate.name,
-      repoRemote: res.binding.repo_remote,
-      projectPath: res.binding.project_path,
-      linkedAt: Date.now(),
-    })
-    spin.stop(`Workspace "${res.datamate.name}" created and linked.`)
-    prompts.log.info(`Manage it at: ${res.manage_url}`)
-    await open(res.manage_url).catch(() => undefined)
-    prompts.outro("Done.")
+    created = await WorkspaceApi.createAndBind({ name, identifier })
   } catch (err) {
     spin.stop("Failed to create workspace.", 1)
+    // A 409 from create means someone else's binding on the same
+    // remote/path beat us. If the pre-check already knew about it, the user
+    // can pick from the list; if the pre-check missed it, this is the
+    // authoritative signal — surface it and hint the picker.
     if (err instanceof ConflictError) {
       prompts.log.error(
-        `This project is already linked to "${err.detail.existing_datamate_name ?? "another workspace"}". Re-run \`altimate-code link\` to switch.`,
+        `This project is already linked to "${err.detail.existing_datamate_name ?? "another workspace"}". Re-run \`altimate-code link\` to switch to a different workspace.`,
       )
     } else {
       prompts.log.error(err instanceof Error ? err.message : String(err))
     }
     process.exitCode = 1
+    return
   }
+  spin.stop(`Workspace "${created.datamate.name}" created.`)
+
+  // If the project was already linked, the new workspace exists but the
+  // binding still points at the OLD workspace — rebind so the project is
+  // now bound to the freshly-created one. Otherwise createAndBind already
+  // wrote the binding as part of the atomic create; we're done.
+  if (existing) {
+    const rebindSpin = prompts.spinner()
+    rebindSpin.start(`Repointing project at "${created.datamate.name}"...`)
+    try {
+      await rebindByMatchedIdentifier({
+        identifier,
+        targetDatamateId: created.datamate.id,
+        expectedCurrentDatamateId: existing.datamate.id,
+        matchedBy: existing.matchedBy,
+      })
+      rebindSpin.stop(`Project is now linked to "${created.datamate.name}".`)
+    } catch (err) {
+      rebindSpin.stop("Could not repoint the project.", 1)
+      prompts.log.error(
+        `Workspace "${created.datamate.name}" was CREATED but could not be linked to this project. ${err instanceof Error ? err.message : String(err)} — re-run \`altimate-code link\` to retry (or delete the workspace in the SaaS).`,
+      )
+      process.exitCode = 1
+      return
+    }
+  }
+  await recordApprovedBinding(directory, {
+    datamateId: created.datamate.id,
+    datamateName: created.datamate.name,
+    repoRemote: created.binding.repo_remote,
+    projectPath: created.binding.project_path,
+    linkedAt: Date.now(),
+  })
+  prompts.log.info(`Manage it at: ${created.manage_url}`)
+  await open(created.manage_url).catch(() => undefined)
+  prompts.outro("Done.")
 }
 
 async function bindOrRebind(
   identifier: ProjectIdentifier,
   targetDatamateId: number,
-  currentDatamateId: number | undefined,
+  existing: ProjectBindingLookup | null,
+  preCheckOk: boolean,
   directory: string,
 ): Promise<void> {
-  const isRebind = currentDatamateId !== undefined
+  const isRebind = existing !== null
   const spin = prompts.spinner()
   spin.start(isRebind ? `Re-linking to workspace...` : `Linking to workspace...`)
   try {
-    const res = await (async () => {
-      if (isRebind) {
-        // Rebind endpoint depends on which identifier is present. Prefer remote
-        // (stronger identity — survives directory moves); fall back to path.
-        return identifier.repoRemote
-          ? WorkspaceApi.rebindByRemote({
-              remote: identifier.repoRemote,
-              targetDatamateId,
-              expectedCurrentDatamateId: currentDatamateId,
-            })
-          : WorkspaceApi.rebindByPath({
-              projectPath: identifier.projectPath!,
-              targetDatamateId,
-              expectedCurrentDatamateId: currentDatamateId,
-            })
+    let res
+    if (isRebind) {
+      res = await rebindByMatchedIdentifier({
+        identifier,
+        targetDatamateId,
+        expectedCurrentDatamateId: existing.datamate.id,
+        matchedBy: existing.matchedBy,
+      })
+    } else {
+      // No known binding OR pre-check failed. Try bindExisting first — if the
+      // pre-check missed a real binding, the server will 409, and we retry as
+      // rebind when we're allowed to. (m10)
+      try {
+        res = await WorkspaceApi.bindExisting(targetDatamateId, identifier)
+      } catch (err) {
+        if (err instanceof ConflictError && !preCheckOk) {
+          // Pre-check failed and the server confirms this project IS linked
+          // already. Retry as an unconditional rebind — we don't have an
+          // ``expected_current_datamate_id`` (pre-check gave us nothing) so
+          // this is last-writer-wins. Callers who need optimistic concurrency
+          // should re-run once the network is back and the pre-check succeeds.
+          spin.stop("Pre-check missed an existing binding — retrying as re-link.", 1)
+          const rebindSpin = prompts.spinner()
+          rebindSpin.start("Re-linking...")
+          try {
+            res = identifier.repoRemote
+              ? await WorkspaceApi.rebindByRemote({
+                  remote: identifier.repoRemote,
+                  targetDatamateId,
+                })
+              : await WorkspaceApi.rebindByPath({
+                  projectPath: identifier.projectPath!,
+                  targetDatamateId,
+                })
+            rebindSpin.stop(`Re-linked to "${res.binding.datamate_name}".`)
+          } catch (retryErr) {
+            rebindSpin.stop("Re-link failed.", 1)
+            throw retryErr
+          }
+        } else {
+          throw err
+        }
       }
-      return WorkspaceApi.bindExisting(targetDatamateId, identifier)
-    })()
+    }
     await recordApprovedBinding(directory, {
       datamateId: res.binding.datamate_id,
       datamateName: res.binding.datamate_name,
@@ -214,7 +287,7 @@ async function bindOrRebind(
     spin.stop(isRebind ? `Re-link failed.` : `Link failed.`, 1)
     if (err instanceof ConflictError) {
       prompts.log.error(
-        `Already linked to "${err.detail.existing_datamate_name ?? "another workspace"}".`,
+        `Already linked to "${err.detail.existing_datamate_name ?? "another workspace"}". Re-run \`altimate-code link\` to switch.`,
       )
     } else if (err instanceof PreconditionFailedError) {
       prompts.log.error("Someone else re-linked this project — re-run and try again.")
@@ -227,4 +300,34 @@ async function bindOrRebind(
     }
     process.exitCode = 1
   }
+}
+
+/** Pick the rebind endpoint that matches which identifier the pre-check
+ * resolved the binding on — NOT which identifier the current call happens to
+ * carry. A repo whose remote was renamed still has a binding under its path;
+ * rebindByRemote against the new remote would 404 with no repair path from
+ * the CLI. (M3) */
+async function rebindByMatchedIdentifier(input: {
+  identifier: ProjectIdentifier
+  targetDatamateId: number
+  expectedCurrentDatamateId: number
+  matchedBy: MatchedIdentifier
+}) {
+  if (input.matchedBy === "remote" && input.identifier.repoRemote) {
+    return WorkspaceApi.rebindByRemote({
+      remote: input.identifier.repoRemote,
+      targetDatamateId: input.targetDatamateId,
+      expectedCurrentDatamateId: input.expectedCurrentDatamateId,
+    })
+  }
+  if (input.matchedBy === "path" && input.identifier.projectPath) {
+    return WorkspaceApi.rebindByPath({
+      projectPath: input.identifier.projectPath,
+      targetDatamateId: input.targetDatamateId,
+      expectedCurrentDatamateId: input.expectedCurrentDatamateId,
+    })
+  }
+  throw new Error(
+    `Cannot rebind — the pre-check matched on ${input.matchedBy} but that field is not present on the current project identifier.`,
+  )
 }

--- a/packages/opencode/src/cli/cmd/link.ts
+++ b/packages/opencode/src/cli/cmd/link.ts
@@ -1,0 +1,242 @@
+// altimate_change - new file
+//
+// On-demand "link this project to a workspace" subcommand. Runs the same three-
+// way flow the TuiPlugin (packages/opencode/src/plugin/tui/altimate/workspace.tsx)
+// offers post-scan, but outside a TUI session — so a user who skipped the
+// post-scan offer (or skipped it 7+ days ago and wants to link now) has a
+// path back in.
+//
+// Deliberately shares the WorkspaceApi + state modules with the plugin so the
+// two entry points can't drift on request shape or error handling.
+import { cmd } from "./cmd"
+import { UI } from "../ui"
+import * as prompts from "@clack/prompts"
+import open from "open"
+import { AltimateApi } from "@/altimate/api/client"
+import {
+  WorkspaceApi,
+  ConflictError,
+  ForbiddenError,
+  NotConfiguredError,
+  NotFoundError,
+  PreconditionFailedError,
+  type DatamateRef,
+} from "@/altimate/workspace/api-client"
+import { detectProjectRemote, projectNameFromRemote } from "@/altimate/workspace/detect"
+import { recordApprovedBinding } from "@/altimate/workspace/state"
+
+export const LinkCommand = cmd({
+  command: "link",
+  describe: "Link this project to an Altimate workspace",
+  builder: (yargs) =>
+    yargs.option("directory", {
+      alias: "d",
+      describe: "Project directory (defaults to cwd)",
+      type: "string",
+      default: process.cwd(),
+    }),
+  handler: async (args) => {
+    // Bail early if the CLI has no Altimate credentials — there's no place to
+    // send them and no gateway to authenticate against.
+    if (!(await AltimateApi.isConfigured())) {
+      UI.error(
+        "Not signed in to Altimate. Run the TUI (altimate-code) and sign in first, then re-run `altimate-code link`.",
+      )
+      process.exitCode = 1
+      return
+    }
+
+    const remote = detectProjectRemote(args.directory)
+    if (!remote) {
+      UI.error(
+        `No git remote found in ${args.directory}. A workspace is bound to a project via its git remote — initialize a repo and add a remote first.`,
+      )
+      process.exitCode = 1
+      return
+    }
+
+    prompts.intro("Link workspace")
+    prompts.log.info(`Project remote: ${remote}`)
+
+    // Server-authoritative pre-check.
+    let existing: Awaited<ReturnType<typeof WorkspaceApi.getBindingForRemote>> = null
+    try {
+      existing = await WorkspaceApi.getBindingForRemote(remote)
+    } catch (err) {
+      if (err instanceof NotConfiguredError) {
+        UI.error(err.message)
+        process.exitCode = 1
+        return
+      }
+      prompts.log.warn(
+        `Could not reach the workspace service (${err instanceof Error ? err.message : String(err)}). Continuing anyway.`,
+      )
+    }
+
+    if (existing) {
+      const choice = await prompts.select<"attach" | "relink" | "cancel">({
+        message: `This project is already linked to workspace "${existing.datamate.name}".`,
+        options: [
+          { value: "attach", label: "Keep this binding (no changes)" },
+          { value: "relink", label: "Re-link to a different workspace" },
+          { value: "cancel", label: "Cancel" },
+        ],
+        initialValue: "attach",
+      })
+      if (prompts.isCancel(choice) || choice === "cancel" || choice === "attach") {
+        prompts.outro(choice === "attach" ? `Kept "${existing.datamate.name}".` : "No changes.")
+        return
+      }
+      await pickAndBind(remote, "relink", existing.datamate.id, args.directory)
+      return
+    }
+
+    const choice = await prompts.select<"create" | "link" | "cancel">({
+      message: "Set up a workspace for this project?",
+      options: [
+        {
+          value: "create",
+          label: "Create a new workspace",
+          hint: "Opens a browser to configure integrations and knowledge.",
+        },
+        {
+          value: "link",
+          label: "Link to an existing workspace",
+          hint: "Attach this project to a workspace you already own.",
+        },
+        { value: "cancel", label: "Cancel" },
+      ],
+      initialValue: "create",
+    })
+    if (prompts.isCancel(choice) || choice === "cancel") {
+      prompts.outro("No workspace was linked.")
+      return
+    }
+
+    if (choice === "create") {
+      await createAndBind(remote, args.directory)
+      return
+    }
+    await pickAndBind(remote, "attach", undefined, args.directory)
+  },
+})
+
+async function createAndBind(remote: string, directory: string): Promise<void> {
+  const defaultName = projectNameFromRemote(remote)
+  const nameInput = await prompts.text({
+    message: "Name this workspace",
+    placeholder: defaultName,
+    defaultValue: defaultName,
+  })
+  if (prompts.isCancel(nameInput)) {
+    prompts.outro("No workspace was created.")
+    return
+  }
+  const name = String(nameInput).trim() || defaultName
+
+  const spin = prompts.spinner()
+  spin.start(`Creating workspace "${name}"...`)
+  try {
+    const res = await WorkspaceApi.createAndBind({ name, repoRemote: remote })
+    await recordApprovedBinding(directory, {
+      datamateId: res.datamate.id,
+      datamateName: res.datamate.name,
+      repoRemote: res.binding.repo_remote,
+      linkedAt: Date.now(),
+    })
+    spin.stop(`Workspace "${res.datamate.name}" created and linked.`)
+    prompts.log.info(`Manage it at: ${res.manage_url}`)
+    // Best-effort browser open — never blocks. If it fails the user has the
+    // URL above to copy manually.
+    await open(res.manage_url).catch(() => undefined)
+    prompts.outro("Done.")
+  } catch (err) {
+    spin.stop("Failed to create workspace.", 1)
+    if (err instanceof ConflictError) {
+      prompts.log.error(
+        `This project is already linked to "${err.detail.existing_datamate_name ?? "another workspace"}". Re-run \`altimate-code link\` and pick "Re-link" if you want to move it.`,
+      )
+    } else {
+      prompts.log.error(err instanceof Error ? err.message : String(err))
+    }
+    process.exitCode = 1
+  }
+}
+
+async function pickAndBind(
+  remote: string,
+  mode: "attach" | "relink",
+  expectedCurrentDatamateId: number | undefined,
+  directory: string,
+): Promise<void> {
+  const spin = prompts.spinner()
+  spin.start("Loading workspaces...")
+  let list: DatamateRef[]
+  try {
+    list = await WorkspaceApi.listDatamates()
+  } catch (err) {
+    spin.stop("Could not load workspaces.", 1)
+    prompts.log.error(err instanceof Error ? err.message : String(err))
+    process.exitCode = 1
+    return
+  }
+  spin.stop(`Found ${list.length} workspace${list.length === 1 ? "" : "s"}.`)
+
+  if (list.length === 0) {
+    prompts.log.warn(
+      "You don't have any workspaces yet. Re-run and pick \"Create a new workspace\" instead.",
+    )
+    prompts.outro("No workspace to link.")
+    return
+  }
+
+  const pick = await prompts.select<number | "cancel">({
+    message: mode === "attach" ? "Pick a workspace to attach to" : "Pick a workspace to re-link to",
+    options: [
+      ...list.map((dm) => ({ value: dm.id as number | "cancel", label: dm.name })),
+      { value: "cancel" as const, label: "Cancel" },
+    ],
+  })
+  if (prompts.isCancel(pick) || pick === "cancel") {
+    prompts.outro("No changes.")
+    return
+  }
+
+  const target = list.find((dm) => dm.id === pick)!
+  const spin2 = prompts.spinner()
+  spin2.start(`${mode === "attach" ? "Linking" : "Re-linking"} to "${target.name}"...`)
+  try {
+    const res =
+      mode === "attach"
+        ? await WorkspaceApi.bindExisting(pick, remote)
+        : await WorkspaceApi.rebindByRemote({
+            remote,
+            targetDatamateId: pick,
+            expectedCurrentDatamateId,
+          })
+    await recordApprovedBinding(directory, {
+      datamateId: res.binding.datamate_id,
+      datamateName: res.binding.datamate_name,
+      repoRemote: res.binding.repo_remote,
+      linkedAt: Date.now(),
+    })
+    spin2.stop(`${mode === "attach" ? "Linked" : "Re-linked"} to "${res.binding.datamate_name}".`)
+    prompts.outro("Done.")
+  } catch (err) {
+    spin2.stop(`${mode === "attach" ? "Link" : "Re-link"} failed.`, 1)
+    if (err instanceof ConflictError) {
+      prompts.log.error(
+        `Already linked to "${err.detail.existing_datamate_name ?? "another workspace"}". Re-run \`altimate-code link\` and pick "Re-link".`,
+      )
+    } else if (err instanceof PreconditionFailedError) {
+      prompts.log.error("Someone else re-linked this project — reload and try again.")
+    } else if (err instanceof NotFoundError) {
+      prompts.log.error("No existing binding to re-link. Try again and pick Create or Link.")
+    } else if (err instanceof ForbiddenError) {
+      prompts.log.error("Only the workspace owner can attach projects to it.")
+    } else {
+      prompts.log.error(err instanceof Error ? err.message : String(err))
+    }
+    process.exitCode = 1
+  }
+}

--- a/packages/opencode/src/cli/cmd/link.ts
+++ b/packages/opencode/src/cli/cmd/link.ts
@@ -245,7 +245,12 @@ async function createThenBindOrRebind(
 
 /** True when the URL parses and its protocol is exactly ``http:`` or ``https:``.
  * Used before handing a server-supplied URL to ``open()`` (which would otherwise
- * dispatch to whatever OS scheme handler matches the protocol). */
+ * dispatch to whatever OS scheme handler matches the protocol).
+ *
+ * Deliberately duplicated in ``packages/opencode/src/plugin/tui/altimate/workspace.tsx``
+ * so the CLI subcommand path (this file) and the TUI plugin path stay
+ * independent. Keep in sync — if the allowed-protocol set ever changes
+ * (e.g. tighten to ``https:`` only), update both copies. */
 function isSafeHttpUrl(url: string): boolean {
   try {
     const u = new URL(url)
@@ -373,7 +378,11 @@ async function bindOrRebind(
  * resolved the binding on — NOT which identifier the current call happens to
  * carry. A repo whose remote was renamed still has a binding under its path;
  * rebindByRemote against the new remote would 404 with no repair path from
- * the CLI. (M3) */
+ * the CLI. (M3)
+ *
+ * Deliberately duplicated in ``packages/opencode/src/plugin/tui/altimate/workspace.tsx``
+ * so the CLI subcommand and the TUI plugin flows can evolve independently.
+ * Keep both copies in sync when the M3 endpoint-selection logic changes. */
 async function rebindByMatchedIdentifier(input: {
   identifier: ProjectIdentifier
   targetDatamateId: number

--- a/packages/opencode/src/cli/cmd/link.ts
+++ b/packages/opencode/src/cli/cmd/link.ts
@@ -203,7 +203,10 @@ async function createThenBindOrRebind(
       return
     }
   }
-  await recordApprovedBinding(directory, {
+  // Prefer the canonicalized ``identifier.projectPath`` over the raw
+  // ``--directory`` argument so ``altimate-code link -d ./myproj`` and its
+  // symlink-resolved twin both write under the same cache key (Kilo cycle 6).
+  await recordApprovedBinding(identifier.projectPath ?? directory, {
     datamateId: created.datamate.id,
     datamateName: created.datamate.name,
     repoRemote: created.binding.repo_remote,
@@ -267,19 +270,45 @@ async function bindOrRebind(
           // ``expected_current_datamate_id`` (pre-check gave us nothing) so
           // this is last-writer-wins. Callers who need optimistic concurrency
           // should re-run once the network is back and the pre-check succeeds.
+          //
+          // Pick the rebind endpoint from the CONFLICT DETAIL, not from the
+          // current identifier — the existing binding may be keyed by a
+          // different identifier than the project's current one (path-keyed
+          // legacy binding + newly-added remote, or vice versa). Keying off
+          // the current identifier reproduces the M3 hazard on this fallback
+          // path. (Kilo cycle 6.)
           spin.stop("Pre-check missed an existing binding — retrying as re-link.", 1)
           const rebindSpin = prompts.spinner()
           rebindSpin.start("Re-linking...")
           try {
-            res = identifier.repoRemote
-              ? await WorkspaceApi.rebindByRemote({
-                  remote: identifier.repoRemote,
-                  targetDatamateId,
-                })
-              : await WorkspaceApi.rebindByPath({
-                  projectPath: identifier.projectPath!,
-                  targetDatamateId,
-                })
+            // detail.project_path present → the conflicting binding is
+            // path-keyed; use /by-path. Else the conflict was on repo_remote.
+            const conflictPath = err.detail.project_path
+            const conflictRemote = err.detail.repo_remote
+            if (conflictPath) {
+              res = await WorkspaceApi.rebindByPath({
+                projectPath: conflictPath,
+                targetDatamateId,
+              })
+            } else if (conflictRemote) {
+              res = await WorkspaceApi.rebindByRemote({
+                remote: conflictRemote,
+                targetDatamateId,
+              })
+            } else {
+              // Server didn't tell us which identifier owned the conflict —
+              // fall back to the current identifier's preference (better than
+              // nothing, but shouldn't happen with a well-formed 409 body).
+              res = identifier.repoRemote
+                ? await WorkspaceApi.rebindByRemote({
+                    remote: identifier.repoRemote,
+                    targetDatamateId,
+                  })
+                : await WorkspaceApi.rebindByPath({
+                    projectPath: identifier.projectPath!,
+                    targetDatamateId,
+                  })
+            }
             rebindSpin.stop(`Re-linked to "${res.binding.datamate_name}".`)
           } catch (retryErr) {
             rebindSpin.stop("Re-link failed.", 1)
@@ -290,7 +319,8 @@ async function bindOrRebind(
         }
       }
     }
-    await recordApprovedBinding(directory, {
+    // Prefer the canonicalized identifier over the raw --directory (Kilo cycle 6).
+    await recordApprovedBinding(identifier.projectPath ?? directory, {
       datamateId: res.binding.datamate_id,
       datamateName: res.binding.datamate_name,
       repoRemote: res.binding.repo_remote,

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -110,17 +110,15 @@ export const TuiThreadCommand = cmd({
         type: "string",
         describe: "prompt to use",
       })
-      .option("agent", {
-        type: "string",
-        describe: "agent to use",
-      })
-      // altimate_change — AI-8504 item 1: launch flag that pins this session
-      // to the workspace this directory is linked to. Resolved same-directory-
-      // only (no backend name search, no fuzzy match) — see
-      // altimate/workspace/launch-resolve.ts.
+      // altimate_change start — --workspace launch flag (AI-8504 item 1); see altimate/workspace/launch-resolve.ts
       .option("workspace", {
         type: "string",
         describe: "attach this session to the workspace linked in this directory, by name",
+      })
+      // altimate_change end
+      .option("agent", {
+        type: "string",
+        describe: "agent to use",
       }),
   handler: async (args) => {
     const unguard = win32InstallCtrlCGuard()

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -113,6 +113,14 @@ export const TuiThreadCommand = cmd({
       .option("agent", {
         type: "string",
         describe: "agent to use",
+      })
+      // altimate_change — AI-8504 item 1: launch flag that pins this session
+      // to the workspace this directory is linked to. Resolved same-directory-
+      // only (no backend name search, no fuzzy match) — see
+      // altimate/workspace/launch-resolve.ts.
+      .option("workspace", {
+        type: "string",
+        describe: "attach this session to the workspace linked in this directory, by name",
       }),
   handler: async (args) => {
     const unguard = win32InstallCtrlCGuard()
@@ -135,6 +143,27 @@ export const TuiThreadCommand = cmd({
         return
       }
       const cwd = Filesystem.resolve(process.cwd())
+
+      // altimate_change start — AI-8504 item 1: launch-time --workspace resolver.
+      // Runs BEFORE the worker starts (needs stdout on this main thread for its
+      // native prompts and info messages). MUST NEVER block launch — a failure
+      // here (missing binding, unreadable cache, credentials-parse failure) is
+      // logged and swallowed; the session still starts. The resolver mutates
+      // ``process.env`` on this thread; the existing worker-spawn env spread
+      // below carries the resolved workspace id across for free — same
+      // mechanism as ``ALTIMATE_LAUNCH_ID``.
+      try {
+        const { resolveWorkspaceForLaunch } = await import(
+          "@/altimate/workspace/launch-resolve"
+        )
+        await resolveWorkspaceForLaunch(cwd, args.workspace)
+      } catch (err) {
+        UI.error(
+          `workspace resolution failed (continuing without a pinned workspace): ` +
+            `${err instanceof Error ? err.message : String(err)}`,
+        )
+      }
+      // altimate_change end
 
       // altimate_change start — hand the launch correlation id to the worker explicitly. A Bun
       // Worker does not see runtime mutations to process.env, so without this the worker mints its

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -44,6 +44,9 @@ import { SkillCommand } from "./cli/cmd/skill"
 // altimate_change start — check: deterministic SQL check command
 import { CheckCommand } from "./cli/cmd/check"
 // altimate_change end
+// altimate_change start — link: workspace-binding subcommand
+import { LinkCommand } from "./cli/cmd/link"
+// altimate_change end
 import { errorMessage } from "./util/error"
 import { PluginCommand } from "./cli/cmd/plug"
 import { Heap } from "./cli/heap"
@@ -169,6 +172,9 @@ let cli = yargs(args)
   // altimate_change end
   // altimate_change start — check: register deterministic SQL check command
   .command(CheckCommand)
+  // altimate_change end
+  // altimate_change start — link: workspace-binding subcommand
+  .command(LinkCommand)
 // altimate_change end
 
 // altimate_change start — workspace-serve: register dev-only workspace serve command

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -10,6 +10,7 @@ import { UninstallCommand } from "./cli/cmd/uninstall"
 import { ModelsCommand } from "./cli/cmd/models"
 import { UI } from "./cli/ui"
 import { InstallationVersion, InstallationLocal } from "@opencode-ai/core/installation/version"
+import { Flag } from "@opencode-ai/core/flag/flag"
 import { FormatError } from "./cli/error"
 import { ServeCommand } from "./cli/cmd/serve"
 // altimate_change start — workspace-serve: dev-only workspace serve command
@@ -173,8 +174,14 @@ let cli = yargs(args)
   // altimate_change start — check: register deterministic SQL check command
   .command(CheckCommand)
   // altimate_change end
-  // altimate_change start — link: workspace-binding subcommand
-  .command(LinkCommand)
+
+// altimate_change start — link: gated on Flag.ALTIMATE_WORKSPACE (pilot)
+// so the command isn't registered — and doesn't show in --help — for users
+// who haven't opted in to the workspaces feature via ALTIMATE_WORKSPACE=1.
+// (M1 in the consensus review.)
+if (Flag.ALTIMATE_WORKSPACE) {
+  cli = cli.command(LinkCommand)
+}
 // altimate_change end
 
 // altimate_change start — workspace-serve: register dev-only workspace serve command

--- a/packages/opencode/src/plugin/tui/altimate/index.ts
+++ b/packages/opencode/src/plugin/tui/altimate/index.ts
@@ -13,6 +13,7 @@ import ProviderCredentials from "./provider-credentials"
 import PromptEnhance from "./prompt-enhance"
 import SkillOps from "./skill-ops"
 import TraceViewer from "./trace-viewer"
+import Workspace from "./workspace"
 
 // Feature plugins are registered here as they are ported from the pre-merge sources on `main`
 // (see the ADR re-home plan). Each lives in its own file under this directory and default-exports
@@ -21,7 +22,8 @@ import TraceViewer from "./trace-viewer"
 //   import SkillOps from "./skill-ops"
 //   import PromptEnhance from "./prompt-enhance"
 //   import TraceViewer from "./trace-viewer"
+//   import Workspace from "./workspace"
 export function altimateTuiPlugins(_flags: Pick<RuntimeFlags.Info, "experimentalEventSystem">): BuiltinTuiPlugin[] {
-  return [ProviderCredentials, PromptEnhance, SkillOps, TraceViewer]
+  return [ProviderCredentials, PromptEnhance, SkillOps, TraceViewer, Workspace]
 }
 // altimate_change end

--- a/packages/opencode/src/plugin/tui/altimate/index.ts
+++ b/packages/opencode/src/plugin/tui/altimate/index.ts
@@ -9,6 +9,7 @@
 // plugin list in ../internal.ts.
 import type { BuiltinTuiPlugin } from "@opencode-ai/tui/builtins"
 import type { RuntimeFlags } from "@/effect/runtime-flags"
+import { Flag } from "@opencode-ai/core/flag/flag"
 import ProviderCredentials from "./provider-credentials"
 import PromptEnhance from "./prompt-enhance"
 import SkillOps from "./skill-ops"
@@ -24,6 +25,11 @@ import Workspace from "./workspace"
 //   import TraceViewer from "./trace-viewer"
 //   import Workspace from "./workspace"
 export function altimateTuiPlugins(_flags: Pick<RuntimeFlags.Info, "experimentalEventSystem">): BuiltinTuiPlugin[] {
-  return [ProviderCredentials, PromptEnhance, SkillOps, TraceViewer, Workspace]
+  const base = [ProviderCredentials, PromptEnhance, SkillOps, TraceViewer]
+  // Workspace TUI plugin is pilot-gated: only registered for users who
+  // opted into ALTIMATE_WORKSPACE. Otherwise the post-scan dialog + the
+  // altimate.workspace.link palette command would ship to 100% of users
+  // regardless of the flag setting. (M1 in the consensus review.)
+  return Flag.ALTIMATE_WORKSPACE ? [...base, Workspace] : base
 }
 // altimate_change end

--- a/packages/opencode/src/plugin/tui/altimate/workspace.tsx
+++ b/packages/opencode/src/plugin/tui/altimate/workspace.tsx
@@ -1,0 +1,503 @@
+// altimate_change start — fork TUI feature: Workspaces (pilot).
+//
+// Post-scan prompt to create or link a "Workspace" (server-side: a Datamate)
+// to the current project, plus an on-demand "Link this project to a workspace"
+// palette command. Server API lives in altimate-backend under
+// /datamate-project-bindings/* (top-level router). Backend contract:
+//
+//   POST   /datamate-project-bindings/            create-and-bind (atomic)
+//   POST   /datamate-project-bindings/bind        attach to existing workspace
+//   PUT    /datamate-project-bindings/by-remote   atomic re-link (FOR UPDATE)
+//   GET    /datamate-project-bindings/by-remote   server-authoritative lookup
+//
+// Fork-owned plugin per docs/internal/2026-06-23-tui-fork-features-as-plugins-adr.md.
+// Registered by ./index.ts's altimateTuiPlugins() aggregator; upstream
+// packages/tui is not touched. Uses `api.ui.*`, `api.keymap.registerLayer`,
+// `api.state.path.directory`, `api.kv` (persistent) — the real TuiPluginApi
+// surface, not a made-up one (see codex round-2 report for the history).
+//
+// Trigger: the /altimate-workspace.postScan command is dispatched by the
+// existing onboarding-telemetry.ts plugin's `tool.execute.after` hook when
+// `project_scan` completes AND `AltimateApi.isConfigured()` returns true AND
+// `Flag.ALTIMATE_WORKSPACE` is on. Dispatch travels via the existing
+// `TuiEvent.CommandExecute` event bus.
+import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
+import type { BuiltinTuiPlugin } from "@opencode-ai/tui/builtins"
+import { createHash } from "node:crypto"
+import open from "open"
+import { createSignal, onMount, Show } from "solid-js"
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  PreconditionFailedError,
+  WorkspaceApi,
+  type DatamateRef,
+  type GetBindingResponse,
+} from "@/altimate/workspace/api-client"
+import { detectProjectRemote, projectNameFromRemote } from "@/altimate/workspace/detect"
+import { readLocalBinding, recordApprovedBinding } from "@/altimate/workspace/state"
+import { Log } from "@/altimate/util/log"
+
+const PLUGIN_ID = "altimate:workspace"
+
+const log = Log.create({ service: "altimate-workspace" })
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Skip latch (TUI-only). Uses TuiPluginApi.kv — persistent across sessions
+// via packages/tui/src/context/kv.tsx (state/kv.json). The `altimate link`
+// subcommand deliberately bypasses this latch (it's user-initiated).
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SKIP_TTL_MS = 7 * 24 * 60 * 60 * 1000
+const KV_SKIP_PREFIX = "altimate.workspace.postScan.skip."
+
+function skipKey(remote: string): string {
+  // Hash to keep the KV keyspace bounded and avoid embedding a URL (which can
+  // contain userinfo even after scrubbing edge cases) into a persisted key.
+  return KV_SKIP_PREFIX + createHash("sha1").update(remote).digest("hex")
+}
+
+function isSkipActive(api: TuiPluginApi, remote: string, nowMs: number): boolean {
+  const rec = api.kv.get<{ skippedAt: number }>(skipKey(remote))
+  if (!rec || typeof rec.skippedAt !== "number") return false
+  return nowMs - rec.skippedAt < SKIP_TTL_MS
+}
+
+function recordSkip(api: TuiPluginApi, remote: string, nowMs: number): void {
+  api.kv.set(skipKey(remote), { skippedAt: nowMs })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dialog components — deliberate three-way selects; no LLM-generated copy.
+// Every dialog closes via `api.ui.dialog.clear()` when the user picks a
+// terminal action, so onboarding is never blocked by a stuck workspace prompt.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface OfferProps {
+  api: TuiPluginApi
+  remote: string
+  defaultName: string
+  suppressLatch?: boolean // altimate link on-demand skips the Skip latch
+}
+
+function OfferDialog(props: OfferProps) {
+  return (
+    <props.api.ui.DialogSelect
+      title={`Set up a workspace for this project? (${props.remote})`}
+      options={[
+        {
+          title: "Create a new workspace",
+          value: "create",
+          description: "Opens a browser to configure integrations and knowledge.",
+        },
+        {
+          title: "Link to an existing workspace",
+          value: "link",
+          description: "Attach this project to a workspace you already own.",
+        },
+        {
+          title: "Skip for now",
+          value: "skip",
+          description: props.suppressLatch ? "Close this prompt." : "Won't ask again for 7 days.",
+        },
+      ]}
+      current="create"
+      onSelect={(option) => {
+        if (option.value === "skip") {
+          if (!props.suppressLatch) recordSkip(props.api, props.remote, Date.now())
+          props.api.ui.dialog.clear()
+          return
+        }
+        if (option.value === "create") {
+          props.api.ui.dialog.replace(() => (
+            <CreateDialog api={props.api} defaultName={props.defaultName} remote={props.remote} />
+          ))
+          return
+        }
+        // link → picker
+        props.api.ui.dialog.replace(() => (
+          <PickerDialog api={props.api} remote={props.remote} mode="attach" />
+        ))
+      }}
+    />
+  )
+}
+
+interface AlreadyLinkedProps {
+  api: TuiPluginApi
+  remote: string
+  workspaceName: string
+  workspaceId: number
+  hasDrift: boolean
+  driftedWas?: string | null
+  unverified?: boolean
+}
+
+function AlreadyLinkedDialog(props: AlreadyLinkedProps) {
+  // Title carries the primary context (workspace name + drift/unverified hint)
+  // since DialogSelect doesn't take a top-level description block. Verbose but
+  // it puts the critical info in the user's field of view before they pick.
+  const title = () => {
+    const parts: string[] = [`Project is linked to workspace "${props.workspaceName}"`]
+    if (props.hasDrift && props.driftedWas) parts.push(`(was ${props.driftedWas}, now ${props.remote})`)
+    if (props.unverified) parts.push("(⚠ unverified — server unreachable, showing cached value)")
+    return parts.join(" ")
+  }
+  return (
+    <props.api.ui.DialogSelect
+      title={title()}
+      options={[
+        {
+          title: "Attach and continue",
+          value: "attach",
+          description: "Use this workspace for the session.",
+        },
+        {
+          title: "Re-link to a different workspace",
+          value: "relink",
+          description: "Swap this project's workspace.",
+        },
+        {
+          title: "Skip for now",
+          value: "skip",
+          description: "Close this prompt without changing the link.",
+        },
+      ]}
+      current={props.hasDrift ? "relink" : "attach"}
+      onSelect={(option) => {
+        if (option.value === "attach" || option.value === "skip") {
+          props.api.ui.dialog.clear()
+          return
+        }
+        // relink → picker with the current workspace id as expected_current so
+        // a concurrent re-link by another client 412s cleanly.
+        props.api.ui.dialog.replace(() => (
+          <PickerDialog
+            api={props.api}
+            remote={props.remote}
+            mode="relink"
+            expectedCurrentDatamateId={props.workspaceId}
+          />
+        ))
+      }}
+    />
+  )
+}
+
+interface PickerProps {
+  api: TuiPluginApi
+  remote: string
+  mode: "attach" | "relink"
+  expectedCurrentDatamateId?: number
+}
+
+function PickerDialog(props: PickerProps) {
+  const [datamates, setDatamates] = createSignal<DatamateRef[] | null>(null)
+  const [loadError, setLoadError] = createSignal<string | null>(null)
+
+  onMount(async () => {
+    try {
+      const list = await WorkspaceApi.listDatamates()
+      setDatamates(list)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to load workspaces"
+      setLoadError(msg)
+      props.api.ui.toast({ variant: "error", message: msg })
+      props.api.ui.dialog.clear()
+    }
+  })
+
+  async function pick(datamateId: number) {
+    try {
+      if (props.mode === "attach") {
+        const res = await WorkspaceApi.bindExisting(datamateId, props.remote)
+        await recordApprovedBinding(props.api.state.path.directory, {
+          datamateId: res.binding.datamate_id,
+          datamateName: res.binding.datamate_name,
+          repoRemote: res.binding.repo_remote,
+          linkedAt: Date.now(),
+        })
+        props.api.ui.toast({
+          variant: "success",
+          message: `Linked to workspace "${res.binding.datamate_name}".`,
+        })
+      } else {
+        const res = await WorkspaceApi.rebindByRemote({
+          remote: props.remote,
+          targetDatamateId: datamateId,
+          expectedCurrentDatamateId: props.expectedCurrentDatamateId,
+        })
+        await recordApprovedBinding(props.api.state.path.directory, {
+          datamateId: res.binding.datamate_id,
+          datamateName: res.binding.datamate_name,
+          repoRemote: res.binding.repo_remote,
+          linkedAt: Date.now(),
+        })
+        props.api.ui.toast({
+          variant: "success",
+          message: `Re-linked to workspace "${res.binding.datamate_name}".`,
+        })
+      }
+      props.api.ui.dialog.clear()
+    } catch (err) {
+      // Surface as a toast so the user sees the specific failure. Dialog closes
+      // either way — the user can re-invoke via /altimate.workspace.link.
+      let msg: string
+      if (err instanceof ConflictError) {
+        msg = `Already linked to "${err.detail.existing_datamate_name ?? "another workspace"}" — pick Re-link from the offer if you want to move it.`
+      } else if (err instanceof PreconditionFailedError) {
+        msg = "Someone else re-linked this project — reload and try again."
+      } else if (err instanceof NotFoundError) {
+        msg = "No existing binding for this remote to re-link. Try Create/Link from the offer instead."
+      } else if (err instanceof ForbiddenError) {
+        msg = "Only the workspace owner can attach projects to it."
+      } else {
+        msg = err instanceof Error ? err.message : "Failed to link workspace"
+      }
+      props.api.ui.toast({ variant: "error", message: msg })
+      props.api.ui.dialog.clear()
+    }
+  }
+
+  // While loading (or on error before dialog closes), render an empty select as
+  // a placeholder — DialogSelect requires the options array up front and doesn't
+  // have a native busy state; the empty list closes to a "no workspaces" message.
+  const options = () => {
+    const list = datamates()
+    if (!list) return [{ title: "Loading workspaces...", value: -1, disabled: true }]
+    if (list.length === 0)
+      return [
+        {
+          title: "No workspaces yet — cancel and pick 'Create a new workspace' instead.",
+          value: -1,
+          disabled: true,
+        },
+      ]
+    return list.map((dm: DatamateRef) => ({ title: dm.name, value: dm.id }))
+  }
+
+  return (
+    <props.api.ui.DialogSelect<number>
+      title={props.mode === "attach" ? "Link to workspace" : "Re-link to workspace"}
+      options={options()}
+      onSelect={(option) => {
+        if (option.value === -1) {
+          props.api.ui.dialog.clear()
+          return
+        }
+        void pick(option.value)
+      }}
+    />
+  )
+}
+
+interface CreateProps {
+  api: TuiPluginApi
+  defaultName: string
+  remote: string
+}
+
+function CreateDialog(props: CreateProps) {
+  const [busy, setBusy] = createSignal(false)
+  const [error, setError] = createSignal<string | null>(null)
+  return (
+    <props.api.ui.DialogPrompt
+      title="Create workspace"
+      placeholder={props.defaultName || "workspace name"}
+      busy={busy()}
+      busyText="Creating workspace..."
+      description={() => (
+        <box gap={1}>
+          <text fg={props.api.theme.current.textMuted}>Name this workspace (defaults to your project name):</text>
+          <text fg={props.api.theme.current.textMuted}>You can add integrations, knowledge, and guardrails in the browser after.</text>
+          <Show when={error()}>
+            <text fg={props.api.theme.current.error}>{error()!}</text>
+          </Show>
+        </box>
+      )}
+      onConfirm={async (value) => {
+        if (busy()) return
+        const name = (value || "").trim() || props.defaultName || "Untitled Workspace"
+        setBusy(true)
+        setError(null)
+        try {
+          const res = await WorkspaceApi.createAndBind({
+            name,
+            repoRemote: props.remote,
+          })
+          await recordApprovedBinding(props.api.state.path.directory, {
+            datamateId: res.datamate.id,
+            datamateName: res.datamate.name,
+            repoRemote: res.binding.repo_remote,
+            linkedAt: Date.now(),
+          })
+          // Best-effort browser open. On failure, fall back to a toast with the
+          // URL so the user has a copy-pasteable path forward — silent failure
+          // was flagged by codex round 1.
+          try {
+            await open(res.manage_url)
+            props.api.ui.toast({
+              variant: "success",
+              message: `Workspace "${res.datamate.name}" created. Opened ${res.manage_url} in your browser.`,
+            })
+          } catch {
+            props.api.ui.toast({
+              variant: "info",
+              message: `Workspace "${res.datamate.name}" created. Open ${res.manage_url} in your browser to configure it.`,
+              duration: 10_000,
+            })
+          }
+          props.api.ui.dialog.clear()
+        } catch (err) {
+          if (err instanceof ConflictError) {
+            setError(
+              `This project is already linked to "${err.detail.existing_datamate_name ?? "another workspace"}". Cancel and pick "Re-link" from the offer if you want to move it.`,
+            )
+          } else {
+            setError(err instanceof Error ? err.message : "Failed to create workspace")
+          }
+        } finally {
+          setBusy(false)
+        }
+      }}
+      onCancel={() => props.api.ui.dialog.clear()}
+    />
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Flow orchestrator — runs on every `altimate.workspace.postScan` command
+// dispatch AND on every `altimate.workspace.link` command dispatch. Idempotent
+// re-entry: if a dialog is already up, the mount replaces it (that's fine —
+// two rapid scan completions collapse to one visible offer).
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function runFlow(
+  api: TuiPluginApi,
+  directory: string,
+  opts: { suppressLatch?: boolean } = {},
+): Promise<void> {
+  const remote = detectProjectRemote(directory)
+  if (!remote) {
+    // Not a git project (or git failed) — nothing to bind to. Silent per spec:
+    // the ticket says "handle failures without blocking the existing flow".
+    return
+  }
+  if (!opts.suppressLatch && isSkipActive(api, remote, Date.now())) {
+    log.info("workspace prompt suppressed by 7-day Skip latch", { remote })
+    return
+  }
+
+  let serverBinding: GetBindingResponse | null | undefined
+  try {
+    serverBinding = await WorkspaceApi.getBindingForRemote(remote)
+  } catch (err) {
+    log.warn("workspace pre-check server call failed, falling back to local cache", {
+      err: err instanceof Error ? err.message : String(err),
+    })
+    serverBinding = undefined
+  }
+
+  if (serverBinding) {
+    // Warm the local cache so an offline follow-up render is consistent.
+    await recordApprovedBinding(directory, {
+      datamateId: serverBinding.datamate.id,
+      datamateName: serverBinding.datamate.name,
+      repoRemote: remote,
+      linkedAt: Date.now(),
+    })
+    api.ui.dialog.replace(() => (
+      <AlreadyLinkedDialog
+        api={api}
+        remote={remote}
+        workspaceName={serverBinding!.datamate.name}
+        workspaceId={serverBinding!.datamate.id}
+        hasDrift={false}
+      />
+    ))
+    return
+  }
+
+  if (serverBinding === null) {
+    // Server confirmed unbound → offer create-or-link.
+    api.ui.dialog.replace(() => (
+      <OfferDialog
+        api={api}
+        remote={remote}
+        defaultName={projectNameFromRemote(remote)}
+        suppressLatch={opts.suppressLatch}
+      />
+    ))
+    return
+  }
+
+  // Server unreachable — fall back to the local cache (marked as unverified).
+  const local = await readLocalBinding(directory)
+  if (local) {
+    api.ui.dialog.replace(() => (
+      <AlreadyLinkedDialog
+        api={api}
+        remote={remote}
+        workspaceName={local.datamateName}
+        workspaceId={local.datamateId}
+        hasDrift={local.repoRemote !== remote}
+        driftedWas={local.repoRemote !== remote ? local.repoRemote : undefined}
+        unverified
+      />
+    ))
+    return
+  }
+  // No local cache either → offer, but flag the server-unreachable state so the
+  // user can decide whether to proceed.
+  api.ui.toast({
+    variant: "warning",
+    message: "Could not reach the Altimate workspace service — pre-check skipped.",
+  })
+  api.ui.dialog.replace(() => (
+    <OfferDialog
+      api={api}
+      remote={remote}
+      defaultName={projectNameFromRemote(remote)}
+      suppressLatch={opts.suppressLatch}
+    />
+  ))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin registration
+// ─────────────────────────────────────────────────────────────────────────────
+
+const tui: TuiPlugin = async (api) => {
+  api.keymap.registerLayer({
+    commands: [
+      {
+        name: "altimate.workspace.postScan",
+        title: "Post-scan workspace prompt",
+        category: "Altimate",
+        namespace: "internal",
+        run() {
+          void runFlow(api, api.state.path.directory)
+        },
+      },
+      {
+        name: "altimate.workspace.link",
+        title: "Link this project to a workspace",
+        category: "Altimate",
+        namespace: "palette",
+        run() {
+          // User-initiated → bypass the Skip latch.
+          void runFlow(api, api.state.path.directory, { suppressLatch: true })
+        },
+      },
+    ],
+  })
+}
+
+export default { id: PLUGIN_ID, tui } satisfies BuiltinTuiPlugin
+
+// Exported for unit tests only. The shared logic (WorkspaceApi, cache, detect,
+// project-name) lives in `@/altimate/workspace/*` and should be tested there;
+// the plugin owns just the TUI-specific latch semantics.
+export { isSkipActive, recordSkip }
+// altimate_change end

--- a/packages/opencode/src/plugin/tui/altimate/workspace.tsx
+++ b/packages/opencode/src/plugin/tui/altimate/workspace.tsx
@@ -91,7 +91,14 @@ function isSkipActive(
 ): boolean {
   const rec = api.kv.get<{ skippedAt: number }>(skipKey(id, scope))
   if (!rec || typeof rec.skippedAt !== "number") return false
-  return nowMs - rec.skippedAt < SKIP_TTL_MS
+  // Reject records timestamped in the future — a system-clock rewind after
+  // ``recordSkip`` would otherwise produce ``nowMs - rec.skippedAt < 0``,
+  // trivially below the 7-day TTL, and suppress the prompt indefinitely.
+  // Treat future timestamps as "corrupt, retry" so the next scan re-offers.
+  // (CodeRabbit cycle 6.)
+  const delta = nowMs - rec.skippedAt
+  if (delta < 0) return false
+  return delta < SKIP_TTL_MS
 }
 
 function recordSkip(
@@ -475,18 +482,21 @@ function PickerDialog(props: PickerProps) {
     }
   }
 
-  // While loading (or on error before dialog closes), render an empty select as
-  // a placeholder — DialogSelect requires the options array up front and doesn't
-  // have a native busy state; the empty list closes to a "no workspaces" message.
+  // While loading (or on error before dialog closes), render a placeholder
+  // row the user can dismiss with Enter. NOTE: DialogSelect's ``filtered()``
+  // drops rows with ``disabled: true`` (packages/tui/src/ui/dialog-select.tsx),
+  // so the placeholder MUST be rendered without that flag — otherwise the
+  // picker shows an empty list, hiding both the loading state and the
+  // "no workspaces yet" hint. Selection is dispatched to ``value === -1``
+  // in ``onSelect`` below and simply clears the dialog. (Kilo cycle 6.)
   const options = () => {
     const list = datamates()
-    if (!list) return [{ title: "Loading workspaces...", value: -1, disabled: true }]
+    if (!list) return [{ title: "Loading workspaces...", value: -1 }]
     if (list.length === 0)
       return [
         {
           title: "No workspaces yet — cancel and pick 'Create a new workspace' instead.",
           value: -1,
-          disabled: true,
         },
       ]
     return list.map((dm: DatamateRef) => ({ title: dm.name, value: dm.id }))
@@ -547,7 +557,8 @@ function OnDemandPickerDialog(props: OnDemandPickerProps) {
 
   const options = () => {
     const list = datamates()
-    if (!list) return [{ title: "Loading workspaces...", value: -1, disabled: true }]
+    // No ``disabled: true`` — DialogSelect filters those out (Kilo cycle 6).
+    if (!list) return [{ title: "Loading workspaces...", value: -1 }]
     // Deliberately short titles + hint in description so the dialog's narrow
     // width doesn't truncate either. The "●" marker stays in the title (single
     // char, cheap) so the currently-linked row is scannable at a glance.

--- a/packages/opencode/src/plugin/tui/altimate/workspace.tsx
+++ b/packages/opencode/src/plugin/tui/altimate/workspace.tsx
@@ -762,6 +762,20 @@ async function runFlow(
 // Plugin registration
 // ─────────────────────────────────────────────────────────────────────────────
 
+/** Report a fire-and-forget flow failure. The keymap ``run()`` callbacks
+ * discard the returned promise with ``void``, so any rejection from
+ * ``recordApprovedBinding`` / ``readLocalBinding`` / anything else awaited
+ * inside would otherwise surface as an unhandled rejection and terminate
+ * the TUI process. Log + surface a toast so the user knows the workspace
+ * flow bailed. (CR round 2.) */
+function reportFlowFailure(api: TuiPluginApi, err: unknown): void {
+  log.error("workspace flow failed", { err: err instanceof Error ? err.message : String(err) })
+  api.ui.toast({
+    variant: "error",
+    message: "Workspace setup failed — see the CLI log for details.",
+  })
+}
+
 const tui: TuiPlugin = async (api) => {
   api.keymap.registerLayer({
     commands: [
@@ -771,7 +785,7 @@ const tui: TuiPlugin = async (api) => {
         category: "Altimate",
         namespace: "internal",
         run() {
-          void runFlow(api, api.state.path.directory)
+          runFlow(api, api.state.path.directory).catch((err) => reportFlowFailure(api, err))
         },
       },
       {
@@ -782,7 +796,9 @@ const tui: TuiPlugin = async (api) => {
         run() {
           // User-initiated → jump straight to picker (currently-linked marked,
           // "＋ Create new" as the first row). No Skip funnel — they invoked.
-          void runOnDemandPicker(api, api.state.path.directory)
+          runOnDemandPicker(api, api.state.path.directory).catch((err) =>
+            reportFlowFailure(api, err),
+          )
         },
       },
     ],

--- a/packages/opencode/src/plugin/tui/altimate/workspace.tsx
+++ b/packages/opencode/src/plugin/tui/altimate/workspace.tsx
@@ -25,7 +25,7 @@ import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { BuiltinTuiPlugin } from "@opencode-ai/tui/builtins"
 import { createHash } from "node:crypto"
 import open from "open"
-import { createSignal, onMount, Show } from "solid-js"
+import { createSignal, onMount } from "solid-js"
 import {
   ConflictError,
   ForbiddenError,
@@ -34,8 +34,13 @@ import {
   WorkspaceApi,
   type DatamateRef,
   type GetBindingResponse,
+  type ProjectIdentifier,
 } from "@/altimate/workspace/api-client"
-import { detectProjectRemote, projectNameFromRemote } from "@/altimate/workspace/detect"
+import {
+  projectNameFromPath,
+  projectNameFromRemote,
+  resolveProjectIdentifier,
+} from "@/altimate/workspace/detect"
 import { readLocalBinding, recordApprovedBinding } from "@/altimate/workspace/state"
 import { Log } from "@/altimate/util/log"
 
@@ -52,20 +57,21 @@ const log = Log.create({ service: "altimate-workspace" })
 const SKIP_TTL_MS = 7 * 24 * 60 * 60 * 1000
 const KV_SKIP_PREFIX = "altimate.workspace.postScan.skip."
 
-function skipKey(remote: string): string {
-  // Hash to keep the KV keyspace bounded and avoid embedding a URL (which can
-  // contain userinfo even after scrubbing edge cases) into a persisted key.
-  return KV_SKIP_PREFIX + createHash("sha1").update(remote).digest("hex")
+/** Latch key from the project's primary identifier (remote > path). Path-only
+ * projects also get a latch — sample-scaffold users are still users. */
+function skipKey(id: ProjectIdentifier): string {
+  const primary = id.repoRemote ?? id.projectPath ?? ""
+  return KV_SKIP_PREFIX + createHash("sha1").update(primary).digest("hex")
 }
 
-function isSkipActive(api: TuiPluginApi, remote: string, nowMs: number): boolean {
-  const rec = api.kv.get<{ skippedAt: number }>(skipKey(remote))
+function isSkipActive(api: TuiPluginApi, id: ProjectIdentifier, nowMs: number): boolean {
+  const rec = api.kv.get<{ skippedAt: number }>(skipKey(id))
   if (!rec || typeof rec.skippedAt !== "number") return false
   return nowMs - rec.skippedAt < SKIP_TTL_MS
 }
 
-function recordSkip(api: TuiPluginApi, remote: string, nowMs: number): void {
-  api.kv.set(skipKey(remote), { skippedAt: nowMs })
+function recordSkip(api: TuiPluginApi, id: ProjectIdentifier, nowMs: number): void {
+  api.kv.set(skipKey(id), { skippedAt: nowMs })
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -76,20 +82,21 @@ function recordSkip(api: TuiPluginApi, remote: string, nowMs: number): void {
 
 interface OfferProps {
   api: TuiPluginApi
-  remote: string
+  identifier: ProjectIdentifier
   defaultName: string
   suppressLatch?: boolean // altimate link on-demand skips the Skip latch
 }
 
 function OfferDialog(props: OfferProps) {
+  const identLabel = () => props.identifier.repoRemote ?? props.identifier.projectPath ?? "this project"
   return (
     <props.api.ui.DialogSelect
-      title={`Set up a workspace for this project? (${props.remote})`}
+      title={`Set up a workspace for this project? (${identLabel()})`}
       options={[
         {
           title: "Create a new workspace",
           value: "create",
-          description: "Opens a browser to configure integrations and knowledge.",
+          description: `Auto-named "${props.defaultName}" from this repo — rename in the SaaS.`,
         },
         {
           title: "Link to an existing workspace",
@@ -105,28 +112,71 @@ function OfferDialog(props: OfferProps) {
       current="create"
       onSelect={(option) => {
         if (option.value === "skip") {
-          if (!props.suppressLatch) recordSkip(props.api, props.remote, Date.now())
+          if (!props.suppressLatch) recordSkip(props.api, props.identifier, Date.now())
           props.api.ui.dialog.clear()
           return
         }
         if (option.value === "create") {
-          props.api.ui.dialog.replace(() => (
-            <CreateDialog api={props.api} defaultName={props.defaultName} remote={props.remote} />
-          ))
+          // Auto-name from git repo — no name prompt. The SaaS UI is the place to
+          // rename / configure; the CLI's job is just to establish the binding.
+          void createAndBindInline(props.api, props.identifier, props.defaultName)
           return
         }
-        // link → picker
+        // link → picker (fresh-project attach path)
         props.api.ui.dialog.replace(() => (
-          <PickerDialog api={props.api} remote={props.remote} mode="attach" />
+          <PickerDialog api={props.api} identifier={props.identifier} mode="attach" />
         ))
       }}
     />
   )
 }
 
+async function createAndBindInline(
+  api: TuiPluginApi,
+  identifier: ProjectIdentifier,
+  name: string,
+): Promise<void> {
+  api.ui.dialog.clear()
+  try {
+    const res = await WorkspaceApi.createAndBind({ name, identifier })
+    await recordApprovedBinding(api.state.path.directory, {
+      datamateId: res.datamate.id,
+      datamateName: res.datamate.name,
+      repoRemote: res.binding.repo_remote,
+      projectPath: res.binding.project_path,
+      linkedAt: Date.now(),
+    })
+    try {
+      await open(res.manage_url)
+      api.ui.toast({
+        variant: "success",
+        message: `Workspace "${res.datamate.name}" created. Opened ${res.manage_url} in your browser.`,
+      })
+    } catch {
+      api.ui.toast({
+        variant: "info",
+        message: `Workspace "${res.datamate.name}" created. Open ${res.manage_url} to configure it.`,
+        duration: 10_000,
+      })
+    }
+  } catch (err) {
+    if (err instanceof ConflictError) {
+      api.ui.toast({
+        variant: "warning",
+        message: `This project is already linked to "${err.detail.existing_datamate_name ?? "another workspace"}". Use the palette's "Link this project to a workspace" to change.`,
+      })
+    } else {
+      api.ui.toast({
+        variant: "error",
+        message: err instanceof Error ? err.message : "Failed to create workspace",
+      })
+    }
+  }
+}
+
 interface AlreadyLinkedProps {
   api: TuiPluginApi
-  remote: string
+  identifier: ProjectIdentifier
   workspaceName: string
   workspaceId: number
   hasDrift: boolean
@@ -140,7 +190,8 @@ function AlreadyLinkedDialog(props: AlreadyLinkedProps) {
   // it puts the critical info in the user's field of view before they pick.
   const title = () => {
     const parts: string[] = [`Project is linked to workspace "${props.workspaceName}"`]
-    if (props.hasDrift && props.driftedWas) parts.push(`(was ${props.driftedWas}, now ${props.remote})`)
+    const now = props.identifier.repoRemote ?? props.identifier.projectPath
+    if (props.hasDrift && props.driftedWas) parts.push(`(was ${props.driftedWas}, now ${now})`)
     if (props.unverified) parts.push("(⚠ unverified — server unreachable, showing cached value)")
     return parts.join(" ")
   }
@@ -175,7 +226,7 @@ function AlreadyLinkedDialog(props: AlreadyLinkedProps) {
         props.api.ui.dialog.replace(() => (
           <PickerDialog
             api={props.api}
-            remote={props.remote}
+            identifier={props.identifier}
             mode="relink"
             expectedCurrentDatamateId={props.workspaceId}
           />
@@ -187,7 +238,7 @@ function AlreadyLinkedDialog(props: AlreadyLinkedProps) {
 
 interface PickerProps {
   api: TuiPluginApi
-  remote: string
+  identifier: ProjectIdentifier
   mode: "attach" | "relink"
   expectedCurrentDatamateId?: number
 }
@@ -211,11 +262,12 @@ function PickerDialog(props: PickerProps) {
   async function pick(datamateId: number) {
     try {
       if (props.mode === "attach") {
-        const res = await WorkspaceApi.bindExisting(datamateId, props.remote)
+        const res = await WorkspaceApi.bindExisting(datamateId, props.identifier)
         await recordApprovedBinding(props.api.state.path.directory, {
           datamateId: res.binding.datamate_id,
           datamateName: res.binding.datamate_name,
           repoRemote: res.binding.repo_remote,
+          projectPath: res.binding.project_path,
           linkedAt: Date.now(),
         })
         props.api.ui.toast({
@@ -223,15 +275,25 @@ function PickerDialog(props: PickerProps) {
           message: `Linked to workspace "${res.binding.datamate_name}".`,
         })
       } else {
-        const res = await WorkspaceApi.rebindByRemote({
-          remote: props.remote,
-          targetDatamateId: datamateId,
-          expectedCurrentDatamateId: props.expectedCurrentDatamateId,
-        })
+        // Rebind: pick the endpoint that matches the identifier we have.
+        // Prefer remote (stronger identity) when available; else fall back to
+        // path — matches the pre-check ordering in getBindingForProject.
+        const res = props.identifier.repoRemote
+          ? await WorkspaceApi.rebindByRemote({
+              remote: props.identifier.repoRemote,
+              targetDatamateId: datamateId,
+              expectedCurrentDatamateId: props.expectedCurrentDatamateId,
+            })
+          : await WorkspaceApi.rebindByPath({
+              projectPath: props.identifier.projectPath!,
+              targetDatamateId: datamateId,
+              expectedCurrentDatamateId: props.expectedCurrentDatamateId,
+            })
         await recordApprovedBinding(props.api.state.path.directory, {
           datamateId: res.binding.datamate_id,
           datamateName: res.binding.datamate_name,
           repoRemote: res.binding.repo_remote,
+          projectPath: res.binding.project_path,
           linkedAt: Date.now(),
         })
         props.api.ui.toast({
@@ -292,106 +354,210 @@ function PickerDialog(props: PickerProps) {
   )
 }
 
-interface CreateProps {
+// Sentinel value for the "＋ Create a new workspace" row in the on-demand
+// picker. Negative so it can't collide with any real datamate id (SERIAL PK).
+const CREATE_NEW_SENTINEL = -2
+
+interface OnDemandPickerProps {
   api: TuiPluginApi
+  identifier: ProjectIdentifier
+  currentlyLinkedDatamateId?: number
+  currentlyLinkedDatamateName?: string
   defaultName: string
-  remote: string
 }
 
-function CreateDialog(props: CreateProps) {
-  const [busy, setBusy] = createSignal(false)
-  const [error, setError] = createSignal<string | null>(null)
+/** Picker-first flow for the on-demand `altimate.workspace.link` command.
+ *
+ * Skips the Create/Link/Skip funnel — the user already opted in by invoking
+ * the palette. Immediately lists workspaces; currently-linked one is marked;
+ * "＋ Create a new workspace" is the first row. No Skip option (user chose to
+ * be here). Auto-names any new workspace from the git repo. */
+function OnDemandPickerDialog(props: OnDemandPickerProps) {
+  const [datamates, setDatamates] = createSignal<DatamateRef[] | null>(null)
+
+  onMount(async () => {
+    try {
+      const list = await WorkspaceApi.listDatamates()
+      setDatamates(list)
+    } catch (err) {
+      props.api.ui.toast({
+        variant: "error",
+        message: err instanceof Error ? err.message : "Failed to load workspaces",
+      })
+      props.api.ui.dialog.clear()
+    }
+  })
+
+  const options = () => {
+    const list = datamates()
+    if (!list) return [{ title: "Loading workspaces...", value: -1, disabled: true }]
+    // Deliberately short titles + hint in description so the dialog's narrow
+    // width doesn't truncate either. The "●" marker stays in the title (single
+    // char, cheap) so the currently-linked row is scannable at a glance.
+    return [
+      {
+        title: "＋ Create a new workspace",
+        value: CREATE_NEW_SENTINEL,
+        description: `Auto-named "${props.defaultName}" from this repo — rename in the SaaS.`,
+      },
+      ...list.map((dm) => ({
+        title: dm.id === props.currentlyLinkedDatamateId ? `● ${dm.name}` : `  ${dm.name}`,
+        value: dm.id,
+        description: dm.id === props.currentlyLinkedDatamateId ? "currently linked to this project" : undefined,
+      })),
+    ]
+  }
+
   return (
-    <props.api.ui.DialogPrompt
-      title="Create workspace"
-      placeholder={props.defaultName || "workspace name"}
-      busy={busy()}
-      busyText="Creating workspace..."
-      description={() => (
-        <box gap={1}>
-          <text fg={props.api.theme.current.textMuted}>Name this workspace (defaults to your project name):</text>
-          <text fg={props.api.theme.current.textMuted}>You can add integrations, knowledge, and guardrails in the browser after.</text>
-          <Show when={error()}>
-            <text fg={props.api.theme.current.error}>{error()!}</text>
-          </Show>
-        </box>
-      )}
-      onConfirm={async (value) => {
-        if (busy()) return
-        const name = (value || "").trim() || props.defaultName || "Untitled Workspace"
-        setBusy(true)
-        setError(null)
-        try {
-          const res = await WorkspaceApi.createAndBind({
-            name,
-            repoRemote: props.remote,
-          })
-          await recordApprovedBinding(props.api.state.path.directory, {
-            datamateId: res.datamate.id,
-            datamateName: res.datamate.name,
-            repoRemote: res.binding.repo_remote,
-            linkedAt: Date.now(),
-          })
-          // Best-effort browser open. On failure, fall back to a toast with the
-          // URL so the user has a copy-pasteable path forward — silent failure
-          // was flagged by codex round 1.
-          try {
-            await open(res.manage_url)
-            props.api.ui.toast({
-              variant: "success",
-              message: `Workspace "${res.datamate.name}" created. Opened ${res.manage_url} in your browser.`,
-            })
-          } catch {
-            props.api.ui.toast({
-              variant: "info",
-              message: `Workspace "${res.datamate.name}" created. Open ${res.manage_url} in your browser to configure it.`,
-              duration: 10_000,
-            })
-          }
+    <props.api.ui.DialogSelect<number>
+      title="Link this project to a workspace"
+      options={options()}
+      current={props.currentlyLinkedDatamateId ?? CREATE_NEW_SENTINEL}
+      onSelect={(option) => {
+        if (option.value === -1) {
           props.api.ui.dialog.clear()
-        } catch (err) {
-          if (err instanceof ConflictError) {
-            setError(
-              `This project is already linked to "${err.detail.existing_datamate_name ?? "another workspace"}". Cancel and pick "Re-link" from the offer if you want to move it.`,
-            )
-          } else {
-            setError(err instanceof Error ? err.message : "Failed to create workspace")
-          }
-        } finally {
-          setBusy(false)
+          return
         }
+        if (option.value === CREATE_NEW_SENTINEL) {
+          void createAndBindInline(props.api, props.identifier, props.defaultName)
+          return
+        }
+        // Picked an existing workspace.
+        if (option.value === props.currentlyLinkedDatamateId) {
+          // No-op — user picked the workspace this project is already linked to.
+          props.api.ui.toast({
+            variant: "info",
+            message: `Already linked to "${props.currentlyLinkedDatamateName}" — nothing changed.`,
+          })
+          props.api.ui.dialog.clear()
+          return
+        }
+        void bindOrRebindInline(
+          props.api,
+          props.identifier,
+          option.value,
+          props.currentlyLinkedDatamateId,
+        )
       }}
-      onCancel={() => props.api.ui.dialog.clear()}
     />
   )
 }
 
+async function bindOrRebindInline(
+  api: TuiPluginApi,
+  identifier: ProjectIdentifier,
+  targetDatamateId: number,
+  currentDatamateId: number | undefined,
+): Promise<void> {
+  api.ui.dialog.clear()
+  try {
+    const res = await (async () => {
+      if (currentDatamateId) {
+        // Rebind: use whichever identifier we have; remote-first for identity.
+        return identifier.repoRemote
+          ? WorkspaceApi.rebindByRemote({
+              remote: identifier.repoRemote,
+              targetDatamateId,
+              expectedCurrentDatamateId: currentDatamateId,
+            })
+          : WorkspaceApi.rebindByPath({
+              projectPath: identifier.projectPath!,
+              targetDatamateId,
+              expectedCurrentDatamateId: currentDatamateId,
+            })
+      }
+      return WorkspaceApi.bindExisting(targetDatamateId, identifier)
+    })()
+    await recordApprovedBinding(api.state.path.directory, {
+      datamateId: res.binding.datamate_id,
+      datamateName: res.binding.datamate_name,
+      repoRemote: res.binding.repo_remote,
+      projectPath: res.binding.project_path,
+      linkedAt: Date.now(),
+    })
+    api.ui.toast({
+      variant: "success",
+      message: currentDatamateId
+        ? `Re-linked to workspace "${res.binding.datamate_name}".`
+        : `Linked to workspace "${res.binding.datamate_name}".`,
+    })
+  } catch (err) {
+    let msg: string
+    if (err instanceof ConflictError) {
+      msg = `Already linked to "${err.detail.existing_datamate_name ?? "another workspace"}".`
+    } else if (err instanceof PreconditionFailedError) {
+      msg = "Someone else re-linked this project — reload and try again."
+    } else if (err instanceof NotFoundError) {
+      msg = "No existing binding to re-link. Try again."
+    } else if (err instanceof ForbiddenError) {
+      msg = "Only the workspace owner can attach projects to it."
+    } else {
+      msg = err instanceof Error ? err.message : "Failed to link workspace"
+    }
+    api.ui.toast({ variant: "error", message: msg })
+  }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
-// Flow orchestrator — runs on every `altimate.workspace.postScan` command
-// dispatch AND on every `altimate.workspace.link` command dispatch. Idempotent
-// re-entry: if a dialog is already up, the mount replaces it (that's fine —
-// two rapid scan completions collapse to one visible offer).
+// Flow orchestrators.
+//
+// `runFlow` — the post-scan trigger flow. Three-way Create/Link/Skip funnel
+// for a user we're prompting FROM ZERO (they haven't opted in). Skip is a
+// first-class outcome; Create branch auto-names.
+//
+// `runOnDemandPicker` — the palette / `/altimate.workspace.link` flow. User
+// already opted in by invoking, so no Skip. Fetches the workspace list +
+// pre-check binding, opens the picker with the currently-linked one marked.
 // ─────────────────────────────────────────────────────────────────────────────
+
+async function runOnDemandPicker(api: TuiPluginApi, directory: string): Promise<void> {
+  const identifier = resolveProjectIdentifier(directory)
+  // Pre-check for the currently-linked marker. Failures are non-fatal — we
+  // still show the picker without the "(currently linked here)" annotation.
+  let existing: GetBindingResponse | null = null
+  try {
+    existing = await WorkspaceApi.getBindingForProject(identifier)
+  } catch (err) {
+    log.warn("on-demand picker pre-check failed", {
+      err: err instanceof Error ? err.message : String(err),
+    })
+  }
+  const defaultName = identifier.repoRemote
+    ? projectNameFromRemote(identifier.repoRemote)
+    : projectNameFromPath(identifier.projectPath)
+  api.ui.dialog.replace(() => (
+    <OnDemandPickerDialog
+      api={api}
+      identifier={identifier}
+      currentlyLinkedDatamateId={existing?.datamate.id}
+      currentlyLinkedDatamateName={existing?.datamate.name}
+      defaultName={defaultName}
+    />
+  ))
+}
 
 async function runFlow(
   api: TuiPluginApi,
   directory: string,
   opts: { suppressLatch?: boolean } = {},
 ): Promise<void> {
-  const remote = detectProjectRemote(directory)
-  if (!remote) {
-    // Not a git project (or git failed) — nothing to bind to. Silent per spec:
-    // the ticket says "handle failures without blocking the existing flow".
-    return
-  }
-  if (!opts.suppressLatch && isSkipActive(api, remote, Date.now())) {
-    log.info("workspace prompt suppressed by 7-day Skip latch", { remote })
+  const identifier = resolveProjectIdentifier(directory)
+  // Path is always populated by resolveProjectIdentifier — projects without a
+  // git remote (sample dbt scaffolds, scratch dirs) still get a binding offer.
+  if (!opts.suppressLatch && isSkipActive(api, identifier, Date.now())) {
+    log.info("workspace prompt suppressed by 7-day Skip latch", {
+      identifier: identifier.repoRemote ?? identifier.projectPath,
+    })
     return
   }
 
+  const defaultName = identifier.repoRemote
+    ? projectNameFromRemote(identifier.repoRemote)
+    : projectNameFromPath(identifier.projectPath)
+
   let serverBinding: GetBindingResponse | null | undefined
   try {
-    serverBinding = await WorkspaceApi.getBindingForRemote(remote)
+    serverBinding = await WorkspaceApi.getBindingForProject(identifier)
   } catch (err) {
     log.warn("workspace pre-check server call failed, falling back to local cache", {
       err: err instanceof Error ? err.message : String(err),
@@ -404,13 +570,14 @@ async function runFlow(
     await recordApprovedBinding(directory, {
       datamateId: serverBinding.datamate.id,
       datamateName: serverBinding.datamate.name,
-      repoRemote: remote,
+      repoRemote: serverBinding.binding.repo_remote,
+      projectPath: serverBinding.binding.project_path,
       linkedAt: Date.now(),
     })
     api.ui.dialog.replace(() => (
       <AlreadyLinkedDialog
         api={api}
-        remote={remote}
+        identifier={identifier}
         workspaceName={serverBinding!.datamate.name}
         workspaceId={serverBinding!.datamate.id}
         hasDrift={false}
@@ -424,8 +591,8 @@ async function runFlow(
     api.ui.dialog.replace(() => (
       <OfferDialog
         api={api}
-        remote={remote}
-        defaultName={projectNameFromRemote(remote)}
+        identifier={identifier}
+        defaultName={defaultName}
         suppressLatch={opts.suppressLatch}
       />
     ))
@@ -435,14 +602,19 @@ async function runFlow(
   // Server unreachable — fall back to the local cache (marked as unverified).
   const local = await readLocalBinding(directory)
   if (local) {
+    // Drift = the identifier the cache remembers differs from what we're
+    // seeing now. Compare on the field that's actually populated in the cache.
+    const cachedIdent = local.repoRemote ?? local.projectPath ?? ""
+    const currentIdent = identifier.repoRemote ?? identifier.projectPath
+    const hasDrift = cachedIdent !== currentIdent
     api.ui.dialog.replace(() => (
       <AlreadyLinkedDialog
         api={api}
-        remote={remote}
+        identifier={identifier}
         workspaceName={local.datamateName}
         workspaceId={local.datamateId}
-        hasDrift={local.repoRemote !== remote}
-        driftedWas={local.repoRemote !== remote ? local.repoRemote : undefined}
+        hasDrift={hasDrift}
+        driftedWas={hasDrift ? cachedIdent : undefined}
         unverified
       />
     ))
@@ -457,8 +629,8 @@ async function runFlow(
   api.ui.dialog.replace(() => (
     <OfferDialog
       api={api}
-      remote={remote}
-      defaultName={projectNameFromRemote(remote)}
+      identifier={identifier}
+      defaultName={defaultName}
       suppressLatch={opts.suppressLatch}
     />
   ))
@@ -486,8 +658,9 @@ const tui: TuiPlugin = async (api) => {
         category: "Altimate",
         namespace: "palette",
         run() {
-          // User-initiated → bypass the Skip latch.
-          void runFlow(api, api.state.path.directory, { suppressLatch: true })
+          // User-initiated → jump straight to picker (currently-linked marked,
+          // "＋ Create new" as the first row). No Skip funnel — they invoked.
+          void runOnDemandPicker(api, api.state.path.directory)
         },
       },
     ],

--- a/packages/opencode/src/plugin/tui/altimate/workspace.tsx
+++ b/packages/opencode/src/plugin/tui/altimate/workspace.tsx
@@ -132,7 +132,6 @@ interface OfferProps {
   api: TuiPluginApi
   identifier: ProjectIdentifier
   defaultName: string
-  suppressLatch?: boolean // altimate link on-demand skips the Skip latch
   /** (tenant, apiUrl) scope for the Skip latch. Resolved once by the caller
    * so the sync ``onSelect`` handler can call ``recordSkip`` without a
    * mid-render await. Null when creds are unavailable — latch falls back
@@ -159,14 +158,13 @@ function OfferDialog(props: OfferProps) {
         {
           title: "Skip for now",
           value: "skip",
-          description: props.suppressLatch ? "Close this prompt." : "Won't ask again for 7 days.",
+          description: "Won't ask again for 7 days.",
         },
       ]}
       current="create"
       onSelect={(option) => {
         if (option.value === "skip") {
-          if (!props.suppressLatch)
-            recordSkip(props.api, props.identifier, props.latchScope, Date.now())
+          recordSkip(props.api, props.identifier, props.latchScope, Date.now())
           props.api.ui.dialog.clear()
           return
         }
@@ -406,6 +404,14 @@ interface PickerProps {
 function PickerDialog(props: PickerProps) {
   const [datamates, setDatamates] = createSignal<DatamateRef[] | null>(null)
   const [loadError, setLoadError] = createSignal<string | null>(null)
+  // DialogSelect delivers ``onSelect`` synchronously per Enter keypress, but
+  // ``pick()`` awaits the network round-trip — a second Enter before the
+  // first bind resolves would fire a duplicate ``bindExisting`` /
+  // ``rebindBy…`` against a project that may already be bound by the first
+  // call. The second call typically 409s, but the toast then contradicts the
+  // success toast the first call is about to render. Latch on the first
+  // in-flight ``pick()``. (kilo cycle 6.)
+  let submitting = false
 
   onMount(async () => {
     try {
@@ -420,6 +426,8 @@ function PickerDialog(props: PickerProps) {
   })
 
   async function pick(datamateId: number) {
+    if (submitting) return
+    submitting = true
     try {
       if (props.mode === "attach") {
         const res = await WorkspaceApi.bindExisting(datamateId, props.identifier)
@@ -463,15 +471,20 @@ function PickerDialog(props: PickerProps) {
       }
       props.api.ui.dialog.clear()
     } catch (err) {
-      // Surface as a toast so the user sees the specific failure. Dialog closes
-      // either way — the user can re-invoke via /altimate.workspace.link.
+      // Surface as a toast so the user sees the specific failure. Dialog
+      // closes either way — the palette command ``altimate.workspace.link``
+      // (or re-running ``altimate-code link``) re-enters the flow, so the
+      // user always has a way to try again from a clean slate.
       let msg: string
       if (err instanceof ConflictError) {
-        msg = `Already linked to "${err.detail.existing_datamate_name ?? "another workspace"}" — pick Re-link from the offer if you want to move it.`
+        // The picker doesn't have a "Re-link" option; the referral used to
+        // point at OfferDialog's Re-link, which doesn't exist either. Point
+        // at the concrete next action instead. (kilo cycle 6.)
+        msg = `Already linked to "${err.detail.existing_datamate_name ?? "another workspace"}". Re-run \`altimate-code link\` to change the workspace.`
       } else if (err instanceof PreconditionFailedError) {
         msg = "Someone else re-linked this project — reload and try again."
       } else if (err instanceof NotFoundError) {
-        msg = "No existing binding for this remote to re-link. Try Create/Link from the offer instead."
+        msg = "No existing binding for this remote to re-link. Re-run `altimate-code link` and pick Create."
       } else if (err instanceof ForbiddenError) {
         msg = "Only the workspace owner can attach projects to it."
       } else {
@@ -479,6 +492,8 @@ function PickerDialog(props: PickerProps) {
       }
       props.api.ui.toast({ variant: "error", message: msg })
       props.api.ui.dialog.clear()
+    } finally {
+      submitting = false
     }
   }
 
@@ -713,11 +728,7 @@ async function runOnDemandPicker(api: TuiPluginApi, directory: string): Promise<
   ))
 }
 
-async function runFlow(
-  api: TuiPluginApi,
-  directory: string,
-  opts: { suppressLatch?: boolean } = {},
-): Promise<void> {
+async function runFlow(api: TuiPluginApi, directory: string): Promise<void> {
   const identifier = resolveProjectIdentifier(directory)
   // Resolve latch scope ONCE — passed to isSkipActive here + threaded into
   // OfferDialog so its sync onSelect can call recordSkip without awaiting.
@@ -725,7 +736,7 @@ async function runFlow(
   const latchScope = await currentLatchScope()
   // Path is always populated by resolveProjectIdentifier — projects without a
   // git remote (sample dbt scaffolds, scratch dirs) still get a binding offer.
-  if (!opts.suppressLatch && isSkipActive(api, identifier, latchScope, Date.now())) {
+  if (isSkipActive(api, identifier, latchScope, Date.now())) {
     log.info("workspace prompt suppressed by 7-day Skip latch", {
       identifier: identifier.repoRemote ?? identifier.projectPath,
     })
@@ -788,7 +799,6 @@ async function runFlow(
         api={api}
         identifier={identifier}
         defaultName={defaultName}
-        suppressLatch={opts.suppressLatch}
         latchScope={latchScope}
       />
     ))
@@ -830,7 +840,6 @@ async function runFlow(
       api={api}
       identifier={identifier}
       defaultName={defaultName}
-      suppressLatch={opts.suppressLatch}
       latchScope={latchScope}
     />
   ))

--- a/packages/opencode/src/plugin/tui/altimate/workspace.tsx
+++ b/packages/opencode/src/plugin/tui/altimate/workspace.tsx
@@ -230,34 +230,49 @@ async function createAndBindInline(
     }
   }
 
-  await recordApprovedBinding(api.state.path.directory, {
-    datamateId: res.datamate.id,
-    datamateName: res.datamate.name,
-    repoRemote: res.binding.repo_remote,
-    projectPath: res.binding.project_path,
-    linkedAt: Date.now(),
-  })
-  // Guard against a non-http(s) manage_url — ``open`` dispatches to whatever
-  // OS handler matches the protocol, so a rogue value could launch an
-  // unrelated app. Fall through to the info toast (with the URL for manual
-  // copy) if the URL isn't a safe http/https link.
-  if (isSafeHttpUrl(res.manage_url)) {
-    try {
-      await open(res.manage_url)
-      api.ui.toast({
-        variant: "success",
-        message: `Workspace "${res.datamate.name}" created. Opened ${res.manage_url} in your browser.`,
-      })
-      return
-    } catch {
-      /* fall through to the "open manually" toast below */
+  // Post-success tail — this function is invoked fire-and-forget
+  // (``void createAndBindInline(...)``), so a bare rejection here would
+  // surface as an unhandled promise and terminate the TUI. Contain the
+  // fallout inside the function itself: ``recordApprovedBinding`` already
+  // swallows its own errors (state.ts is best-effort), but ``open()`` and
+  // the toast APIs can reject unexpectedly. Fall back to a plain info
+  // toast so the user still sees the URL. (Kilo cycle 5.)
+  try {
+    await recordApprovedBinding(api.state.path.directory, {
+      datamateId: res.datamate.id,
+      datamateName: res.datamate.name,
+      repoRemote: res.binding.repo_remote,
+      projectPath: res.binding.project_path,
+      linkedAt: Date.now(),
+    })
+    // Guard against a non-http(s) manage_url — ``open`` dispatches to whatever
+    // OS handler matches the protocol, so a rogue value could launch an
+    // unrelated app. Fall through to the info toast (with the URL for manual
+    // copy) if the URL isn't a safe http/https link.
+    if (isSafeHttpUrl(res.manage_url)) {
+      try {
+        await open(res.manage_url)
+        api.ui.toast({
+          variant: "success",
+          message: `Workspace "${res.datamate.name}" created. Opened ${res.manage_url} in your browser.`,
+        })
+        return
+      } catch {
+        /* fall through to the "open manually" toast below */
+      }
     }
+    api.ui.toast({
+      variant: "info",
+      message: `Workspace "${res.datamate.name}" created. Open ${res.manage_url} to configure it.`,
+      duration: 10_000,
+    })
+  } catch (err) {
+    api.ui.toast({
+      variant: "info",
+      message: `Workspace "${res.datamate.name}" created and linked.`,
+    })
+    void err
   }
-  api.ui.toast({
-    variant: "info",
-    message: `Workspace "${res.datamate.name}" created. Open ${res.manage_url} to configure it.`,
-    duration: 10_000,
-  })
 }
 
 /** True when the URL parses and its protocol is exactly ``http:`` or ``https:``.

--- a/packages/opencode/src/plugin/tui/altimate/workspace.tsx
+++ b/packages/opencode/src/plugin/tui/altimate/workspace.tsx
@@ -43,6 +43,7 @@ import {
   resolveProjectIdentifier,
 } from "@/altimate/workspace/detect"
 import { readLocalBinding, recordApprovedBinding } from "@/altimate/workspace/state"
+import { AltimateApi } from "@/altimate/api/client"
 import { Log } from "@/altimate/util/log"
 
 const PLUGIN_ID = "altimate:workspace"
@@ -58,21 +59,60 @@ const log = Log.create({ service: "altimate-workspace" })
 const SKIP_TTL_MS = 7 * 24 * 60 * 60 * 1000
 const KV_SKIP_PREFIX = "altimate.workspace.postScan.skip."
 
-/** Latch key from the project's primary identifier (remote > path). Path-only
- * projects also get a latch — sample-scaffold users are still users. */
-function skipKey(id: ProjectIdentifier): string {
-  const primary = id.repoRemote ?? id.projectPath ?? ""
-  return KV_SKIP_PREFIX + createHash("sha1").update(primary).digest("hex")
+/** (tenant, apiUrl) scope for the Skip latch — matches the local binding
+ * cache's top-level scoping. Without this a Skip in one Altimate account
+ * suppresses the post-scan prompt for the same project in every other
+ * account for 7 days. Sync-provided by the caller because ``recordSkip`` is
+ * invoked inside the dialog's synchronous ``onSelect`` handler. Null means
+ * "unscoped" (used only when credentials are unavailable). (cubic round 3.) */
+export interface LatchScope {
+  tenant: string
+  apiUrl: string
 }
 
-function isSkipActive(api: TuiPluginApi, id: ProjectIdentifier, nowMs: number): boolean {
-  const rec = api.kv.get<{ skippedAt: number }>(skipKey(id))
+/** Latch key from (tenant, apiUrl, primary identifier). Path-only projects
+ * also get a latch — sample-scaffold users are still users. */
+function skipKey(id: ProjectIdentifier, scope: LatchScope | null): string {
+  const primary = id.repoRemote ?? id.projectPath ?? ""
+  const scopeString = scope ? `${scope.tenant}|${scope.apiUrl}|` : ""
+  return (
+    KV_SKIP_PREFIX +
+    createHash("sha1")
+      .update(scopeString + primary)
+      .digest("hex")
+  )
+}
+
+function isSkipActive(
+  api: TuiPluginApi,
+  id: ProjectIdentifier,
+  scope: LatchScope | null,
+  nowMs: number,
+): boolean {
+  const rec = api.kv.get<{ skippedAt: number }>(skipKey(id, scope))
   if (!rec || typeof rec.skippedAt !== "number") return false
   return nowMs - rec.skippedAt < SKIP_TTL_MS
 }
 
-function recordSkip(api: TuiPluginApi, id: ProjectIdentifier, nowMs: number): void {
-  api.kv.set(skipKey(id), { skippedAt: nowMs })
+function recordSkip(
+  api: TuiPluginApi,
+  id: ProjectIdentifier,
+  scope: LatchScope | null,
+  nowMs: number,
+): void {
+  api.kv.set(skipKey(id, scope), { skippedAt: nowMs })
+}
+
+/** Best-effort ``LatchScope`` from the current CLI credentials. Returns null
+ * on any credential failure — the latch then falls back to an unscoped key. */
+async function currentLatchScope(): Promise<LatchScope | null> {
+  try {
+    if (!(await AltimateApi.isConfigured().catch(() => false))) return null
+    const creds = await AltimateApi.getCredentials()
+    return { tenant: creds.altimateInstanceName, apiUrl: creds.altimateUrl }
+  } catch {
+    return null
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -86,6 +126,11 @@ interface OfferProps {
   identifier: ProjectIdentifier
   defaultName: string
   suppressLatch?: boolean // altimate link on-demand skips the Skip latch
+  /** (tenant, apiUrl) scope for the Skip latch. Resolved once by the caller
+   * so the sync ``onSelect`` handler can call ``recordSkip`` without a
+   * mid-render await. Null when creds are unavailable — latch falls back
+   * to unscoped. (cubic round 3.) */
+  latchScope: LatchScope | null
 }
 
 function OfferDialog(props: OfferProps) {
@@ -113,7 +158,8 @@ function OfferDialog(props: OfferProps) {
       current="create"
       onSelect={(option) => {
         if (option.value === "skip") {
-          if (!props.suppressLatch) recordSkip(props.api, props.identifier, Date.now())
+          if (!props.suppressLatch)
+            recordSkip(props.api, props.identifier, props.latchScope, Date.now())
           props.api.ui.dialog.clear()
           return
         }
@@ -647,9 +693,13 @@ async function runFlow(
   opts: { suppressLatch?: boolean } = {},
 ): Promise<void> {
   const identifier = resolveProjectIdentifier(directory)
+  // Resolve latch scope ONCE — passed to isSkipActive here + threaded into
+  // OfferDialog so its sync onSelect can call recordSkip without awaiting.
+  // (cubic round 3.)
+  const latchScope = await currentLatchScope()
   // Path is always populated by resolveProjectIdentifier — projects without a
   // git remote (sample dbt scaffolds, scratch dirs) still get a binding offer.
-  if (!opts.suppressLatch && isSkipActive(api, identifier, Date.now())) {
+  if (!opts.suppressLatch && isSkipActive(api, identifier, latchScope, Date.now())) {
     log.info("workspace prompt suppressed by 7-day Skip latch", {
       identifier: identifier.repoRemote ?? identifier.projectPath,
     })
@@ -713,6 +763,7 @@ async function runFlow(
         identifier={identifier}
         defaultName={defaultName}
         suppressLatch={opts.suppressLatch}
+        latchScope={latchScope}
       />
     ))
     return
@@ -754,6 +805,7 @@ async function runFlow(
       identifier={identifier}
       defaultName={defaultName}
       suppressLatch={opts.suppressLatch}
+      latchScope={latchScope}
     />
   ))
 }

--- a/packages/opencode/src/plugin/tui/altimate/workspace.tsx
+++ b/packages/opencode/src/plugin/tui/altimate/workspace.tsx
@@ -33,7 +33,8 @@ import {
   PreconditionFailedError,
   WorkspaceApi,
   type DatamateRef,
-  type GetBindingResponse,
+  type MatchedIdentifier,
+  type ProjectBindingLookup,
   type ProjectIdentifier,
 } from "@/altimate/workspace/api-client"
 import {
@@ -135,30 +136,16 @@ async function createAndBindInline(
   api: TuiPluginApi,
   identifier: ProjectIdentifier,
   name: string,
+  /** When present, this project is already bound to another workspace.
+   * createAndBind succeeds but leaves the binding pointing at the OLD
+   * workspace; without this rebind step the new workspace is an orphaned
+   * (billable) SaaS resource the CLI knows nothing about (M2). */
+  rebindFrom?: { expectedCurrentDatamateId: number; matchedBy: MatchedIdentifier },
 ): Promise<void> {
   api.ui.dialog.clear()
+  let res: Awaited<ReturnType<typeof WorkspaceApi.createAndBind>>
   try {
-    const res = await WorkspaceApi.createAndBind({ name, identifier })
-    await recordApprovedBinding(api.state.path.directory, {
-      datamateId: res.datamate.id,
-      datamateName: res.datamate.name,
-      repoRemote: res.binding.repo_remote,
-      projectPath: res.binding.project_path,
-      linkedAt: Date.now(),
-    })
-    try {
-      await open(res.manage_url)
-      api.ui.toast({
-        variant: "success",
-        message: `Workspace "${res.datamate.name}" created. Opened ${res.manage_url} in your browser.`,
-      })
-    } catch {
-      api.ui.toast({
-        variant: "info",
-        message: `Workspace "${res.datamate.name}" created. Open ${res.manage_url} to configure it.`,
-        duration: 10_000,
-      })
-    }
+    res = await WorkspaceApi.createAndBind({ name, identifier })
   } catch (err) {
     if (err instanceof ConflictError) {
       api.ui.toast({
@@ -171,7 +158,81 @@ async function createAndBindInline(
         message: err instanceof Error ? err.message : "Failed to create workspace",
       })
     }
+    return
   }
+
+  if (rebindFrom) {
+    // The atomic create-and-bind wrote a NEW binding for the new workspace,
+    // but the existing binding for THIS project's remote/path still points
+    // at the old workspace. Repoint via the matched-identifier rebind
+    // endpoint. If rebind fails, tell the user the workspace exists but
+    // the link didn't switch — do not silently orphan.
+    try {
+      await rebindByMatchedIdentifier({
+        identifier,
+        targetDatamateId: res.datamate.id,
+        expectedCurrentDatamateId: rebindFrom.expectedCurrentDatamateId,
+        matchedBy: rebindFrom.matchedBy,
+      })
+    } catch (err) {
+      api.ui.toast({
+        variant: "error",
+        message: `Workspace "${res.datamate.name}" was CREATED but could not be linked to this project (${err instanceof Error ? err.message : String(err)}). Run \`altimate-code link\` to retry.`,
+        duration: 15_000,
+      })
+      return
+    }
+  }
+
+  await recordApprovedBinding(api.state.path.directory, {
+    datamateId: res.datamate.id,
+    datamateName: res.datamate.name,
+    repoRemote: res.binding.repo_remote,
+    projectPath: res.binding.project_path,
+    linkedAt: Date.now(),
+  })
+  try {
+    await open(res.manage_url)
+    api.ui.toast({
+      variant: "success",
+      message: `Workspace "${res.datamate.name}" created. Opened ${res.manage_url} in your browser.`,
+    })
+  } catch {
+    api.ui.toast({
+      variant: "info",
+      message: `Workspace "${res.datamate.name}" created. Open ${res.manage_url} to configure it.`,
+      duration: 10_000,
+    })
+  }
+}
+
+/** Pick the rebind endpoint that matches which identifier the pre-check
+ * resolved the binding on. Shared with cli/cmd/link.ts through duplicated
+ * code (M3) — the modules deliberately don't cross-import so the CLI
+ * subcommand stays self-contained. */
+async function rebindByMatchedIdentifier(input: {
+  identifier: ProjectIdentifier
+  targetDatamateId: number
+  expectedCurrentDatamateId: number
+  matchedBy: MatchedIdentifier
+}) {
+  if (input.matchedBy === "remote" && input.identifier.repoRemote) {
+    return WorkspaceApi.rebindByRemote({
+      remote: input.identifier.repoRemote,
+      targetDatamateId: input.targetDatamateId,
+      expectedCurrentDatamateId: input.expectedCurrentDatamateId,
+    })
+  }
+  if (input.matchedBy === "path" && input.identifier.projectPath) {
+    return WorkspaceApi.rebindByPath({
+      projectPath: input.identifier.projectPath,
+      targetDatamateId: input.targetDatamateId,
+      expectedCurrentDatamateId: input.expectedCurrentDatamateId,
+    })
+  }
+  throw new Error(
+    `Cannot rebind — pre-check matched on ${input.matchedBy} but that field is not present on the current project identifier.`,
+  )
 }
 
 interface AlreadyLinkedProps {
@@ -182,6 +243,12 @@ interface AlreadyLinkedProps {
   hasDrift: boolean
   driftedWas?: string | null
   unverified?: boolean
+  /** Which identifier arm resolved the binding — remote-matched projects
+   * rebind via ``/by-remote``, path-matched via ``/by-path``. Not the same
+   * as ``identifier.repoRemote`` / ``identifier.projectPath``, which reflect
+   * the CURRENT project, not the binding's origin. Threaded into PickerDialog
+   * so a re-link picks the correct endpoint. (M3) */
+  matchedBy: MatchedIdentifier
 }
 
 function AlreadyLinkedDialog(props: AlreadyLinkedProps) {
@@ -222,13 +289,15 @@ function AlreadyLinkedDialog(props: AlreadyLinkedProps) {
           return
         }
         // relink → picker with the current workspace id as expected_current so
-        // a concurrent re-link by another client 412s cleanly.
+        // a concurrent re-link by another client 412s cleanly. matchedBy
+        // determines which rebind endpoint the picker will call (M3).
         props.api.ui.dialog.replace(() => (
           <PickerDialog
             api={props.api}
             identifier={props.identifier}
             mode="relink"
             expectedCurrentDatamateId={props.workspaceId}
+            matchedBy={props.matchedBy}
           />
         ))
       }}
@@ -241,6 +310,9 @@ interface PickerProps {
   identifier: ProjectIdentifier
   mode: "attach" | "relink"
   expectedCurrentDatamateId?: number
+  /** Set for ``mode: "relink"`` — which identifier arm the pre-check matched
+   * on so we pick the correct rebind endpoint. (M3) */
+  matchedBy?: MatchedIdentifier
 }
 
 function PickerDialog(props: PickerProps) {
@@ -275,20 +347,20 @@ function PickerDialog(props: PickerProps) {
           message: `Linked to workspace "${res.binding.datamate_name}".`,
         })
       } else {
-        // Rebind: pick the endpoint that matches the identifier we have.
-        // Prefer remote (stronger identity) when available; else fall back to
-        // path — matches the pre-check ordering in getBindingForProject.
-        const res = props.identifier.repoRemote
-          ? await WorkspaceApi.rebindByRemote({
-              remote: props.identifier.repoRemote,
-              targetDatamateId: datamateId,
-              expectedCurrentDatamateId: props.expectedCurrentDatamateId,
-            })
-          : await WorkspaceApi.rebindByPath({
-              projectPath: props.identifier.projectPath!,
-              targetDatamateId: datamateId,
-              expectedCurrentDatamateId: props.expectedCurrentDatamateId,
-            })
+        // Rebind: pick the endpoint that matches which identifier the
+        // pre-check RESOLVED the binding on — not what the current identifier
+        // happens to carry. A repo whose remote was renamed still has its
+        // binding under its path; rebindByRemote against the new remote would
+        // 404 with no repair path from the TUI. (M3)
+        if (!props.matchedBy || !props.expectedCurrentDatamateId) {
+          throw new Error("relink picker opened without matchedBy / expectedCurrentDatamateId")
+        }
+        const res = await rebindByMatchedIdentifier({
+          identifier: props.identifier,
+          targetDatamateId: datamateId,
+          expectedCurrentDatamateId: props.expectedCurrentDatamateId,
+          matchedBy: props.matchedBy,
+        })
         await recordApprovedBinding(props.api.state.path.directory, {
           datamateId: res.binding.datamate_id,
           datamateName: res.binding.datamate_name,
@@ -363,6 +435,10 @@ interface OnDemandPickerProps {
   identifier: ProjectIdentifier
   currentlyLinkedDatamateId?: number
   currentlyLinkedDatamateName?: string
+  /** Which identifier arm the pre-check matched on. Required to pick the
+   * correct rebind endpoint when the user swaps workspaces or picks Create
+   * on an already-linked project. (M3) */
+  matchedBy?: MatchedIdentifier
   defaultName: string
 }
 
@@ -419,7 +495,18 @@ function OnDemandPickerDialog(props: OnDemandPickerProps) {
           return
         }
         if (option.value === CREATE_NEW_SENTINEL) {
-          void createAndBindInline(props.api, props.identifier, props.defaultName)
+          // If already linked, thread the pre-check outcome so createAndBind
+          // is followed by a rebind — otherwise the new workspace is a real
+          // (billable) SaaS resource left orphaned while the project is
+          // still bound to the OLD workspace. (M2)
+          const rebindFrom =
+            props.currentlyLinkedDatamateId !== undefined && props.matchedBy
+              ? {
+                  expectedCurrentDatamateId: props.currentlyLinkedDatamateId,
+                  matchedBy: props.matchedBy,
+                }
+              : undefined
+          void createAndBindInline(props.api, props.identifier, props.defaultName, rebindFrom)
           return
         }
         // Picked an existing workspace.
@@ -432,12 +519,11 @@ function OnDemandPickerDialog(props: OnDemandPickerProps) {
           props.api.ui.dialog.clear()
           return
         }
-        void bindOrRebindInline(
-          props.api,
-          props.identifier,
-          option.value,
-          props.currentlyLinkedDatamateId,
-        )
+        const existing =
+          props.currentlyLinkedDatamateId !== undefined && props.matchedBy
+            ? { datamateId: props.currentlyLinkedDatamateId, matchedBy: props.matchedBy }
+            : undefined
+        void bindOrRebindInline(props.api, props.identifier, option.value, existing)
       }}
     />
   )
@@ -447,24 +533,22 @@ async function bindOrRebindInline(
   api: TuiPluginApi,
   identifier: ProjectIdentifier,
   targetDatamateId: number,
-  currentDatamateId: number | undefined,
+  /** Pre-check outcome. Absent means "not linked / pre-check missed" and
+   * we call bindExisting; present means "linked" and we rebind via the
+   * matched-identifier endpoint (M3). */
+  existing: { datamateId: number; matchedBy: MatchedIdentifier } | undefined,
 ): Promise<void> {
   api.ui.dialog.clear()
+  const isRebind = existing !== undefined
   try {
     const res = await (async () => {
-      if (currentDatamateId) {
-        // Rebind: use whichever identifier we have; remote-first for identity.
-        return identifier.repoRemote
-          ? WorkspaceApi.rebindByRemote({
-              remote: identifier.repoRemote,
-              targetDatamateId,
-              expectedCurrentDatamateId: currentDatamateId,
-            })
-          : WorkspaceApi.rebindByPath({
-              projectPath: identifier.projectPath!,
-              targetDatamateId,
-              expectedCurrentDatamateId: currentDatamateId,
-            })
+      if (existing) {
+        return rebindByMatchedIdentifier({
+          identifier,
+          targetDatamateId,
+          expectedCurrentDatamateId: existing.datamateId,
+          matchedBy: existing.matchedBy,
+        })
       }
       return WorkspaceApi.bindExisting(targetDatamateId, identifier)
     })()
@@ -477,7 +561,7 @@ async function bindOrRebindInline(
     })
     api.ui.toast({
       variant: "success",
-      message: currentDatamateId
+      message: isRebind
         ? `Re-linked to workspace "${res.binding.datamate_name}".`
         : `Linked to workspace "${res.binding.datamate_name}".`,
     })
@@ -514,7 +598,7 @@ async function runOnDemandPicker(api: TuiPluginApi, directory: string): Promise<
   const identifier = resolveProjectIdentifier(directory)
   // Pre-check for the currently-linked marker. Failures are non-fatal — we
   // still show the picker without the "(currently linked here)" annotation.
-  let existing: GetBindingResponse | null = null
+  let existing: ProjectBindingLookup | null = null
   try {
     existing = await WorkspaceApi.getBindingForProject(identifier)
   } catch (err) {
@@ -531,6 +615,7 @@ async function runOnDemandPicker(api: TuiPluginApi, directory: string): Promise<
       identifier={identifier}
       currentlyLinkedDatamateId={existing?.datamate.id}
       currentlyLinkedDatamateName={existing?.datamate.name}
+      matchedBy={existing?.matchedBy}
       defaultName={defaultName}
     />
   ))
@@ -555,7 +640,7 @@ async function runFlow(
     ? projectNameFromRemote(identifier.repoRemote)
     : projectNameFromPath(identifier.projectPath)
 
-  let serverBinding: GetBindingResponse | null | undefined
+  let serverBinding: ProjectBindingLookup | null | undefined
   try {
     serverBinding = await WorkspaceApi.getBindingForProject(identifier)
   } catch (err) {
@@ -574,13 +659,27 @@ async function runFlow(
       projectPath: serverBinding.binding.project_path,
       linkedAt: Date.now(),
     })
+    // Drift = the identifier the server matched on doesn't equal the
+    // corresponding identifier this project currently has. E.g. we matched
+    // on remote but the current remote differs from what the binding
+    // stored — the repo was renamed / remote swapped. The dialog surfaces
+    // this so the user isn't silently attached to a stale binding. (M3)
+    const boundIdent =
+      serverBinding.matchedBy === "remote"
+        ? serverBinding.binding.repo_remote
+        : serverBinding.binding.project_path
+    const currentIdent =
+      serverBinding.matchedBy === "remote" ? identifier.repoRemote : identifier.projectPath
+    const hasDrift = boundIdent != null && currentIdent != null && boundIdent !== currentIdent
     api.ui.dialog.replace(() => (
       <AlreadyLinkedDialog
         api={api}
         identifier={identifier}
         workspaceName={serverBinding!.datamate.name}
         workspaceId={serverBinding!.datamate.id}
-        hasDrift={false}
+        matchedBy={serverBinding!.matchedBy}
+        hasDrift={hasDrift}
+        driftedWas={hasDrift ? boundIdent : undefined}
       />
     ))
     return
@@ -602,17 +701,20 @@ async function runFlow(
   // Server unreachable — fall back to the local cache (marked as unverified).
   const local = await readLocalBinding(directory)
   if (local) {
-    // Drift = the identifier the cache remembers differs from what we're
-    // seeing now. Compare on the field that's actually populated in the cache.
+    // Prefer whichever identifier the cache remembers as populated. Same
+    // ordering as the server-side pre-check: remote first, path fallback.
+    const cachedMatchedBy: MatchedIdentifier = local.repoRemote ? "remote" : "path"
     const cachedIdent = local.repoRemote ?? local.projectPath ?? ""
-    const currentIdent = identifier.repoRemote ?? identifier.projectPath
-    const hasDrift = cachedIdent !== currentIdent
+    const currentIdent =
+      cachedMatchedBy === "remote" ? identifier.repoRemote : identifier.projectPath
+    const hasDrift = cachedIdent !== "" && currentIdent != null && cachedIdent !== currentIdent
     api.ui.dialog.replace(() => (
       <AlreadyLinkedDialog
         api={api}
         identifier={identifier}
         workspaceName={local.datamateName}
         workspaceId={local.datamateId}
+        matchedBy={cachedMatchedBy}
         hasDrift={hasDrift}
         driftedWas={hasDrift ? cachedIdent : undefined}
         unverified

--- a/packages/opencode/src/plugin/tui/altimate/workspace.tsx
+++ b/packages/opencode/src/plugin/tui/altimate/workspace.tsx
@@ -191,18 +191,38 @@ async function createAndBindInline(
     projectPath: res.binding.project_path,
     linkedAt: Date.now(),
   })
+  // Guard against a non-http(s) manage_url — ``open`` dispatches to whatever
+  // OS handler matches the protocol, so a rogue value could launch an
+  // unrelated app. Fall through to the info toast (with the URL for manual
+  // copy) if the URL isn't a safe http/https link.
+  if (isSafeHttpUrl(res.manage_url)) {
+    try {
+      await open(res.manage_url)
+      api.ui.toast({
+        variant: "success",
+        message: `Workspace "${res.datamate.name}" created. Opened ${res.manage_url} in your browser.`,
+      })
+      return
+    } catch {
+      /* fall through to the "open manually" toast below */
+    }
+  }
+  api.ui.toast({
+    variant: "info",
+    message: `Workspace "${res.datamate.name}" created. Open ${res.manage_url} to configure it.`,
+    duration: 10_000,
+  })
+}
+
+/** True when the URL parses and its protocol is exactly ``http:`` or ``https:``.
+ * Used before handing a server-supplied URL to ``open()`` (which would otherwise
+ * dispatch to whatever OS scheme handler matches the protocol). */
+function isSafeHttpUrl(url: string): boolean {
   try {
-    await open(res.manage_url)
-    api.ui.toast({
-      variant: "success",
-      message: `Workspace "${res.datamate.name}" created. Opened ${res.manage_url} in your browser.`,
-    })
+    const u = new URL(url)
+    return u.protocol === "http:" || u.protocol === "https:"
   } catch {
-    api.ui.toast({
-      variant: "info",
-      message: `Workspace "${res.datamate.name}" created. Open ${res.manage_url} to configure it.`,
-      duration: 10_000,
-    })
+    return false
   }
 }
 

--- a/packages/opencode/test/altimate/plugin/workspace.test.ts
+++ b/packages/opencode/test/altimate/plugin/workspace.test.ts
@@ -1,0 +1,231 @@
+// altimate_change - new file
+// Unit coverage for the pure-logic pieces of the workspace TuiPlugin
+// (packages/opencode/src/plugin/tui/altimate/workspace.tsx). The JSX
+// components and the AltimateApi credential fetch are not exercised here —
+// they need a running TUI harness and are covered by the manual smoke plan.
+// This file focuses on the deterministic layer: URL parsing, git detection,
+// state read/write + chmod, latch semantics, and error classification.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { existsSync, mkdirSync, rmSync, statSync } from "node:fs"
+import path from "node:path"
+import os from "node:os"
+
+// Redirect Global.Path.state BEFORE importing the module under test so its
+// module-level cachePath() resolves inside the sandbox.
+const SANDBOX = path.join(os.tmpdir(), `altimate-workspace-test-${process.pid}-${Date.now()}`)
+mkdirSync(path.join(SANDBOX, "state"), { recursive: true })
+process.env.XDG_STATE_HOME = path.join(SANDBOX, "state")
+
+const { isSkipActive, recordSkip } = await import(
+  "../../../src/plugin/tui/altimate/workspace"
+)
+const { projectNameFromRemote, detectProjectRemote } = await import(
+  "../../../src/altimate/workspace/detect"
+)
+const { cachePath, readLocalBinding, recordApprovedBinding } = await import(
+  "../../../src/altimate/workspace/state"
+)
+
+// Stub AltimateApi.getCredentials / isConfigured — used by readLocalBinding
+// and recordApprovedBinding for tenant/apiUrl scoping. Re-import allows
+// per-test override of the module state.
+import { AltimateApi } from "../../../src/altimate/api/client"
+const originalIsConfigured = AltimateApi.isConfigured
+const originalGetCreds = AltimateApi.getCredentials
+type Creds = Awaited<ReturnType<typeof AltimateApi.getCredentials>>
+function stubCreds(tenant: string, apiUrl: string) {
+  ;(AltimateApi as unknown as { isConfigured: () => Promise<boolean> }).isConfigured = async () => true
+  ;(AltimateApi as unknown as { getCredentials: () => Promise<Creds> }).getCredentials = async () =>
+    ({
+      altimateInstanceName: tenant,
+      altimateUrl: apiUrl,
+      altimateApiKey: "dummy",
+    }) as Creds
+}
+function unstubCreds() {
+  ;(AltimateApi as unknown as { isConfigured: typeof originalIsConfigured }).isConfigured = originalIsConfigured
+  ;(AltimateApi as unknown as { getCredentials: typeof originalGetCreds }).getCredentials = originalGetCreds
+}
+
+// Minimal TuiKV shim for latch tests. Reads/writes are process-local, matching
+// what the plugin uses via api.kv in production.
+function makeKv(): { get: <T = unknown>(k: string, fb?: T) => T; set: (k: string, v: unknown) => void } {
+  const store = new Map<string, unknown>()
+  return {
+    get: <T = unknown>(k: string, fb?: T): T => (store.has(k) ? (store.get(k) as T) : (fb as T)),
+    set: (k: string, v: unknown) => {
+      store.set(k, v)
+    },
+  }
+}
+
+afterEach(() => {
+  unstubCreds()
+  // Wipe the cache file between tests so scoping tests don't bleed state.
+  try {
+    rmSync(cachePath(), { force: true })
+  } catch {
+    /* not created by every test */
+  }
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// projectNameFromRemote
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("projectNameFromRemote", () => {
+  test("extracts repo name from HTTPS remote", () => {
+    expect(projectNameFromRemote("https://github.com/foo/bar.git")).toBe("bar")
+  })
+  test("extracts repo name from SSH-form remote", () => {
+    expect(projectNameFromRemote("git@github.com:foo/bar.git")).toBe("bar")
+  })
+  test("handles remote without .git suffix", () => {
+    expect(projectNameFromRemote("https://github.com/foo/bar")).toBe("bar")
+  })
+  test("handles trailing slash", () => {
+    expect(projectNameFromRemote("https://github.com/foo/bar/")).toBe("bar")
+  })
+  test("falls back for empty-ish inputs", () => {
+    expect(projectNameFromRemote("")).toBe("workspace")
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// detectProjectRemote — thin wrapper over git; only assert graceful failure
+// (the git-not-a-repo case) since happy paths would need a live repo fixture.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("detectProjectRemote", () => {
+  test("returns undefined when directory is not a git repo", () => {
+    // /tmp is never a git repo in a stock macOS install.
+    const result = detectProjectRemote(os.tmpdir())
+    expect(result).toBeUndefined()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Local state: cache + chmod + tenant scoping
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("workspace binding cache", () => {
+  beforeEach(() => {
+    stubCreds("acme", "https://api.acme.example.com")
+  })
+
+  test("records and reads back a binding for the same directory + tenant", async () => {
+    await recordApprovedBinding("/work/proj-a", {
+      datamateId: 42,
+      datamateName: "Marketing",
+      repoRemote: "git@github.com:acme/proj-a.git",
+      linkedAt: 1_700_000_000_000,
+    })
+
+    const read = await readLocalBinding("/work/proj-a")
+    expect(read).not.toBeNull()
+    expect(read!.datamateId).toBe(42)
+    expect(read!.datamateName).toBe("Marketing")
+  })
+
+  test("chmods the cache file to 0o600 after write", async () => {
+    await recordApprovedBinding("/work/proj-a", {
+      datamateId: 1,
+      datamateName: "X",
+      repoRemote: "git@github.com:acme/x.git",
+      linkedAt: 1,
+    })
+    expect(existsSync(cachePath())).toBe(true)
+    const mode = statSync(cachePath()).mode & 0o777
+    expect(mode).toBe(0o600)
+  })
+
+  test("returns null when the cached tenant differs from current credentials", async () => {
+    await recordApprovedBinding("/work/proj-a", {
+      datamateId: 42,
+      datamateName: "Marketing",
+      repoRemote: "git@github.com:acme/proj-a.git",
+      linkedAt: 1,
+    })
+
+    // Switch account → the cached binding must not be surfaced.
+    unstubCreds()
+    stubCreds("other-tenant", "https://api.acme.example.com")
+
+    const read = await readLocalBinding("/work/proj-a")
+    expect(read).toBeNull()
+  })
+
+  test("returns null when the cached apiUrl differs from current credentials", async () => {
+    await recordApprovedBinding("/work/proj-a", {
+      datamateId: 42,
+      datamateName: "Marketing",
+      repoRemote: "git@github.com:acme/proj-a.git",
+      linkedAt: 1,
+    })
+
+    unstubCreds()
+    stubCreds("acme", "https://different-host.example.com")
+
+    const read = await readLocalBinding("/work/proj-a")
+    expect(read).toBeNull()
+  })
+
+  test("returns null when directory has no cached binding", async () => {
+    await recordApprovedBinding("/work/proj-a", {
+      datamateId: 42,
+      datamateName: "Marketing",
+      repoRemote: "git@github.com:acme/proj-a.git",
+      linkedAt: 1,
+    })
+    const read = await readLocalBinding("/work/proj-b")
+    expect(read).toBeNull()
+  })
+
+  test("returns null when credentials are missing entirely", async () => {
+    unstubCreds()
+    ;(AltimateApi as unknown as { isConfigured: () => Promise<boolean> }).isConfigured = async () => false
+    const read = await readLocalBinding("/work/proj-a")
+    expect(read).toBeNull()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Skip latch (TuiKV shim)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Skip latch", () => {
+  const remote = "git@github.com:acme/proj-a.git"
+
+  test("no record → not active", () => {
+    const api = { kv: makeKv() } as any
+    expect(isSkipActive(api, remote, Date.now())).toBe(false)
+  })
+
+  test("recorded within 7 days → active", () => {
+    const api = { kv: makeKv() } as any
+    const now = 1_700_000_000_000
+    recordSkip(api, remote, now)
+    expect(isSkipActive(api, remote, now + 6 * 24 * 60 * 60 * 1000)).toBe(true)
+  })
+
+  test("recorded past 7 days → not active", () => {
+    const api = { kv: makeKv() } as any
+    const now = 1_700_000_000_000
+    recordSkip(api, remote, now)
+    expect(isSkipActive(api, remote, now + 8 * 24 * 60 * 60 * 1000)).toBe(false)
+  })
+
+  test("boundary at exactly 7 days → not active (>= rejects)", () => {
+    const api = { kv: makeKv() } as any
+    const now = 1_700_000_000_000
+    recordSkip(api, remote, now)
+    expect(isSkipActive(api, remote, now + 7 * 24 * 60 * 60 * 1000)).toBe(false)
+  })
+
+  test("different remotes have independent latches", () => {
+    const api = { kv: makeKv() } as any
+    const now = 1_700_000_000_000
+    recordSkip(api, "git@github.com:acme/one.git", now)
+    expect(isSkipActive(api, "git@github.com:acme/two.git", now)).toBe(false)
+  })
+})

--- a/packages/opencode/test/altimate/plugin/workspace.test.ts
+++ b/packages/opencode/test/altimate/plugin/workspace.test.ts
@@ -5,16 +5,28 @@
 // they need a running TUI harness and are covered by the manual smoke plan.
 // This file focuses on the deterministic layer: URL parsing, git detection,
 // state read/write + chmod, latch semantics, and error classification.
-import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { existsSync, mkdirSync, rmSync, statSync } from "node:fs"
 import path from "node:path"
 import os from "node:os"
 
 // Redirect Global.Path.state BEFORE importing the module under test so its
-// module-level cachePath() resolves inside the sandbox.
+// module-level cachePath() resolves inside the sandbox. Restore the original
+// XDG_STATE_HOME in afterAll so parallel test files aren't polluted by our
+// process-scoped tempdir. (CR round 2 — test isolation.)
+const ORIGINAL_XDG_STATE_HOME = process.env.XDG_STATE_HOME
 const SANDBOX = path.join(os.tmpdir(), `altimate-workspace-test-${process.pid}-${Date.now()}`)
 mkdirSync(path.join(SANDBOX, "state"), { recursive: true })
 process.env.XDG_STATE_HOME = path.join(SANDBOX, "state")
+afterAll(() => {
+  if (ORIGINAL_XDG_STATE_HOME === undefined) delete process.env.XDG_STATE_HOME
+  else process.env.XDG_STATE_HOME = ORIGINAL_XDG_STATE_HOME
+  try {
+    rmSync(SANDBOX, { recursive: true, force: true })
+  } catch {
+    /* best effort */
+  }
+})
 
 const { isSkipActive, recordSkip } = await import(
   "../../../src/plugin/tui/altimate/workspace"
@@ -98,8 +110,14 @@ describe("projectNameFromRemote", () => {
 
 describe("detectProjectRemote", () => {
   test("returns undefined when directory is not a git repo", () => {
-    // /tmp is never a git repo in a stock macOS install.
-    const result = detectProjectRemote(os.tmpdir())
+    // Use a FRESHLY-created empty directory inside SANDBOX rather than
+    // ``os.tmpdir()`` — an ancestor of the system tmpdir can be inside a
+    // git worktree (e.g. when the whole /tmp is on a repo-managed volume),
+    // and ``git remote get-url`` would then walk up and return the parent
+    // repo's remote. (CR round 2.)
+    const emptyDir = path.join(SANDBOX, `empty-${Date.now()}`)
+    mkdirSync(emptyDir, { recursive: true })
+    const result = detectProjectRemote(emptyDir)
     expect(result).toBeUndefined()
   })
 })

--- a/packages/opencode/test/altimate/plugin/workspace.test.ts
+++ b/packages/opencode/test/altimate/plugin/workspace.test.ts
@@ -110,15 +110,23 @@ describe("projectNameFromRemote", () => {
 
 describe("detectProjectRemote", () => {
   test("returns undefined when directory is not a git repo", () => {
-    // Use a FRESHLY-created empty directory inside SANDBOX rather than
-    // ``os.tmpdir()`` — an ancestor of the system tmpdir can be inside a
-    // git worktree (e.g. when the whole /tmp is on a repo-managed volume),
-    // and ``git remote get-url`` would then walk up and return the parent
-    // repo's remote. (CR round 2.)
+    // Cubic round 3 caught that "empty dir under SANDBOX" still shares
+    // ``os.tmpdir()``'s ancestor chain — if any ancestor is a git worktree,
+    // ``git remote get-url`` walks up and returns that repo's remote. Set
+    // ``GIT_CEILING_DIRECTORIES`` to stop the walk at SANDBOX so this test
+    // is deterministic regardless of where ``os.tmpdir()`` lives on the
+    // runner.
     const emptyDir = path.join(SANDBOX, `empty-${Date.now()}`)
     mkdirSync(emptyDir, { recursive: true })
-    const result = detectProjectRemote(emptyDir)
-    expect(result).toBeUndefined()
+    const prevCeiling = process.env.GIT_CEILING_DIRECTORIES
+    process.env.GIT_CEILING_DIRECTORIES = SANDBOX
+    try {
+      const result = detectProjectRemote(emptyDir)
+      expect(result).toBeUndefined()
+    } finally {
+      if (prevCeiling === undefined) delete process.env.GIT_CEILING_DIRECTORIES
+      else process.env.GIT_CEILING_DIRECTORIES = prevCeiling
+    }
   })
 })
 
@@ -218,39 +226,50 @@ describe("workspace binding cache", () => {
 
 describe("Skip latch", () => {
   const ident = { repoRemote: "git@github.com:acme/proj-a.git", projectPath: "/work/proj-a" }
+  const scope = { tenant: "acme", apiUrl: "https://api.acme.example.com" }
 
   test("no record → not active", () => {
     const api = { kv: makeKv() } as any
-    expect(isSkipActive(api, ident, Date.now())).toBe(false)
+    expect(isSkipActive(api, ident, scope, Date.now())).toBe(false)
   })
 
   test("recorded within 7 days → active", () => {
     const api = { kv: makeKv() } as any
     const now = 1_700_000_000_000
-    recordSkip(api, ident, now)
-    expect(isSkipActive(api, ident, now + 6 * 24 * 60 * 60 * 1000)).toBe(true)
+    recordSkip(api, ident, scope, now)
+    expect(isSkipActive(api, ident, scope, now + 6 * 24 * 60 * 60 * 1000)).toBe(true)
   })
 
   test("recorded past 7 days → not active", () => {
     const api = { kv: makeKv() } as any
     const now = 1_700_000_000_000
-    recordSkip(api, ident, now)
-    expect(isSkipActive(api, ident, now + 8 * 24 * 60 * 60 * 1000)).toBe(false)
+    recordSkip(api, ident, scope, now)
+    expect(isSkipActive(api, ident, scope, now + 8 * 24 * 60 * 60 * 1000)).toBe(false)
   })
 
   test("boundary at exactly 7 days → not active (>= rejects)", () => {
     const api = { kv: makeKv() } as any
     const now = 1_700_000_000_000
-    recordSkip(api, ident, now)
-    expect(isSkipActive(api, ident, now + 7 * 24 * 60 * 60 * 1000)).toBe(false)
+    recordSkip(api, ident, scope, now)
+    expect(isSkipActive(api, ident, scope, now + 7 * 24 * 60 * 60 * 1000)).toBe(false)
   })
 
   test("different remotes have independent latches", () => {
     const api = { kv: makeKv() } as any
     const now = 1_700_000_000_000
-    recordSkip(api, { repoRemote: "git@github.com:acme/one.git", projectPath: "/w/one" }, now)
+    recordSkip(
+      api,
+      { repoRemote: "git@github.com:acme/one.git", projectPath: "/w/one" },
+      scope,
+      now,
+    )
     expect(
-      isSkipActive(api, { repoRemote: "git@github.com:acme/two.git", projectPath: "/w/two" }, now),
+      isSkipActive(
+        api,
+        { repoRemote: "git@github.com:acme/two.git", projectPath: "/w/two" },
+        scope,
+        now,
+      ),
     ).toBe(false)
   })
 
@@ -258,9 +277,21 @@ describe("Skip latch", () => {
     const api = { kv: makeKv() } as any
     const now = 1_700_000_000_000
     const pathOnly = { projectPath: "/scratch/sample-dbt" }
-    recordSkip(api, pathOnly, now)
-    expect(isSkipActive(api, pathOnly, now + 3 * 24 * 60 * 60 * 1000)).toBe(true)
+    recordSkip(api, pathOnly, scope, now)
+    expect(isSkipActive(api, pathOnly, scope, now + 3 * 24 * 60 * 60 * 1000)).toBe(true)
     // A different path is not affected.
-    expect(isSkipActive(api, { projectPath: "/scratch/other" }, now)).toBe(false)
+    expect(isSkipActive(api, { projectPath: "/scratch/other" }, scope, now)).toBe(false)
+  })
+
+  test("different tenant scopes are independent latches (cubic round 3)", () => {
+    const api = { kv: makeKv() } as any
+    const now = 1_700_000_000_000
+    recordSkip(api, ident, { tenant: "acme", apiUrl: "https://api.acme.example.com" }, now)
+    expect(
+      isSkipActive(api, ident, { tenant: "other", apiUrl: "https://api.acme.example.com" }, now),
+    ).toBe(false)
+    expect(
+      isSkipActive(api, ident, { tenant: "acme", apiUrl: "https://api.other.example.com" }, now),
+    ).toBe(false)
   })
 })

--- a/packages/opencode/test/altimate/plugin/workspace.test.ts
+++ b/packages/opencode/test/altimate/plugin/workspace.test.ts
@@ -118,6 +118,7 @@ describe("workspace binding cache", () => {
       datamateId: 42,
       datamateName: "Marketing",
       repoRemote: "git@github.com:acme/proj-a.git",
+      projectPath: "/work/proj-a",
       linkedAt: 1_700_000_000_000,
     })
 
@@ -132,6 +133,7 @@ describe("workspace binding cache", () => {
       datamateId: 1,
       datamateName: "X",
       repoRemote: "git@github.com:acme/x.git",
+      projectPath: "/work/proj-a",
       linkedAt: 1,
     })
     expect(existsSync(cachePath())).toBe(true)
@@ -144,6 +146,7 @@ describe("workspace binding cache", () => {
       datamateId: 42,
       datamateName: "Marketing",
       repoRemote: "git@github.com:acme/proj-a.git",
+      projectPath: "/work/proj-a",
       linkedAt: 1,
     })
 
@@ -160,6 +163,7 @@ describe("workspace binding cache", () => {
       datamateId: 42,
       datamateName: "Marketing",
       repoRemote: "git@github.com:acme/proj-a.git",
+      projectPath: "/work/proj-a",
       linkedAt: 1,
     })
 
@@ -175,6 +179,7 @@ describe("workspace binding cache", () => {
       datamateId: 42,
       datamateName: "Marketing",
       repoRemote: "git@github.com:acme/proj-a.git",
+      projectPath: "/work/proj-a",
       linkedAt: 1,
     })
     const read = await readLocalBinding("/work/proj-b")
@@ -194,38 +199,50 @@ describe("workspace binding cache", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("Skip latch", () => {
-  const remote = "git@github.com:acme/proj-a.git"
+  const ident = { repoRemote: "git@github.com:acme/proj-a.git", projectPath: "/work/proj-a" }
 
   test("no record → not active", () => {
     const api = { kv: makeKv() } as any
-    expect(isSkipActive(api, remote, Date.now())).toBe(false)
+    expect(isSkipActive(api, ident, Date.now())).toBe(false)
   })
 
   test("recorded within 7 days → active", () => {
     const api = { kv: makeKv() } as any
     const now = 1_700_000_000_000
-    recordSkip(api, remote, now)
-    expect(isSkipActive(api, remote, now + 6 * 24 * 60 * 60 * 1000)).toBe(true)
+    recordSkip(api, ident, now)
+    expect(isSkipActive(api, ident, now + 6 * 24 * 60 * 60 * 1000)).toBe(true)
   })
 
   test("recorded past 7 days → not active", () => {
     const api = { kv: makeKv() } as any
     const now = 1_700_000_000_000
-    recordSkip(api, remote, now)
-    expect(isSkipActive(api, remote, now + 8 * 24 * 60 * 60 * 1000)).toBe(false)
+    recordSkip(api, ident, now)
+    expect(isSkipActive(api, ident, now + 8 * 24 * 60 * 60 * 1000)).toBe(false)
   })
 
   test("boundary at exactly 7 days → not active (>= rejects)", () => {
     const api = { kv: makeKv() } as any
     const now = 1_700_000_000_000
-    recordSkip(api, remote, now)
-    expect(isSkipActive(api, remote, now + 7 * 24 * 60 * 60 * 1000)).toBe(false)
+    recordSkip(api, ident, now)
+    expect(isSkipActive(api, ident, now + 7 * 24 * 60 * 60 * 1000)).toBe(false)
   })
 
   test("different remotes have independent latches", () => {
     const api = { kv: makeKv() } as any
     const now = 1_700_000_000_000
-    recordSkip(api, "git@github.com:acme/one.git", now)
-    expect(isSkipActive(api, "git@github.com:acme/two.git", now)).toBe(false)
+    recordSkip(api, { repoRemote: "git@github.com:acme/one.git", projectPath: "/w/one" }, now)
+    expect(
+      isSkipActive(api, { repoRemote: "git@github.com:acme/two.git", projectPath: "/w/two" }, now),
+    ).toBe(false)
+  })
+
+  test("path-only projects (no remote) also get a latch — key derives from path", () => {
+    const api = { kv: makeKv() } as any
+    const now = 1_700_000_000_000
+    const pathOnly = { projectPath: "/scratch/sample-dbt" }
+    recordSkip(api, pathOnly, now)
+    expect(isSkipActive(api, pathOnly, now + 3 * 24 * 60 * 60 * 1000)).toBe(true)
+    // A different path is not affected.
+    expect(isSkipActive(api, { projectPath: "/scratch/other" }, now)).toBe(false)
   })
 })

--- a/packages/opencode/test/altimate/workspace/launch-resolve.test.ts
+++ b/packages/opencode/test/altimate/workspace/launch-resolve.test.ts
@@ -1,0 +1,177 @@
+// altimate_change - new file
+//
+// Unit coverage for the --workspace launch resolver. Exercises the pure
+// name-match helper directly, and the wired-up resolveWorkspaceForLaunch
+// with the local binding cache + ALTIMATE_WORKSPACE flag stubbed. Does
+// NOT exercise the tui.ts wiring or the worker subprocess env-var pickup
+// — those are integration territory.
+import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdirSync, rmSync } from "node:fs"
+import path from "node:path"
+import os from "node:os"
+
+// Redirect Global.Path.state BEFORE importing state.ts so cachePath()
+// resolves inside the sandbox. Same isolation pattern as workspace.test.ts.
+const ORIGINAL_XDG_STATE_HOME = process.env.XDG_STATE_HOME
+const SANDBOX = path.join(
+  os.tmpdir(),
+  `altimate-launch-resolve-test-${process.pid}-${Date.now()}`,
+)
+mkdirSync(path.join(SANDBOX, "state"), { recursive: true })
+process.env.XDG_STATE_HOME = path.join(SANDBOX, "state")
+afterAll(() => {
+  if (ORIGINAL_XDG_STATE_HOME === undefined) delete process.env.XDG_STATE_HOME
+  else process.env.XDG_STATE_HOME = ORIGINAL_XDG_STATE_HOME
+  try {
+    rmSync(SANDBOX, { recursive: true, force: true })
+  } catch {
+    /* best effort */
+  }
+})
+
+const { nameMatches, resolveWorkspaceForLaunch } = await import(
+  "../../../src/altimate/workspace/launch-resolve"
+)
+const { getResolvedWorkspaceId, setResolvedWorkspaceId } = await import(
+  "../../../src/altimate/workspace/session-context"
+)
+const { recordApprovedBinding, cachePath } = await import(
+  "../../../src/altimate/workspace/state"
+)
+
+// Stub credentials so state.ts's tenant/apiUrl scoping is deterministic.
+import { AltimateApi } from "../../../src/altimate/api/client"
+type Creds = Awaited<ReturnType<typeof AltimateApi.getCredentials>>
+const originalIsConfigured = AltimateApi.isConfigured
+const originalGetCreds = AltimateApi.getCredentials
+function stubCreds() {
+  ;(AltimateApi as unknown as { isConfigured: () => Promise<boolean> }).isConfigured = async () =>
+    true
+  ;(AltimateApi as unknown as { getCredentials: () => Promise<Creds> }).getCredentials =
+    async () =>
+      ({
+        altimateInstanceName: "altimate2",
+        altimateUrl: "http://localhost:5001",
+        altimateApiKey: "dummy",
+      }) as Creds
+}
+function unstubCreds() {
+  ;(AltimateApi as unknown as { isConfigured: typeof originalIsConfigured }).isConfigured =
+    originalIsConfigured
+  ;(AltimateApi as unknown as { getCredentials: typeof originalGetCreds }).getCredentials =
+    originalGetCreds
+}
+
+beforeEach(() => {
+  stubCreds()
+  setResolvedWorkspaceId(null)
+  // Clean cache file between tests so state doesn't leak across cases.
+  try {
+    rmSync(cachePath(), { force: true })
+  } catch {
+    /* best effort */
+  }
+  // Explicitly enable the pilot flag for every test. Restored per-test in
+  // afterEach so the "flag off" test can override.
+  process.env.ALTIMATE_WORKSPACE = "1"
+})
+afterEach(() => {
+  unstubCreds()
+  setResolvedWorkspaceId(null)
+  delete process.env.ALTIMATE_WORKSPACE
+})
+
+describe("nameMatches", () => {
+  const binding = {
+    datamateId: 42,
+    datamateName: "Growth",
+    repoRemote: "ssh://git@github.com/foo/bar",
+    projectPath: "/tmp/foo",
+    linkedAt: 0,
+  }
+
+  test("exact match", () => {
+    expect(nameMatches("Growth", binding)).toBe(true)
+  })
+  test("case-insensitive match", () => {
+    expect(nameMatches("GROWTH", binding)).toBe(true)
+    expect(nameMatches("growth", binding)).toBe(true)
+  })
+  test("whitespace-trimmed match", () => {
+    expect(nameMatches("  Growth  ", binding)).toBe(true)
+  })
+  test("mismatch", () => {
+    expect(nameMatches("Other", binding)).toBe(false)
+  })
+  test("substring is not a hit (no fuzzy match)", () => {
+    expect(nameMatches("Grow", binding)).toBe(false)
+    expect(nameMatches("Growthy", binding)).toBe(false)
+  })
+})
+
+describe("resolveWorkspaceForLaunch", () => {
+  const DIRECTORY = path.join(SANDBOX, "project")
+
+  beforeEach(async () => {
+    mkdirSync(DIRECTORY, { recursive: true })
+    await recordApprovedBinding(DIRECTORY, {
+      datamateId: 42,
+      datamateName: "Growth",
+      repoRemote: null,
+      projectPath: DIRECTORY,
+      linkedAt: 0,
+    })
+  })
+
+  test("no --workspace arg → no env var set, no-op", async () => {
+    await resolveWorkspaceForLaunch(DIRECTORY, undefined)
+    expect(getResolvedWorkspaceId()).toBeNull()
+  })
+
+  test("ALTIMATE_WORKSPACE flag off → no env var set even when --workspace given", async () => {
+    delete process.env.ALTIMATE_WORKSPACE
+    await resolveWorkspaceForLaunch(DIRECTORY, "Growth")
+    expect(getResolvedWorkspaceId()).toBeNull()
+  })
+
+  test("matching name → env var set to the binding's datamateId", async () => {
+    await resolveWorkspaceForLaunch(DIRECTORY, "Growth")
+    expect(getResolvedWorkspaceId()).toBe(42)
+  })
+
+  test("case-insensitive matching name → env var set", async () => {
+    await resolveWorkspaceForLaunch(DIRECTORY, "growth")
+    expect(getResolvedWorkspaceId()).toBe(42)
+  })
+
+  test("mismatched name → env var STILL set (attaches to linked workspace with a note per AI-8504 spec)", async () => {
+    await resolveWorkspaceForLaunch(DIRECTORY, "Other")
+    expect(getResolvedWorkspaceId()).toBe(42)
+  })
+
+  test("no binding for this directory → env var NOT set (fail-fast)", async () => {
+    const unlinkedDir = path.join(SANDBOX, "unlinked")
+    mkdirSync(unlinkedDir, { recursive: true })
+    await resolveWorkspaceForLaunch(unlinkedDir, "Growth")
+    expect(getResolvedWorkspaceId()).toBeNull()
+  })
+})
+
+describe("session-context env-var round trip", () => {
+  test("set/get/clear cycle", () => {
+    setResolvedWorkspaceId(123)
+    expect(getResolvedWorkspaceId()).toBe(123)
+    setResolvedWorkspaceId(null)
+    expect(getResolvedWorkspaceId()).toBeNull()
+  })
+
+  test("malformed env value returns null (defense against poisoned env)", () => {
+    process.env.ALTIMATE_RESOLVED_WORKSPACE_ID = "not-a-number"
+    expect(getResolvedWorkspaceId()).toBeNull()
+    process.env.ALTIMATE_RESOLVED_WORKSPACE_ID = "0"
+    expect(getResolvedWorkspaceId()).toBeNull()
+    process.env.ALTIMATE_RESOLVED_WORKSPACE_ID = "-5"
+    expect(getResolvedWorkspaceId()).toBeNull()
+    delete process.env.ALTIMATE_RESOLVED_WORKSPACE_ID
+  })
+})


### PR DESCRIPTION
## Summary

Adds the CLI half of Workspaces (server-side epic AI-8390): after a project scan completes, the TUI offers to create or link an Altimate workspace. Also adds an on-demand `altimate-code link` subcommand for the same flow at any time.

- **TUI plugin** (`packages/opencode/src/plugin/tui/altimate/workspace.tsx`) — fork-owned single file, wired through the existing `altimateTuiPlugins()` aggregator. Renders three dialogs: Create-or-Link-or-Skip, Already-linked (with drift + unverified-cache flags), and a picker over the user's workspaces. Post-scan trigger uses a one-shot `session.idle` listener so the dialog opens after the LLM's onboarding menu finishes streaming (not while it's still generating).
- **`altimate-code link` subcommand** — picker-first UX (currently-linked row marked, "＋ Create new" as the first row, auto-named from the git repo or directory basename). Shares the `WorkspaceApi` client + state cache + project-identifier detection with the plugin so the two entry points can't drift.
- **Project identity** is `repo_remote` when a git remote is present (stronger — survives directory moves), else the absolute symlink-resolved `project_path`. Neither is required to be non-null in isolation, but at least one must be present.
- **Local binding cache** at `~/.local/share/altimate-code/altimate-workspace-bindings.json`, `chmod 0o600`, scoped to `(tenant, apiUrl)` so an account switch invalidates the file. Server is always authoritative; the cache is offline fallback with a mandatory "unverified" render flag.
- **Skip latch** persists across sessions via `TuiPluginApi.kv` — 7-day rolling suppression keyed on `sha1(repoRemote ?? projectPath)`. The subcommand deliberately bypasses it (user-initiated).
- **Feature flag** `Flag.ALTIMATE_WORKSPACE` — off by default; existing onboarding behavior is unchanged when unset.

Talks to `datamate-project-bindings/*` endpoints on altimate-backend (see the paired backend PR).

## Test plan

- [x] `bun turbo typecheck` — clean
- [x] `bun test test/altimate/plugin/workspace.test.ts` — 18/18 (including the new path-only latch case)
- [x] `bun test test/altimate` — 4047 pass, 10 pre-existing `sample_setup` timeout failures unrelated to this change
- [ ] Manual smoke against a real backend for both the post-scan and on-demand paths
- [ ] Manual smoke against a project with no git remote (the reason for the path-based fallback identifier)

## Fork markers

All fork-only code is wrapped in `altimate_change start` / `altimate_change end` markers or `altimate_change - new file`, per the ADR at `docs/internal/2026-06-23-tui-fork-features-as-plugins-adr.md`. Zero edits to `packages/tui/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016H42Vt4pt5dcD7opRqckeM

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a post-scan Workspaces prompt, a `altimate-code link` subcommand, and a `--workspace <name>` launch flag behind `Flag.ALTIMATE_WORKSPACE`. Previously sessions couldn’t attach to a workspace at launch and projects couldn’t link; now the TUI offers create/link after the scan goes idle, users can link on demand, and launch can pin the session to the workspace linked in this directory without blocking startup.

- Registers the TUI plugin and `link` command only when `ALTIMATE_WORKSPACE` is set (does not inherit `OPENCODE_EXPERIMENTAL`).
- Post-scan trigger: listens for session idle via the non-deprecated EventV2 Status stream; installs one serialized listener and tears it down; on install failure clears pending sessions; 7‑day skip latch keyed by remote or path and scoped to tenant+apiUrl; rejects future timestamps.
- Project identity and re-linking: uses `{repoRemote?, projectPath}` (symlink‑resolved); pre-check tries remote then path and returns which matched; re-link uses the matched identifier; surfaces drift; supports path‑only projects.
- API client and cache: 15s timeout across fetch and body reads; distinguishes timeout vs network errors; parses FastAPI `detail`; rejects empty or `null` 2xx bodies; accepts `/datamates` envelopes `{datamates: [...]}`, `[...]`, or `{data: [...]}` with guards for non-arrays and null rows; validates `manage_url` is http(s); local binding cache scoped to tenant+apiUrl with canonicalized directory keys, runtime shape validation, and best‑effort writes (`chmod 0600` post‑write).
- Picker and conflicts: marks the linked workspace and offers “＋ Create new”; creating while linked rebinds to the new workspace; submit guard prevents duplicate binds; subcommand fails fast when stdin isn’t a TTY; on pre‑check failure a 409 bind retries as a re‑link using the server’s conflict detail to choose the endpoint; mismatch copy points to `altimate-code link`.
- Launch flag (AI‑8504 item 1): `altimate-code tui --workspace <name>` resolves by exact (case‑insensitive, trimmed) name against this directory’s local binding only; on mismatch it prints a note and attaches to the currently linked workspace; never blocks launch; hands off the resolved id via `altimate/workspace/session-context`. Builder registers `--workspace` before `--agent`.

- Rollout: opt‑in by setting `ALTIMATE_WORKSPACE`; requires backend `/datamate-project-bindings/*` and `/datamates/`. No migrations; users must be signed in to Altimate or the prompt is skipped.

<sup>Written for commit 12e47f53d2a3d7f1e28f23c1cc2f5f8f872cd634. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/1099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added workspace linking through the `altimate-code link` command.
  - Added TUI workspace setup, selection, re-linking, and management actions.
  - Added project-to-workspace binding with secure, account-aware local persistence.
  - Added optional post-scan workspace telemetry.
  - Added seven-day skip preferences for workspace prompts.
  - Workspace features are available only when enabled.

- **Bug Fixes**
  - Improved handling of workspace conflicts, access errors, network failures, invalid local state, and credential-protected project remotes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->