### PR TITLE
fix: truncation cleanup deletes fresh files — Identifier 48-bit timestamp wrapped on 2026-08-14

### DIFF
--- a/packages/opencode/src/tool/truncate.ts
+++ b/packages/opencode/src/tool/truncate.ts
@@ -6,7 +6,6 @@ import type { Agent } from "../agent/agent"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { evaluate } from "@/permission/evaluate"
 import { Config } from "@/config/config"
-import { Identifier } from "../id/id"
 import { ToolID } from "./schema"
 import { TRUNCATION_DIR } from "./truncation-dir"
 
@@ -52,17 +51,27 @@ export const layer = Layer.effect(
     const fs = yield* FSUtil.Service
 
     const cleanup = Effect.fn("Truncate.cleanup")(function* () {
-      const cutoff = Identifier.timestamp(
-        Identifier.create("tool", "ascending", Date.now() - Duration.toMillis(RETENTION)),
-      )
+      // altimate_change start — upstream_fix: age files by mtime, not decoded ID timestamps.
+      // Identifier packs `timestamp * 4096` into 48 bits, which wraps every
+      // 2^36 ms (~795 days) — the 26th wrap landed 2026-08-14T11:19:55Z, after
+      // which every new ID decoded as "ancient" and cleanup deleted files the
+      // moment they were written. File mtime has no wrap.
+      const cutoffMs = Date.now() - Duration.toMillis(RETENTION)
       const entries = yield* fs.readDirectory(TRUNCATION_DIR).pipe(
         Effect.map((all) => all.filter((name) => name.startsWith("tool_"))),
         Effect.catch(() => Effect.succeed([])),
       )
       for (const entry of entries) {
-        if (Identifier.timestamp(entry) >= cutoff) continue
-        yield* fs.remove(path.join(TRUNCATION_DIR, entry)).pipe(Effect.catch(() => Effect.void))
+        const file = path.join(TRUNCATION_DIR, entry)
+        const mtimeMs = yield* Effect.tryPromise(() => import("node:fs/promises").then((nfs) => nfs.stat(file))).pipe(
+          Effect.map((st) => st.mtimeMs),
+          // Unstat-able file: keep it — deletion must fail safe.
+          Effect.catch(() => Effect.succeed(Number.POSITIVE_INFINITY)),
+        )
+        if (mtimeMs >= cutoffMs) continue
+        yield* fs.remove(file).pipe(Effect.catch(() => Effect.void))
       }
+      // altimate_change end
     })
 
     const write = Effect.fn("Truncate.write")(function* (text: string) {

--- a/packages/opencode/src/tool/truncate.ts
+++ b/packages/opencode/src/tool/truncate.ts
@@ -63,11 +63,12 @@ export const layer = Layer.effect(
       )
       for (const entry of entries) {
         const file = path.join(TRUNCATION_DIR, entry)
-        const mtimeMs = yield* Effect.tryPromise(() => import("node:fs/promises").then((nfs) => nfs.stat(file))).pipe(
-          Effect.map((st) => st.mtimeMs),
-          // Unstat-able file: keep it — deletion must fail safe.
-          Effect.catch(() => Effect.succeed(Number.POSITIVE_INFINITY)),
-        )
+        // Stat through the INJECTED filesystem (FSUtil extends FileSystem) so
+        // custom/in-memory providers behave identically to the host FS.
+        const info = yield* fs.stat(file).pipe(Effect.catch(() => Effect.succeed(undefined)))
+        // Unstat-able file or absent mtime: keep it — deletion must fail safe.
+        const mtimeMs =
+          info && Option.isSome(info.mtime) ? info.mtime.value.getTime() : Number.POSITIVE_INFINITY
         if (mtimeMs >= cutoffMs) continue
         yield* fs.remove(file).pipe(Effect.catch(() => Effect.void))
       }

--- a/packages/opencode/src/tool/truncation.ts
+++ b/packages/opencode/src/tool/truncation.ts
@@ -1,7 +1,6 @@
 import fs from "fs/promises"
 import path from "path"
 import { Global } from "../global"
-import { Identifier } from "../id/id"
 import { PermissionNext } from "../permission/next"
 import type { Agent } from "../agent/agent"
 import { Scheduler } from "../scheduler"
@@ -35,20 +34,24 @@ export namespace Truncate {
   }
 
   export async function cleanup() {
-    const cutoff = Identifier.timestamp(Identifier.create("tool", "ascending", Date.now() - RETENTION_MS))
+    // altimate_change start — upstream_fix: age files by mtime, not decoded ID
+    // timestamps. Identifier packs `timestamp * 4096` into 48 bits, wrapping
+    // every 2^36 ms (~795 days; the 26th wrap: 2026-08-14T11:19:55Z), after
+    // which every new ID decoded as "ancient" and cleanup deleted files the
+    // moment they were written. File mtime has no wrap. Stat failures keep
+    // the file — deletion must fail safe.
+    const cutoffMs = Date.now() - RETENTION_MS
     const entries = await Glob.scan("tool_*", { cwd: DIR, include: "file" }).catch(() => [] as string[])
     for (const entry of entries) {
-      // altimate_change start - tolerate stale/malformed tool-output files from older builds.
-      let timestamp: number
-      try {
-        timestamp = Identifier.timestamp(entry)
-      } catch {
-        continue
-      }
-      if (timestamp >= cutoff) continue
-      // altimate_change end
-      await fs.unlink(path.join(DIR, entry)).catch(() => {})
+      const file = path.join(DIR, entry)
+      const mtimeMs = await fs
+        .stat(file)
+        .then((st) => st.mtimeMs)
+        .catch(() => Number.POSITIVE_INFINITY)
+      if (mtimeMs >= cutoffMs) continue
+      await fs.unlink(file).catch(() => {})
     }
+    // altimate_change end
   }
 
   function hasTaskTool(agent?: Agent.Info): boolean {

--- a/packages/opencode/test/lib/filesystem.ts
+++ b/packages/opencode/test/lib/filesystem.ts
@@ -12,9 +12,8 @@ export const writeFileStringScoped = Effect.fn("test.writeFileStringScoped")(fun
 /** Create a symlink whose removal is guaranteed by the test scope, even when
  *  an assertion fails mid-test (finalizers run on scope close regardless). */
 export const symlinkScoped = Effect.fn("test.symlinkScoped")(function* (target: string, link: string) {
-  yield* Effect.promise(() => import("node:fs/promises").then((nfs) => nfs.symlink(target, link)))
-  yield* Effect.addFinalizer(() =>
-    Effect.promise(() => import("node:fs/promises").then((nfs) => nfs.unlink(link).catch(() => {}))),
-  )
+  const fs = yield* FileSystem.FileSystem
+  yield* fs.symlink(target, link)
+  yield* Effect.addFinalizer(() => fs.remove(link, { force: true }).pipe(Effect.orDie))
   return link
 })

--- a/packages/opencode/test/lib/filesystem.ts
+++ b/packages/opencode/test/lib/filesystem.ts
@@ -8,3 +8,13 @@ export const writeFileStringScoped = Effect.fn("test.writeFileStringScoped")(fun
   yield* Effect.addFinalizer(() => fs.remove(file, { force: true }).pipe(Effect.orDie))
   return file
 })
+
+/** Create a symlink whose removal is guaranteed by the test scope, even when
+ *  an assertion fails mid-test (finalizers run on scope close regardless). */
+export const symlinkScoped = Effect.fn("test.symlinkScoped")(function* (target: string, link: string) {
+  yield* Effect.promise(() => import("node:fs/promises").then((nfs) => nfs.symlink(target, link)))
+  yield* Effect.addFinalizer(() =>
+    Effect.promise(() => import("node:fs/promises").then((nfs) => nfs.unlink(link).catch(() => {}))),
+  )
+  return link
+})

--- a/packages/opencode/test/tool/truncation.test.ts
+++ b/packages/opencode/test/tool/truncation.test.ts
@@ -9,7 +9,7 @@ import { Identifier } from "../../src/id/id"
 import { Process } from "@/util/process"
 import path from "path"
 import { testEffect } from "../lib/effect"
-import { writeFileStringScoped } from "../lib/filesystem"
+import { symlinkScoped, writeFileStringScoped } from "../lib/filesystem"
 import { TestConfig } from "../fixture/config"
 
 const FIXTURES_DIR = path.join(import.meta.dir, "fixtures")
@@ -262,7 +262,10 @@ describe("Truncate", () => {
         yield* writeFileStringScoped(old, "old content")
         yield* writeFileStringScoped(recent, "recent content")
         const nfs = yield* Effect.promise(() => import("node:fs/promises"))
-        yield* Effect.promise(() => nfs.symlink(path.join(Truncate.DIR, "nonexistent-target"), dangling))
+        // Scoped: the finalizer unlinks it even when an assertion fails —
+        // otherwise a failed expect would leak the link into the real data
+        // dir, where the fail-safe under test deliberately keeps it forever.
+        yield* symlinkScoped(path.join(Truncate.DIR, "nonexistent-target"), dangling)
         const oldTime = new Date(Date.now() - 10 * DAY_MS)
         const recentTime = new Date(Date.now() - 3 * DAY_MS)
         yield* Effect.promise(() => nfs.utimes(old, oldTime, oldTime))
@@ -275,7 +278,6 @@ describe("Truncate", () => {
         // dangling link even when the link itself survived.
         const danglingKept = yield* Effect.promise(() => nfs.lstat(dangling).then(() => true).catch(() => false))
         expect(danglingKept).toBe(true)
-        yield* Effect.promise(() => nfs.unlink(dangling).catch(() => {}))
       }),
     )
   })

--- a/packages/opencode/test/tool/truncation.test.ts
+++ b/packages/opencode/test/tool/truncation.test.ts
@@ -251,11 +251,16 @@ describe("Truncate", () => {
 
         yield* fs.makeDirectory(Truncate.DIR, { recursive: true })
 
-        const old = path.join(Truncate.DIR, Identifier.create("tool", "ascending", Date.now() - 10 * DAY_MS))
-        const recent = path.join(Truncate.DIR, Identifier.create("tool", "ascending", Date.now() - 3 * DAY_MS))
+        // Age is judged by file mtime (ID-embedded timestamps wrap every
+        // ~795 days — see Truncate.cleanup), so set mtimes explicitly.
+        const old = path.join(Truncate.DIR, Identifier.create("tool", "ascending"))
+        const recent = path.join(Truncate.DIR, Identifier.create("tool", "ascending"))
 
         yield* writeFileStringScoped(old, "old content")
         yield* writeFileStringScoped(recent, "recent content")
+        const nfs = yield* Effect.promise(() => import("node:fs/promises"))
+        yield* Effect.promise(() => nfs.utimes(old, new Date(Date.now() - 10 * DAY_MS), new Date(Date.now() - 10 * DAY_MS)))
+        yield* Effect.promise(() => nfs.utimes(recent, new Date(Date.now() - 3 * DAY_MS), new Date(Date.now() - 3 * DAY_MS)))
         yield* svc.cleanup()
 
         expect(yield* fs.exists(old)).toBe(false)

--- a/packages/opencode/test/tool/truncation.test.ts
+++ b/packages/opencode/test/tool/truncation.test.ts
@@ -255,16 +255,27 @@ describe("Truncate", () => {
         // ~795 days — see Truncate.cleanup), so set mtimes explicitly.
         const old = path.join(Truncate.DIR, Identifier.create("tool", "ascending"))
         const recent = path.join(Truncate.DIR, Identifier.create("tool", "ascending"))
+        // Dangling symlink: listed by readDirectory, but stat fails — the
+        // fail-safe branch must KEEP it rather than delete on uncertainty.
+        const dangling = path.join(Truncate.DIR, Identifier.create("tool", "ascending"))
 
         yield* writeFileStringScoped(old, "old content")
         yield* writeFileStringScoped(recent, "recent content")
         const nfs = yield* Effect.promise(() => import("node:fs/promises"))
-        yield* Effect.promise(() => nfs.utimes(old, new Date(Date.now() - 10 * DAY_MS), new Date(Date.now() - 10 * DAY_MS)))
-        yield* Effect.promise(() => nfs.utimes(recent, new Date(Date.now() - 3 * DAY_MS), new Date(Date.now() - 3 * DAY_MS)))
+        yield* Effect.promise(() => nfs.symlink(path.join(Truncate.DIR, "nonexistent-target"), dangling))
+        const oldTime = new Date(Date.now() - 10 * DAY_MS)
+        const recentTime = new Date(Date.now() - 3 * DAY_MS)
+        yield* Effect.promise(() => nfs.utimes(old, oldTime, oldTime))
+        yield* Effect.promise(() => nfs.utimes(recent, recentTime, recentTime))
         yield* svc.cleanup()
 
         expect(yield* fs.exists(old)).toBe(false)
         expect(yield* fs.exists(recent)).toBe(true)
+        // lstat: fs.exists follows symlinks and would report false for a
+        // dangling link even when the link itself survived.
+        const danglingKept = yield* Effect.promise(() => nfs.lstat(dangling).then(() => true).catch(() => false))
+        expect(danglingKept).toBe(true)
+        yield* Effect.promise(() => nfs.unlink(dangling).catch(() => {}))
       }),
     )
   })


### PR DESCRIPTION
### Issue for this PR

Closes #1112

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes the `Truncate > cleanup` test failing on every CI run since 2026-08-17 (on unchanged code), and the underlying live data-loss bug.

`Identifier.create` packs `timestamp * 4096 + counter` into 6 bytes, which wraps every 2^36 ms (~795.4 days). The 26th wrap since epoch landed **2026-08-14T11:19:55Z**. After that boundary, newly created IDs decode to tiny timestamps while the 7-day-retention cutoff (computed from a pre-wrap timestamp) decodes as astronomically large — so both truncation cleanups considered every freshly written file "older than 7 days" and **deleted truncated tool outputs the moment cleanup ran**.

Fix: both cleanups (`tool/truncate.ts` Effect service and the legacy `tool/truncation.ts` module used by bootstrap/bash/prompt) now age files by **mtime**, which does not wrap; stat failures keep the file (deletion fails safe). Tagged `upstream_fix` — the wrap-prone ID encoding is upstream OpenCode code; if upstream reworks the encoding we can drop the marker.

Why this is correct: the wrap arithmetic is verified (`2^36 ms = 795.4 days`; boundary `26 × 2^36 ms = 2026-08-14T11:19:55Z`, matching the first CI failure on Aug 17 when the test's `now - 3 days` fixture crossed the boundary), and mtime-based aging removes the dependence on the ID encoding entirely.

### How did you verify your code works?

- Reproduced the failing test locally (recent file deleted), then green after the fix; test now sets explicit mtimes (`utimes`) instead of ID-embedded timestamps.
- Full `test/tool` directory: 496 pass / 0 fail; typecheck clean; marker check clean (`upstream_fix` markers in place).
- Not verified: behavior at the NEXT wrap boundary (Nov 2028) — irrelevant now that aging uses mtime.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches scheduled cleanup that deletes persisted tool outputs; behavior change is intentional but wrong mtime handling could retain stale files or, if fail-safe were removed, delete unpredictably.
> 
> **Overview**
> Fixes **truncated tool output being deleted immediately** after the 48-bit `Identifier` timestamp encoding wrapped (~2026-08-14). Cleanup no longer infers age from `tool_*` filenames; it uses **file mtime** against a 7-day cutoff in both the Effect `Truncate` service and the legacy `truncation` module.
> 
> **Fail-safe behavior:** stat errors, missing mtime, or unstatable entries (e.g. dangling symlinks) are **kept**, not deleted. The Effect path stats via injected `FSUtil` so in-memory/custom FS matches production.
> 
> Tests set explicit `utimes` instead of ID-embedded times, add a dangling-symlink case, and introduce scoped `symlinkScoped` for cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78a9ddc6aa9f21451b35e07973ef801fb8794f10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents truncation cleanup from deleting fresh tool outputs by aging files by mtime instead of decoding `Identifier` timestamps. After the 48-bit timestamp wrapped on 2026-08-14, new files decoded as “ancient” and were removed; cleanup now compares file mtime to the retention cutoff and keeps files on stat errors.

- Updates both cleanup paths: `packages/opencode/src/tool/truncate.ts` stats via injected `FSUtil.Service` (from `@opencode-ai/core/fs-util`); `packages/opencode/src/tool/truncation.ts` uses Node `fs`. Deletes only when `mtimeMs < cutoffMs`; stat failure or absent mtime keeps the file (including dangling symlinks).
- Tests set explicit mtimes and add a dangling symlink case verified with `lstat`; introduces `symlinkScoped` that uses the injected `FileSystem` service for teardown even on failed assertions. No public API or configuration changes; no migration required.

<sup>Written for commit b88f3255c3516bc44a1abcc46d883a4dff02b38d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/1113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of temporary tool files by using their actual filesystem modification times.
  * Prevented files from being deleted when their metadata cannot be read, reducing the risk of accidental removal.
  * Preserved existing filtering and error-handling behavior, including safe handling of dangling links and failed deletions.

* **Tests**
  * Updated cleanup coverage to verify removal based on file age rather than identifier contents.
  * Added checks ensuring recent files and files with unavailable metadata are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->