### PR TITLE
fix: redact non-SQL content echoed in safety threat messages (main sanity failure)

### DIFF
--- a/packages/opencode/src/altimate/native/altimate-core.ts
+++ b/packages/opencode/src/altimate/native/altimate-core.ts
@@ -42,20 +42,6 @@ function fail(error: unknown): AltimateCoreResult {
   return { success: false, data: {}, error: String(error) }
 }
 
-/** Redact raw-input echoes from a scan result's threats (see EngineCoerce.redactThreatText). */
-function redactScan(scan: Record<string, unknown>): Record<string, unknown> {
-  const threats = (scan.threats as any[] | undefined)?.map((t: any) => ({
-    ...t,
-    message: typeof t.message === "string" ? EngineCoerce.redactThreatText(t.message) : t.message,
-    detail: typeof t.detail === "string" ? EngineCoerce.redactThreatText(t.detail) : t.detail,
-    // For multi_statement the matched pattern IS the raw input line — an
-    // arbitrary-file content echo. Injection rules keep their SQL-shaped
-    // patterns (useful, and inherently query-derived).
-    matched_pattern: t.rule === "multi_statement" ? "<redacted>" : t.matched_pattern,
-  }))
-  return threats ? { ...scan, threats } : scan
-}
-
 // ---------------------------------------------------------------------------
 // IFF / QUALIFY transpile transforms (ported from Python guard.py)
 // ---------------------------------------------------------------------------
@@ -128,7 +114,7 @@ export function registerAll(): void {
   register("altimate_core.safety", async (params) => {
     try {
       const raw = core.scanSql(params.sql)
-      const data = redactScan(toData(raw))
+      const data = EngineCoerce.redactScan(toData(raw))
       return ok(true, data)
     } catch (e) {
       return fail(e)
@@ -246,7 +232,7 @@ export function registerAll(): void {
       // Redact AFTER diff-scoping: subtraction must compare raw engine
       // matched_patterns on both sides (redacting first would rewrite head
       // multi_statement keys to "<redacted>" and never match the base).
-      safety = redactScan(safety)
+      safety = EngineCoerce.redactScan(safety)
       // PII exposure for the composite check — the tool has always rendered a
       // PII section; previously nothing populated it. Additive: a PII failure
       // must not fail the whole composite.
@@ -488,7 +474,13 @@ export function registerAll(): void {
     try {
       const schema = schemaOrEmpty(params.schema_path, params.schema_context)
       const raw = await core.evaluate(params.sql, schema)
-      return ok(true, toData(raw))
+      const data = toData(raw)
+      // EvalResult embeds a full safety scan — redact its threat echoes too
+      // (the CLI grade check renders nested threat messages).
+      if (data.safety && typeof data.safety === "object") {
+        data.safety = EngineCoerce.redactScan(data.safety as Record<string, unknown>)
+      }
+      return ok(true, data)
     } catch (e) {
       return fail(e)
     }

--- a/packages/opencode/src/altimate/native/altimate-core.ts
+++ b/packages/opencode/src/altimate/native/altimate-core.ts
@@ -207,7 +207,7 @@ export function registerAll(): void {
       // occurrence, so a PR that ADDS a second identical injection still
       // reports it. Recompute safe/risk_score from the surviving threats so a
       // fully pre-existing threat set doesn't leave a stale unsafe verdict.
-      let safety: Record<string, unknown> = redactScan(toData(core.scanSql(params.sql)))
+      let safety: Record<string, unknown> = toData(core.scanSql(params.sql))
       if (params.base_sql) {
         try {
           const baseCounts = new Map<string, number>()
@@ -243,6 +243,10 @@ export function registerAll(): void {
           // Unscannable base — keep the full head scan (fail open to MORE findings).
         }
       }
+      // Redact AFTER diff-scoping: subtraction must compare raw engine
+      // matched_patterns on both sides (redacting first would rewrite head
+      // multi_statement keys to "<redacted>" and never match the base).
+      safety = redactScan(safety)
       // PII exposure for the composite check — the tool has always rendered a
       // PII section; previously nothing populated it. Additive: a PII failure
       // must not fail the whole composite.

--- a/packages/opencode/src/altimate/native/altimate-core.ts
+++ b/packages/opencode/src/altimate/native/altimate-core.ts
@@ -42,6 +42,20 @@ function fail(error: unknown): AltimateCoreResult {
   return { success: false, data: {}, error: String(error) }
 }
 
+/** Redact raw-input echoes from a scan result's threats (see EngineCoerce.redactThreatText). */
+function redactScan(scan: Record<string, unknown>): Record<string, unknown> {
+  const threats = (scan.threats as any[] | undefined)?.map((t: any) => ({
+    ...t,
+    message: typeof t.message === "string" ? EngineCoerce.redactThreatText(t.message) : t.message,
+    detail: typeof t.detail === "string" ? EngineCoerce.redactThreatText(t.detail) : t.detail,
+    // For multi_statement the matched pattern IS the raw input line — an
+    // arbitrary-file content echo. Injection rules keep their SQL-shaped
+    // patterns (useful, and inherently query-derived).
+    matched_pattern: t.rule === "multi_statement" ? "<redacted>" : t.matched_pattern,
+  }))
+  return threats ? { ...scan, threats } : scan
+}
+
 // ---------------------------------------------------------------------------
 // IFF / QUALIFY transpile transforms (ported from Python guard.py)
 // ---------------------------------------------------------------------------
@@ -114,7 +128,7 @@ export function registerAll(): void {
   register("altimate_core.safety", async (params) => {
     try {
       const raw = core.scanSql(params.sql)
-      const data = toData(raw)
+      const data = redactScan(toData(raw))
       return ok(true, data)
     } catch (e) {
       return fail(e)
@@ -193,7 +207,7 @@ export function registerAll(): void {
       // occurrence, so a PR that ADDS a second identical injection still
       // reports it. Recompute safe/risk_score from the surviving threats so a
       // fully pre-existing threat set doesn't leave a stale unsafe verdict.
-      let safety: Record<string, unknown> = toData(core.scanSql(params.sql))
+      let safety: Record<string, unknown> = redactScan(toData(core.scanSql(params.sql)))
       if (params.base_sql) {
         try {
           const baseCounts = new Map<string, number>()

--- a/packages/opencode/src/altimate/native/engine-coerce.ts
+++ b/packages/opencode/src/altimate/native/engine-coerce.ts
@@ -64,18 +64,55 @@ export function piiColumnsFromReport(piiData: unknown): Array<Record<string, any
  *
  * The engine's `multi_statement` rule quotes the offending "statement type"
  * verbatim — for non-SQL input (e.g. `altimate check /etc/passwd`) that
- * reflects arbitrary file content back into CLI/tool output. Keep the token
- * only when it looks like a SQL keyword phrase; otherwise redact.
+ * reflects arbitrary file content back into CLI/tool output. A token is kept
+ * only when it BOTH looks like a short keyword phrase AND starts with a known
+ * SQL statement keyword — shape alone would pass content like
+ * "TOP SECRET PASSWORD" or "AKIAIOSFODNN7EXAMPLE".
  */
-const SQL_KEYWORD_LIKE = /^[A-Za-z_][A-Za-z0-9_$ ]{0,31}$/
+const REDACTED = "<non-SQL content redacted>"
+const SQL_TOKEN_SHAPE = /^[A-Za-z_][A-Za-z0-9_$ ]{0,31}$/
+const SQL_STATEMENT_KEYWORDS = new Set([
+  "SELECT", "INSERT", "UPDATE", "DELETE", "DROP", "CREATE", "ALTER", "TRUNCATE",
+  "GRANT", "REVOKE", "MERGE", "WITH", "BEGIN", "COMMIT", "ROLLBACK", "SET",
+  "USE", "CALL", "EXPLAIN", "ANALYZE", "VACUUM", "COPY", "SHOW", "DESCRIBE",
+  "DESC", "EXECUTE", "EXEC", "REPLACE", "VALUES", "LOCK", "UNLOCK", "COMMENT",
+  "RENAME", "START", "SAVEPOINT", "RELEASE", "PREPARE", "DEALLOCATE",
+])
+function isSqlStatementType(token: string): boolean {
+  const t = token.trim()
+  if (!SQL_TOKEN_SHAPE.test(t)) return false
+  return SQL_STATEMENT_KEYWORDS.has(t.split(/\s+/)[0].toUpperCase())
+}
 export function redactThreatText(text: string): string {
-  return text
-    .replace(/(Disallowed statement type: )(.+)$/i, (_m, prefix: string, tok: string) =>
-      SQL_KEYWORD_LIKE.test(tok.trim()) ? `${prefix}${tok}` : `${prefix}<non-SQL content redacted>`,
-    )
-    .replace(/(Statement type ')([^']*)(')/i, (_m, a: string, tok: string, c: string) =>
-      SQL_KEYWORD_LIKE.test(tok) ? `${a}${tok}${c}` : `${a}<non-SQL content redacted>${c}`,
-    )
+  return (
+    text
+      .replace(/(Disallowed statement type: )(.+)$/i, (_m, prefix: string, tok: string) =>
+        isSqlStatementType(tok) ? `${prefix}${tok}` : `${prefix}${REDACTED}`,
+      )
+      // GREEDY quoted match — an attacker apostrophe inside the token would
+      // otherwise close the match early and leak the remainder
+      // (e.g. "Statement type 'DROP'ROOT:X:0' is not…"). Greedy capture spans
+      // to the LAST quote; embedded quotes fail the shape check and redact.
+      .replace(/(Statement type ')(.*)(')/i, (_m, a: string, tok: string, c: string) =>
+        isSqlStatementType(tok) ? `${a}${tok}${c}` : `${a}${REDACTED}${c}`,
+      )
+  )
+}
+
+/**
+ * Redact raw-input echoes from a scan result's threats. For `multi_statement`
+ * the matched pattern IS the raw input line, so it is always redacted;
+ * injection rules keep their SQL-shaped patterns. Pure record manipulation —
+ * safe to use from any consumer without loading the NAPI binding.
+ */
+export function redactScan(scan: Record<string, unknown>): Record<string, unknown> {
+  const threats = (scan.threats as any[] | undefined)?.map((t: any) => ({
+    ...t,
+    message: typeof t.message === "string" ? redactThreatText(t.message) : t.message,
+    detail: typeof t.detail === "string" ? redactThreatText(t.detail) : t.detail,
+    matched_pattern: t.rule === "multi_statement" ? "<redacted>" : t.matched_pattern,
+  }))
+  return threats ? { ...scan, threats } : scan
 }
 
 export * as EngineCoerce from "./engine-coerce"

--- a/packages/opencode/src/altimate/native/engine-coerce.ts
+++ b/packages/opencode/src/altimate/native/engine-coerce.ts
@@ -78,10 +78,22 @@ const SQL_STATEMENT_KEYWORDS = new Set([
   "DESC", "EXECUTE", "EXEC", "REPLACE", "VALUES", "LOCK", "UNLOCK", "COMMENT",
   "RENAME", "START", "SAVEPOINT", "RELEASE", "PREPARE", "DEALLOCATE",
 ])
+// Auxiliary words allowed AFTER a statement keyword ("ALTER TABLE",
+// "DROP INDEX IF EXISTS"). Every word of a preserved phrase must come from
+// the keyword vocabulary — checking only the first word would preserve
+// attacker tails like "SET SECRET PASSWORD" verbatim.
+const SQL_AUX_KEYWORDS = new Set([
+  "TABLE", "INDEX", "VIEW", "DATABASE", "SCHEMA", "COLUMN", "TRIGGER",
+  "FUNCTION", "PROCEDURE", "SEQUENCE", "MATERIALIZED", "TEMPORARY", "TEMP",
+  "IF", "NOT", "EXISTS", "OR", "INTO", "TRANSACTION", "WORK", "CASCADE",
+  "UNIQUE", "ROLE", "USER", "EXTENSION", "TYPE",
+])
 function isSqlStatementType(token: string): boolean {
   const t = token.trim()
   if (!SQL_TOKEN_SHAPE.test(t)) return false
-  return SQL_STATEMENT_KEYWORDS.has(t.split(/\s+/)[0].toUpperCase())
+  const words = t.split(/\s+/).map((w) => w.toUpperCase())
+  if (!SQL_STATEMENT_KEYWORDS.has(words[0])) return false
+  return words.slice(1).every((w) => SQL_STATEMENT_KEYWORDS.has(w) || SQL_AUX_KEYWORDS.has(w))
 }
 export function redactThreatText(text: string): string {
   return (

--- a/packages/opencode/src/altimate/native/engine-coerce.ts
+++ b/packages/opencode/src/altimate/native/engine-coerce.ts
@@ -59,4 +59,23 @@ export function piiColumnsFromReport(piiData: unknown): Array<Record<string, any
   return columns.filter((c) => c && c.classification !== "None")
 }
 
+/**
+ * Redact raw input echoed inside engine threat messages.
+ *
+ * The engine's `multi_statement` rule quotes the offending "statement type"
+ * verbatim — for non-SQL input (e.g. `altimate check /etc/passwd`) that
+ * reflects arbitrary file content back into CLI/tool output. Keep the token
+ * only when it looks like a SQL keyword phrase; otherwise redact.
+ */
+const SQL_KEYWORD_LIKE = /^[A-Za-z_][A-Za-z0-9_$ ]{0,31}$/
+export function redactThreatText(text: string): string {
+  return text
+    .replace(/(Disallowed statement type: )(.+)$/i, (_m, prefix: string, tok: string) =>
+      SQL_KEYWORD_LIKE.test(tok.trim()) ? `${prefix}${tok}` : `${prefix}<non-SQL content redacted>`,
+    )
+    .replace(/(Statement type ')([^']*)(')/i, (_m, a: string, tok: string, c: string) =>
+      SQL_KEYWORD_LIKE.test(tok) ? `${a}${tok}${c}` : `${a}<non-SQL content redacted>${c}`,
+    )
+}
+
 export * as EngineCoerce from "./engine-coerce"

--- a/packages/opencode/src/altimate/native/engine-coerce.ts
+++ b/packages/opencode/src/altimate/native/engine-coerce.ts
@@ -78,22 +78,17 @@ const SQL_STATEMENT_KEYWORDS = new Set([
   "DESC", "EXECUTE", "EXEC", "REPLACE", "VALUES", "LOCK", "UNLOCK", "COMMENT",
   "RENAME", "START", "SAVEPOINT", "RELEASE", "PREPARE", "DEALLOCATE",
 ])
-// Auxiliary words allowed AFTER a statement keyword ("ALTER TABLE",
-// "DROP INDEX IF EXISTS"). Every word of a preserved phrase must come from
-// the keyword vocabulary — checking only the first word would preserve
-// attacker tails like "SET SECRET PASSWORD" verbatim.
-const SQL_AUX_KEYWORDS = new Set([
-  "TABLE", "INDEX", "VIEW", "DATABASE", "SCHEMA", "COLUMN", "TRIGGER",
-  "FUNCTION", "PROCEDURE", "SEQUENCE", "MATERIALIZED", "TEMPORARY", "TEMP",
-  "IF", "NOT", "EXISTS", "OR", "INTO", "TRANSACTION", "WORK", "CASCADE",
-  "UNIQUE", "ROLE", "USER", "EXTENSION", "TYPE",
-])
+// The engine emits SINGLE-WORD statement types only — probed against the
+// live 0.7.0 binary across DDL/DML/DCL/TCL second statements, the full
+// observed set is {ALTER, BEGIN, CALL, CREATE, DELETE, DROP, EXPLAIN, GRANT,
+// INSERT, SET, TRUNCATE, UPDATE}. Exact single-keyword matching is therefore
+// both engine-faithful and the strictest rule: multi-word input can only be
+// non-engine content (kills keyword-permutation leaks like
+// "SELECT DELETE UPDATE" without redacting anything the engine produces).
 function isSqlStatementType(token: string): boolean {
   const t = token.trim()
   if (!SQL_TOKEN_SHAPE.test(t)) return false
-  const words = t.split(/\s+/).map((w) => w.toUpperCase())
-  if (!SQL_STATEMENT_KEYWORDS.has(words[0])) return false
-  return words.slice(1).every((w) => SQL_STATEMENT_KEYWORDS.has(w) || SQL_AUX_KEYWORDS.has(w))
+  return SQL_STATEMENT_KEYWORDS.has(t.toUpperCase())
 }
 export function redactThreatText(text: string): string {
   return (

--- a/packages/opencode/src/altimate/native/sql/register.ts
+++ b/packages/opencode/src/altimate/native/sql/register.ts
@@ -38,7 +38,8 @@ export function registerAllSql(): void {
 
       const lint = JSON.parse(JSON.stringify(lintRaw))
       const semantics = JSON.parse(JSON.stringify(semanticsRaw))
-      const safety = JSON.parse(JSON.stringify(safetyRaw))
+      // Redact raw-input echoes (multi_statement quotes the input verbatim).
+      const safety = EngineCoerce.redactScan(JSON.parse(JSON.stringify(safetyRaw))) as any
 
       const issues: SqlAnalyzeIssue[] = []
 

--- a/packages/opencode/test/altimate/threat-redaction.test.ts
+++ b/packages/opencode/test/altimate/threat-redaction.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, beforeAll } from "bun:test"
+import { describe, expect, test, beforeAll, afterAll } from "bun:test"
 import { EngineCoerce } from "../../src/altimate/native/engine-coerce"
 
 let coreAvailable = false
@@ -9,7 +9,7 @@ try {
 const describeIf = coreAvailable ? describe : describe.skip
 
 describe("redactThreatText", () => {
-  test("keeps SQL-keyword-like statement types", () => {
+  test("keeps SQL-statement-keyword types", () => {
     expect(EngineCoerce.redactThreatText("Disallowed statement type: DROP")).toBe("Disallowed statement type: DROP")
     expect(EngineCoerce.redactThreatText("Statement type 'ALTER TABLE' is not in the allowed list")).toBe(
       "Statement type 'ALTER TABLE' is not in the allowed list",
@@ -24,6 +24,28 @@ describe("redactThreatText", () => {
     expect(EngineCoerce.redactThreatText(detail)).not.toContain("ROOT:X:0")
   })
 
+  test("redacts keyword-shaped but non-SQL content (allowlist, not shape)", () => {
+    // Shape alone would pass these — the first word must be a SQL statement keyword.
+    expect(EngineCoerce.redactThreatText("Disallowed statement type: TOP SECRET PASSWORD")).toBe(
+      "Disallowed statement type: <non-SQL content redacted>",
+    )
+    expect(EngineCoerce.redactThreatText("Disallowed statement type: AKIAIOSFODNN7EXAMPLE")).toBe(
+      "Disallowed statement type: <non-SQL content redacted>",
+    )
+    expect(EngineCoerce.redactThreatText("Statement type 'PRIVATE NOTE' is not in the allowed list")).toBe(
+      "Statement type '<non-SQL content redacted>' is not in the allowed list",
+    )
+  })
+
+  test("embedded apostrophes cannot close the quoted match early", () => {
+    // Greedy capture spans to the LAST quote; the embedded quote fails the
+    // shape check and everything inside is redacted.
+    const attack = "Statement type 'DROP'ROOT:X:0:0' is not in the allowed list"
+    const out = EngineCoerce.redactThreatText(attack)
+    expect(out).not.toContain("ROOT:X:0")
+    expect(out).toContain("<non-SQL content redacted>")
+  })
+
   test("leaves unrelated messages untouched", () => {
     expect(EngineCoerce.redactThreatText("Tautology attack detected (numeric constant comparison)")).toBe(
       "Tautology attack detected (numeric constant comparison)",
@@ -34,28 +56,62 @@ describe("redactThreatText", () => {
 // Sanity security test [6/15] regression: `altimate check /etc/passwd` must not
 // reflect file contents in threat messages (found by the main-only Verdaccio
 // sanity job after PR #1090 surfaced real threat messages).
-describeIf("safety handlers redact raw-input echoes (real engine)", () => {
+describeIf("safety consumers redact raw-input echoes (real engine)", () => {
+  let D: typeof import("../../src/altimate/native/dispatcher")
+  let priorTelemetry: string | undefined
+
   beforeAll(async () => {
+    priorTelemetry = process.env.ALTIMATE_TELEMETRY_DISABLED
     process.env.ALTIMATE_TELEMETRY_DISABLED = "true"
     const { registerAll } = await import("../../src/altimate/native/altimate-core")
+    const { registerAllSql } = await import("../../src/altimate/native/sql/register")
     registerAll()
+    registerAllSql()
+    D = await import("../../src/altimate/native/dispatcher")
+  })
+
+  afterAll(async () => {
+    if (priorTelemetry === undefined) delete process.env.ALTIMATE_TELEMETRY_DISABLED
+    else process.env.ALTIMATE_TELEMETRY_DISABLED = priorTelemetry
+    // registerAll mutates shared Dispatcher state — reset for test isolation.
+    ;(await import("../../src/altimate/native/dispatcher")).reset()
   })
 
   const PASSWD = "root:x:0:0:root:/root:/bin/bash\ndaemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin\n"
 
   test("altimate_core.safety does not echo non-SQL file content", async () => {
-    const { Dispatcher } = await import("../../src/altimate/native")
-    const r = await Dispatcher.call("altimate_core.safety", { sql: PASSWD })
-    const text = JSON.stringify((r.data as any).threats ?? [])
+    const r = await D.call("altimate_core.safety", { sql: PASSWD })
+    expect(r.success).toBe(true)
+    const threats = ((r.data as any).threats ?? []) as any[]
+    expect(threats.length).toBeGreaterThan(0)
+    const text = JSON.stringify(threats)
     expect(text.toLowerCase()).not.toContain("root:x:0")
     expect(text).toContain("redacted")
   })
 
   test("composite check does not echo non-SQL file content in threats", async () => {
-    const { Dispatcher } = await import("../../src/altimate/native")
-    const r = await Dispatcher.call("altimate_core.check", { sql: PASSWD })
-    const threats = JSON.stringify(((r.data as any).safety?.threats ?? []))
-    expect(threats.toLowerCase()).not.toContain("root:x:0")
+    const r = await D.call("altimate_core.check", { sql: PASSWD })
+    expect(r.success).toBe(true)
+    // The sanitizer must actually be exercised — an empty threat list would
+    // make the not-contains assertion vacuous.
+    const threats = (((r.data as any).safety?.threats ?? []) as any[])
+    expect(threats.length).toBeGreaterThan(0)
+    const text = JSON.stringify(threats)
+    expect(text.toLowerCase()).not.toContain("root:x:0")
+    expect(text).toContain("redacted")
+  })
+
+  test("sql.analyze does not echo non-SQL file content in issues", async () => {
+    const r = await D.call("sql.analyze", { sql: PASSWD })
+    const text = JSON.stringify((r as any).issues ?? [])
+    expect(text.toLowerCase()).not.toContain("root:x:0")
+  })
+
+  test("altimate_core.grade nested safety threats are redacted", async () => {
+    const r = await D.call("altimate_core.grade", { sql: PASSWD })
+    expect(r.success).toBe(true)
+    const text = JSON.stringify(((r.data as any).safety?.threats ?? []))
+    expect(text.toLowerCase()).not.toContain("root:x:0")
   })
 
   test("diff-scoping still filters pre-existing multi_statement threats despite redaction", async () => {
@@ -63,15 +119,13 @@ describeIf("safety handlers redact raw-input echoes (real engine)", () => {
     // rewrote head matched_patterns to "<redacted>" so base keys never matched
     // and pre-existing threats resurfaced as introduced. Redaction now runs
     // after subtraction: identical base/head must yield zero threats.
-    const { Dispatcher } = await import("../../src/altimate/native")
-    const r = await Dispatcher.call("altimate_core.check", { sql: PASSWD, base_sql: PASSWD })
+    const r = await D.call("altimate_core.check", { sql: PASSWD, base_sql: PASSWD })
     expect((((r.data as any).safety?.threats ?? []) as any[]).length).toBe(0)
     expect((r.data as any).safety.safe).toBe(true)
   })
 
   test("real SQL statement types are preserved in messages", async () => {
-    const { Dispatcher } = await import("../../src/altimate/native")
-    const r = await Dispatcher.call("altimate_core.safety", { sql: "SELECT 1; DROP TABLE users;" })
+    const r = await D.call("altimate_core.safety", { sql: "SELECT 1; DROP TABLE users;" })
     const threats = ((r.data as any).threats ?? []) as any[]
     const messages = threats.map((t) => `${t.message} ${t.detail}`).join(" ")
     // SQL-keyword statement types stay useful in messages/details

--- a/packages/opencode/test/altimate/threat-redaction.test.ts
+++ b/packages/opencode/test/altimate/threat-redaction.test.ts
@@ -9,10 +9,10 @@ try {
 const describeIf = coreAvailable ? describe : describe.skip
 
 describe("redactThreatText", () => {
-  test("keeps SQL-statement-keyword types", () => {
+  test("keeps single SQL-statement-keyword types (the only shape the engine emits)", () => {
     expect(EngineCoerce.redactThreatText("Disallowed statement type: DROP")).toBe("Disallowed statement type: DROP")
-    expect(EngineCoerce.redactThreatText("Statement type 'ALTER TABLE' is not in the allowed list")).toBe(
-      "Statement type 'ALTER TABLE' is not in the allowed list",
+    expect(EngineCoerce.redactThreatText("Statement type 'ALTER' is not in the allowed list")).toBe(
+      "Statement type 'ALTER' is not in the allowed list",
     )
   })
 
@@ -35,16 +35,17 @@ describe("redactThreatText", () => {
     expect(EngineCoerce.redactThreatText("Statement type 'PRIVATE NOTE' is not in the allowed list")).toBe(
       "Statement type '<non-SQL content redacted>' is not in the allowed list",
     )
-    // A keyword PREFIX must not preserve an arbitrary tail.
+    // ANY multi-word phrase redacts — the engine only emits single-word
+    // statement types (live-probed), so multi-word input is never engine
+    // vocabulary: keyword-prefixed tails and keyword permutations both die.
     expect(EngineCoerce.redactThreatText("Disallowed statement type: SET SECRET PASSWORD")).toBe(
       "Disallowed statement type: <non-SQL content redacted>",
     )
     expect(EngineCoerce.redactThreatText("Disallowed statement type: DROP DEAD FRED")).toBe(
       "Disallowed statement type: <non-SQL content redacted>",
     )
-    // Compound statement types made purely of keywords stay useful.
-    expect(EngineCoerce.redactThreatText("Disallowed statement type: DROP INDEX IF EXISTS")).toBe(
-      "Disallowed statement type: DROP INDEX IF EXISTS",
+    expect(EngineCoerce.redactThreatText("Disallowed statement type: SELECT DELETE UPDATE")).toBe(
+      "Disallowed statement type: <non-SQL content redacted>",
     )
   })
 

--- a/packages/opencode/test/altimate/threat-redaction.test.ts
+++ b/packages/opencode/test/altimate/threat-redaction.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test, beforeAll } from "bun:test"
+import { EngineCoerce } from "../../src/altimate/native/engine-coerce"
+
+let coreAvailable = false
+try {
+  require.resolve("@altimateai/altimate-core")
+  coreAvailable = true
+} catch {}
+const describeIf = coreAvailable ? describe : describe.skip
+
+describe("redactThreatText", () => {
+  test("keeps SQL-keyword-like statement types", () => {
+    expect(EngineCoerce.redactThreatText("Disallowed statement type: DROP")).toBe("Disallowed statement type: DROP")
+    expect(EngineCoerce.redactThreatText("Statement type 'ALTER TABLE' is not in the allowed list")).toBe(
+      "Statement type 'ALTER TABLE' is not in the allowed list",
+    )
+  })
+
+  test("redacts non-SQL content (e.g. /etc/passwd lines)", () => {
+    const msg = "Disallowed statement type: ROOT:X:0:0:ROOT:/ROOT:/BIN/BASH"
+    expect(EngineCoerce.redactThreatText(msg)).toBe("Disallowed statement type: <non-SQL content redacted>")
+    const detail = "Statement type 'ROOT:X:0:0:ROOT:/ROOT:/BIN/BASH' is not in the allowed list: [\"SELECT\"]"
+    expect(EngineCoerce.redactThreatText(detail)).toContain("'<non-SQL content redacted>'")
+    expect(EngineCoerce.redactThreatText(detail)).not.toContain("ROOT:X:0")
+  })
+
+  test("leaves unrelated messages untouched", () => {
+    expect(EngineCoerce.redactThreatText("Tautology attack detected (numeric constant comparison)")).toBe(
+      "Tautology attack detected (numeric constant comparison)",
+    )
+  })
+})
+
+// Sanity security test [6/15] regression: `altimate check /etc/passwd` must not
+// reflect file contents in threat messages (found by the main-only Verdaccio
+// sanity job after PR #1090 surfaced real threat messages).
+describeIf("safety handlers redact raw-input echoes (real engine)", () => {
+  beforeAll(async () => {
+    process.env.ALTIMATE_TELEMETRY_DISABLED = "true"
+    const { registerAll } = await import("../../src/altimate/native/altimate-core")
+    registerAll()
+  })
+
+  const PASSWD = "root:x:0:0:root:/root:/bin/bash\ndaemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin\n"
+
+  test("altimate_core.safety does not echo non-SQL file content", async () => {
+    const { Dispatcher } = await import("../../src/altimate/native")
+    const r = await Dispatcher.call("altimate_core.safety", { sql: PASSWD })
+    const text = JSON.stringify((r.data as any).threats ?? [])
+    expect(text.toLowerCase()).not.toContain("root:x:0")
+    expect(text).toContain("redacted")
+  })
+
+  test("composite check does not echo non-SQL file content in threats", async () => {
+    const { Dispatcher } = await import("../../src/altimate/native")
+    const r = await Dispatcher.call("altimate_core.check", { sql: PASSWD })
+    const threats = JSON.stringify(((r.data as any).safety?.threats ?? []))
+    expect(threats.toLowerCase()).not.toContain("root:x:0")
+  })
+
+  test("real SQL statement types are preserved in messages", async () => {
+    const { Dispatcher } = await import("../../src/altimate/native")
+    const r = await Dispatcher.call("altimate_core.safety", { sql: "SELECT 1; DROP TABLE users;" })
+    const threats = ((r.data as any).threats ?? []) as any[]
+    const messages = threats.map((t) => `${t.message} ${t.detail}`).join(" ")
+    // SQL-keyword statement types stay useful in messages/details
+    // (matched_pattern is always redacted for multi_statement by design).
+    expect(messages).toContain("DROP")
+    expect(messages).not.toContain("redacted")
+  })
+})

--- a/packages/opencode/test/altimate/threat-redaction.test.ts
+++ b/packages/opencode/test/altimate/threat-redaction.test.ts
@@ -35,6 +35,17 @@ describe("redactThreatText", () => {
     expect(EngineCoerce.redactThreatText("Statement type 'PRIVATE NOTE' is not in the allowed list")).toBe(
       "Statement type '<non-SQL content redacted>' is not in the allowed list",
     )
+    // A keyword PREFIX must not preserve an arbitrary tail.
+    expect(EngineCoerce.redactThreatText("Disallowed statement type: SET SECRET PASSWORD")).toBe(
+      "Disallowed statement type: <non-SQL content redacted>",
+    )
+    expect(EngineCoerce.redactThreatText("Disallowed statement type: DROP DEAD FRED")).toBe(
+      "Disallowed statement type: <non-SQL content redacted>",
+    )
+    // Compound statement types made purely of keywords stay useful.
+    expect(EngineCoerce.redactThreatText("Disallowed statement type: DROP INDEX IF EXISTS")).toBe(
+      "Disallowed statement type: DROP INDEX IF EXISTS",
+    )
   })
 
   test("embedded apostrophes cannot close the quoted match early", () => {
@@ -103,15 +114,27 @@ describeIf("safety consumers redact raw-input echoes (real engine)", () => {
 
   test("sql.analyze does not echo non-SQL file content in issues", async () => {
     const r = await D.call("sql.analyze", { sql: PASSWD })
-    const text = JSON.stringify((r as any).issues ?? [])
+    const safetyIssues = (((r as any).issues ?? []) as any[]).filter((i) => i.type === "safety")
+    // The sanitizer must actually be exercised — no safety issues would make
+    // the not-contains assertion vacuous.
+    expect(safetyIssues.length).toBeGreaterThan(0)
+    const text = JSON.stringify(safetyIssues)
     expect(text.toLowerCase()).not.toContain("root:x:0")
+    expect(text).toContain("redacted")
   })
 
-  test("altimate_core.grade nested safety threats are redacted", async () => {
+  test("altimate_core.grade result does not echo non-SQL file content", async () => {
+    // EvalResult's safety section is { method, score } — no threat scan to
+    // echo (the handler's redactScan is defense-in-depth if that changes).
+    // Assert the whole result is echo-free, minus the `sql` field, which by
+    // contract carries back the caller's own input.
     const r = await D.call("altimate_core.grade", { sql: PASSWD })
     expect(r.success).toBe(true)
-    const text = JSON.stringify(((r.data as any).safety?.threats ?? []))
-    expect(text.toLowerCase()).not.toContain("root:x:0")
+    // `sql` (EvalResult) and `lint.sql` (LintResult) carry back the caller's
+    // own input by contract and are never rendered by the CLI grade check.
+    const { sql: _echoedInput, ...rest } = r.data as any
+    if (rest.lint) rest.lint = { ...rest.lint, sql: undefined }
+    expect(JSON.stringify(rest).toLowerCase()).not.toContain("root:x:0")
   })
 
   test("diff-scoping still filters pre-existing multi_statement threats despite redaction", async () => {

--- a/packages/opencode/test/altimate/threat-redaction.test.ts
+++ b/packages/opencode/test/altimate/threat-redaction.test.ts
@@ -58,6 +58,17 @@ describeIf("safety handlers redact raw-input echoes (real engine)", () => {
     expect(threats.toLowerCase()).not.toContain("root:x:0")
   })
 
+  test("diff-scoping still filters pre-existing multi_statement threats despite redaction", async () => {
+    // Regression (cursor review on #1111): redacting BEFORE base subtraction
+    // rewrote head matched_patterns to "<redacted>" so base keys never matched
+    // and pre-existing threats resurfaced as introduced. Redaction now runs
+    // after subtraction: identical base/head must yield zero threats.
+    const { Dispatcher } = await import("../../src/altimate/native")
+    const r = await Dispatcher.call("altimate_core.check", { sql: PASSWD, base_sql: PASSWD })
+    expect((((r.data as any).safety?.threats ?? []) as any[]).length).toBe(0)
+    expect((r.data as any).safety.safe).toBe(true)
+  })
+
   test("real SQL statement types are preserved in messages", async () => {
     const { Dispatcher } = await import("../../src/altimate/native")
     const r = await Dispatcher.call("altimate_core.safety", { sql: "SELECT 1; DROP TABLE users;" })


### PR DESCRIPTION
### Issue for this PR

Closes #1110

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes the `Sanity (Verdaccio)` failure on main (security phase `[6/15] Path traversal in file args`). That job only runs on pushes to main, so #1090's PR CI could not see it.

Root cause: #1090 correctly started surfacing real engine `ThreatFinding` messages in `check --checks safety` (they previously collapsed into one generic warning). The engine's `multi_statement` rule quotes the raw "statement type" token verbatim, and its `matched_pattern` is the raw input line — for non-SQL input (`altimate check ../../../../etc/passwd`) that reflects the file's contents into CLI output (`Disallowed statement type: ROOT:X:0:0:…`), which the sanity test rightly flags as an information-disclosure hazard.

Fix at the dispatcher boundary so every consumer (CLI, tools, review) is covered:
- `EngineCoerce.redactThreatText` keeps SQL-keyword-like statement types (`DROP`, `ALTER TABLE`) and replaces arbitrary content with `<non-SQL content redacted>` in threat `message`/`detail`.
- `multi_statement` threats additionally redact `matched_pattern` (for that rule the pattern IS the raw input line); injection rules keep their SQL-shaped patterns. Diff-scoping identity keys stay consistent because base and head redact identically.
- Wired into the `altimate_core.safety` handler and the composite check.

Engine-side fix filed upstream: AltimateAI/altimate-core-internal#765 (the token should be sanitized at the source so all consumers are safe by default).

### How did you verify your code works?

- Reproduced the exact sanity scenario locally before/after: `altimate check <passwd-like file>` echoed `ROOT:X:0:0:…` before, now renders `<non-SQL content redacted>`; real SQL still reports `Disallowed statement type: DROP`.
- New `threat-redaction.test.ts`: unit tests for the redaction (keyword kept / content redacted / unrelated messages untouched) + real-engine tests through both handlers asserting passwd-like input no longer echoes and `DROP` survives in messages.
- Full `test/altimate` + `test/cli`: 4793 pass / 0 fail; typecheck and marker check clean.
- Not verified: the Verdaccio sanity harness itself (needs the docker-compose stack); the failing grep condition (`root:x:0` in output) is reproduced and covered directly.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-sensitive output sanitization on all safety consumers; ordering relative to diff-scoping is critical to avoid regressing composite check behavior.
> 
> **Overview**
> Fixes an **information-disclosure** path where safety scans could echo arbitrary input (e.g. `/etc/passwd` lines) in CLI and tool output after real `multi_statement` threat messages were surfaced.
> 
> Adds **`EngineCoerce.redactThreatText`** and **`EngineCoerce.redactScan`**: threat `message`/`detail` keep only single-word SQL statement keywords the engine actually emits; everything else becomes `<non-SQL content redacted>`. **`multi_statement`** threats always set **`matched_pattern`** to `<redacted>`; other rules keep SQL-shaped patterns.
> 
> Wires redaction into **`altimate_core.safety`**, **`sql.analyze`**, **`altimate_core.grade`** (nested safety), and **`altimate_core.check`** — with redaction **after** base/head diff-scoping so subtraction still compares raw `matched_pattern` keys (fixes pre-existing threats incorrectly resurfacing).
> 
> New **`threat-redaction.test.ts`** covers allowlist/quote bypass cases, integration across handlers, and identical base/head yielding zero threats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 389ff1aff37e645f9416cf7aefd5c59bfc6bdccc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts non-SQL content in safety threat output and fixes the main-only Verdaccio sanity failure. Previously `multi_statement` echoed raw input in the “statement type” and `matched_pattern`; now we preserve single-word SQL statement types and redact everything else after diff-scoping.

- Adds `EngineCoerce.redactThreatText` and `EngineCoerce.redactScan`: exact single-keyword allowlist matching engine output, greedy-quote handling, and "<non-SQL content redacted>" for non-SQL tokens.
- Sets `matched_pattern` to "<redacted>" for `multi_statement`; other rules keep SQL-shaped patterns.
- Applies redaction in `altimate_core.safety`, `sql.analyze`, `altimate_core.check` (after subtraction), and `altimate_core.grade` (defense-in-depth).
- No caller or config changes. Tests cover keyword preservation, non-SQL redaction, quote bypasses, all consumers, and a regression ensuring identical base/head scans yield zero threats.

<sup>Written for commit 389ff1aff37e645f9416cf7aefd5c59bfc6bdccc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/1111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved threat-result sanitization by removing non-SQL content from displayed messages, details, and matched patterns.
  * Preserved relevant SQL statement types and patterns needed for accurate threat comparison.
  * Ensured safety, composite, analysis, and grading results remain correctly filtered and recalculated after redaction.

* **Tests**
  * Added coverage for threat-message redaction, SQL preservation, embedded-quote bypass protection, unchanged unrelated messages, and diff-scoped results.
  * Added integration coverage across safety scans, composite checks, SQL analysis, and grading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->