### PR TITLE
fix(check): reject non-SQL files by extension — unblock v0.9.6 release

### DIFF
--- a/packages/opencode/src/cli/cmd/check-helpers.ts
+++ b/packages/opencode/src/cli/cmd/check-helpers.ts
@@ -52,13 +52,19 @@ export const VALID_CHECKS = new Set(["lint", "validate", "safety", "policy", "pi
  * parsed and echoed back through engine error messages (v0.9.6 fix). */
 export const SQL_EXTENSIONS = new Set([".sql", ".ddl"])
 
-/** Case-insensitive SQL-extension test. Path.extname returns "" for
- * files without a dot, which correctly resolves to "not a SQL file". */
+/** Case-insensitive SQL-extension test. Matches node's ``path.extname``
+ * semantics: a filename whose only dot is the FIRST character (e.g.
+ * ``.sql`` or ``.ddl``) is a dotfile with NO extension, not a SQL file.
+ * ``.query.sql`` is a dotfile with a real ``.sql`` extension (accepted).
+ * ``foo.bar/baz`` is not SQL (the dot is in the directory, not the
+ * filename). (cubic P2 round on release/v0.9.6 hotfix.) */
 export function isSqlFile(filePath: string): boolean {
-  const dot = filePath.lastIndexOf(".")
   const slash = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"))
-  if (dot <= slash) return false
-  return SQL_EXTENSIONS.has(filePath.slice(dot).toLowerCase())
+  const basename = slash === -1 ? filePath : filePath.slice(slash + 1)
+  const dot = basename.lastIndexOf(".")
+  // dot === -1: no extension. dot === 0: dotfile with no extension (e.g. ``.sql``).
+  if (dot <= 0) return false
+  return SQL_EXTENSIONS.has(basename.slice(dot).toLowerCase())
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/opencode/src/cli/cmd/check-helpers.ts
+++ b/packages/opencode/src/cli/cmd/check-helpers.ts
@@ -47,6 +47,20 @@ export const SEVERITY_RANK: Record<Severity, number> = { error: 2, warning: 1, i
 
 export const VALID_CHECKS = new Set(["lint", "validate", "safety", "policy", "pii", "semantic", "grade"])
 
+/** Extensions the ``check`` command will treat as SQL. Anything else is
+ * skipped before it reaches the engine, so non-SQL content cannot be
+ * parsed and echoed back through engine error messages (v0.9.6 fix). */
+export const SQL_EXTENSIONS = new Set([".sql", ".ddl"])
+
+/** Case-insensitive SQL-extension test. Path.extname returns "" for
+ * files without a dot, which correctly resolves to "not a SQL file". */
+export function isSqlFile(filePath: string): boolean {
+  const dot = filePath.lastIndexOf(".")
+  const slash = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"))
+  if (dot <= slash) return false
+  return SQL_EXTENSIONS.has(filePath.slice(dot).toLowerCase())
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/packages/opencode/src/cli/cmd/check.ts
+++ b/packages/opencode/src/cli/cmd/check.ts
@@ -2,7 +2,7 @@
 import type { Argv } from "yargs"
 import { cmd } from "./cmd"
 import { Dispatcher } from "../../altimate/native"
-import { readFileSync, existsSync, statSync } from "fs"
+import { readFileSync, existsSync, statSync, lstatSync, realpathSync } from "fs"
 import { Glob } from "../../util/glob"
 import path from "path"
 import {
@@ -512,6 +512,38 @@ export const CheckCommand = cmd({
       if (!st.isFile()) {
         console.error(`Warning: not a regular file (directory or other), skipping: ${f}`)
         return false
+      }
+      // Reject symlinks whose target does NOT itself have a SQL extension.
+      // The extension filter above only inspects the LINK name, and
+      // statSync follows the link — so ``ln -s /etc/passwd passwd.sql``
+      // sails through with statIsFile=true and readFileSync then reads
+      // /etc/passwd's content, which the safety renderer echoes back
+      // (the same class of leak this whole PR exists to close). Detect
+      // symlinks with lstat and re-validate the resolved target's
+      // extension. Preserves ``link.sql -> real.sql`` (both are SQL) but
+      // rejects ``passwd.sql -> /etc/passwd``. (coderabbit MAJOR round
+      // on release/v0.9.6 hotfix.)
+      let lst
+      try {
+        lst = lstatSync(f)
+      } catch (e) {
+        console.error(`Warning: lstat failed, skipping: ${f} (${(e as Error).message})`)
+        return false
+      }
+      if (lst.isSymbolicLink()) {
+        let resolved: string
+        try {
+          resolved = realpathSync(f)
+        } catch (e) {
+          console.error(`Warning: symlink resolve failed, skipping: ${f} (${(e as Error).message})`)
+          return false
+        }
+        if (!isSqlFile(resolved)) {
+          console.error(
+            `Warning: symlink target is not a SQL file, skipping: ${f} -> ${resolved}`,
+          )
+          return false
+        }
       }
       return true
     })

--- a/packages/opencode/src/cli/cmd/check.ts
+++ b/packages/opencode/src/cli/cmd/check.ts
@@ -2,7 +2,7 @@
 import type { Argv } from "yargs"
 import { cmd } from "./cmd"
 import { Dispatcher } from "../../altimate/native"
-import { readFileSync, existsSync } from "fs"
+import { readFileSync, existsSync, statSync } from "fs"
 import { Glob } from "../../util/glob"
 import path from "path"
 import {
@@ -461,8 +461,10 @@ export const CheckCommand = cmd({
     // 3. Resolve files
     let files: string[] = args.files ?? []
     if (files.length === 0) {
-      console.error("No files specified, searching for **/*.sql in current directory...")
-      files = await Glob.scan("**/*.sql", { cwd: process.cwd(), absolute: true })
+      console.error("No files specified, searching for **/*.{sql,ddl} in current directory...")
+      const sqls = await Glob.scan("**/*.sql", { cwd: process.cwd(), absolute: true })
+      const ddls = await Glob.scan("**/*.ddl", { cwd: process.cwd(), absolute: true })
+      files = [...new Set([...sqls, ...ddls])]
     } else {
       // Expand globs in positional args
       const expanded: string[] = []
@@ -495,6 +497,20 @@ export const CheckCommand = cmd({
       if (!isSqlFile(f)) {
         const ext = path.extname(f).toLowerCase() || "none"
         console.error(`Warning: not a SQL file (extension "${ext}"), skipping: ${f}`)
+        return false
+      }
+      // Reject directories (and symlinks-to-directories) whose name happens
+      // to end in .sql / .ddl — statSync follows symlinks, so a symlink to
+      // a dir is rejected. (cubic P2 round on release/v0.9.6 hotfix.)
+      let st
+      try {
+        st = statSync(f)
+      } catch (e) {
+        console.error(`Warning: stat failed, skipping: ${f} (${(e as Error).message})`)
+        return false
+      }
+      if (!st.isFile()) {
+        console.error(`Warning: not a regular file (directory or other), skipping: ${f}`)
         return false
       }
       return true

--- a/packages/opencode/src/cli/cmd/check.ts
+++ b/packages/opencode/src/cli/cmd/check.ts
@@ -10,6 +10,7 @@ import {
   type CheckCategoryResult,
   type Severity,
   VALID_CHECKS,
+  isSqlFile,
   normalizeSeverity,
   filterBySeverity,
   toCategoryResult,
@@ -476,10 +477,24 @@ export const CheckCommand = cmd({
       files = expanded
     }
 
-    // Filter to only existing .sql files
+    // Filter to only existing SQL files by extension. The prior version
+    // only checked existence — the "SQL" filter was a lie in the comment.
+    // Feeding a non-SQL file (e.g. ``altimate check /etc/passwd``) meant
+    // the engine parsed each line as a SQL statement; the 0.7.0 engine's
+    // ``multi_statement`` safety rule then echoed the offending line
+    // (uppercased) in its error message, leaking the file's first line
+    // into stdout. Rejecting by extension keeps non-SQL content from
+    // reaching the engine at all — no message, no leak. (v0.9.6 sanity
+    // regression; sanity test at test/sanity/phases/security.sh:96-103
+    // has been present + passing since PR #844.)
     files = files.filter((f) => {
       if (!existsSync(f)) {
         console.error(`Warning: file not found, skipping: ${f}`)
+        return false
+      }
+      if (!isSqlFile(f)) {
+        const ext = path.extname(f).toLowerCase() || "none"
+        console.error(`Warning: not a SQL file (extension "${ext}"), skipping: ${f}`)
         return false
       }
       return true

--- a/packages/opencode/src/cli/cmd/check.ts
+++ b/packages/opencode/src/cli/cmd/check.ts
@@ -513,16 +513,21 @@ export const CheckCommand = cmd({
         console.error(`Warning: not a regular file (directory or other), skipping: ${f}`)
         return false
       }
-      // Reject symlinks whose target does NOT itself have a SQL extension.
-      // The extension filter above only inspects the LINK name, and
-      // statSync follows the link — so ``ln -s /etc/passwd passwd.sql``
-      // sails through with statIsFile=true and readFileSync then reads
-      // /etc/passwd's content, which the safety renderer echoes back
-      // (the same class of leak this whole PR exists to close). Detect
-      // symlinks with lstat and re-validate the resolved target's
-      // extension. Preserves ``link.sql -> real.sql`` (both are SQL) but
-      // rejects ``passwd.sql -> /etc/passwd``. (coderabbit MAJOR round
-      // on release/v0.9.6 hotfix.)
+      // Reject symlinks entirely. An earlier attempt validated the
+      // symlink target's extension and then let the flow continue to
+      // ``readFileSync(f)``, but that opens a TOCTOU race: between
+      // validation and read, an attacker with write access to the
+      // parent directory can swap the symlink to point at a non-SQL
+      // file (e.g. /etc/passwd), which readFileSync would then dutifully
+      // read — reopening the same leak class this PR closes. Closing
+      // the race properly requires opening the file once, fstat'ing the
+      // fd, and passing the fd (not the path) through to every
+      // downstream reader — a large refactor for a CLI most invocations
+      // don't hit. Simpler + safer: refuse symlinks. Users who need to
+      // check a linked file can pass the resolved target directly.
+      // (coderabbit MAJOR TOCTOU on release/v0.9.6 hotfix; reverses the
+      // "accept link-to-SQL" behavior cubic asked for in the prior round
+      // — noted in the thread.)
       let lst
       try {
         lst = lstatSync(f)
@@ -531,19 +536,16 @@ export const CheckCommand = cmd({
         return false
       }
       if (lst.isSymbolicLink()) {
-        let resolved: string
+        let target = ""
         try {
-          resolved = realpathSync(f)
-        } catch (e) {
-          console.error(`Warning: symlink resolve failed, skipping: ${f} (${(e as Error).message})`)
-          return false
+          target = realpathSync(f)
+        } catch {
+          // If we can't even resolve, just report the link path.
         }
-        if (!isSqlFile(resolved)) {
-          console.error(
-            `Warning: symlink target is not a SQL file, skipping: ${f} -> ${resolved}`,
-          )
-          return false
-        }
+        console.error(
+          `Warning: symlinks are not accepted (TOCTOU-safe), skipping: ${f}${target ? ` -> ${target}` : ""}`,
+        )
+        return false
       }
       return true
     })

--- a/packages/opencode/test/altimate/dispatcher.test.ts
+++ b/packages/opencode/test/altimate/dispatcher.test.ts
@@ -1,13 +1,11 @@
-import { describe, expect, test, beforeEach, beforeAll, afterAll, mock } from "bun:test"
+import { describe, expect, test, beforeEach, mock } from "bun:test"
 import * as Dispatcher from "../../src/altimate/native/dispatcher"
 
-// Disable telemetry via env var instead of mock.module
-beforeAll(() => {
-  process.env.ALTIMATE_TELEMETRY_DISABLED = "true"
-})
-afterAll(() => {
-  delete process.env.ALTIMATE_TELEMETRY_DISABLED
-})
+// No telemetry disable needed — Dispatcher.call already wraps every
+// Telemetry.track call in try/catch that swallows all errors, so telemetry
+// firing during a test cannot fail the test. The previous env-var
+// mutation was defensive against nothing and wasn't parallel-safe (issue
+// #1130 — https://github.com/AltimateAI/altimate-code/issues/1130).
 
 describe("Dispatcher", () => {
   beforeEach(() => {

--- a/packages/opencode/test/altimate/dispatcher.test.ts
+++ b/packages/opencode/test/altimate/dispatcher.test.ts
@@ -6,6 +6,18 @@ import * as Dispatcher from "../../src/altimate/native/dispatcher"
 // firing during a test cannot fail the test. The previous env-var
 // mutation was defensive against nothing and wasn't parallel-safe (issue
 // #1130 — https://github.com/AltimateAI/altimate-code/issues/1130).
+//
+// Concurrency contract: the ``Dispatcher`` module is a process-wide
+// singleton (``nativeHandlers`` Map, ``_ensureRegistered`` hook). These
+// tests intentionally mutate that singleton via ``Dispatcher.reset()``
+// and ``Dispatcher.setRegistrationHook()``. This is safe under bun's
+// DEFAULT behaviour of running test files sequentially in one process,
+// but NOT parallel-safe if the runner is later flipped to ``--concurrency
+// N``. Isolating the dispatcher would require an instance-per-test
+// refactor across the whole module; deferred as a broader tech-debt
+// task (issue #1130 tracks the parallel-safety cleanup for this + the
+// sibling release-adversarial file). Same class of finding as the
+// env-var mutation coderabbit flagged.
 
 describe("Dispatcher", () => {
   beforeEach(() => {

--- a/packages/opencode/test/cli/check-e2e.test.ts
+++ b/packages/opencode/test/cli/check-e2e.test.ts
@@ -16,6 +16,7 @@ import {
   formatText,
   buildCheckOutput,
   VALID_CHECKS,
+  isSqlFile,
   type Finding,
   type CheckCategoryResult,
 } from "../../src/cli/cmd/check-helpers"
@@ -1399,6 +1400,67 @@ describe("check command adversarial", () => {
     const r = await runHandler(baseArgs({ files, checks: "lint" }))
     const j = parseJson(r.stdout)
     expect(j.files_checked).toBe(50)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isSqlFile — SQL-extension filter (v0.9.6 sanity regression)
+// ---------------------------------------------------------------------------
+//
+// v0.9.6 shipped an ``altimate-core`` 0.7.0 upgrade whose new
+// ``multi_statement`` safety rule echoes the offending statement text in
+// its error message. When ``check`` was invoked on a non-SQL file (e.g.
+// ``altimate check /etc/passwd``), the engine parsed each line as SQL,
+// failed, and echoed the line back — leaking file content to stdout.
+// The sanity test at ``test/sanity/phases/security.sh:96-103`` has been
+// present + passing since PR #844 (June 2026); v0.9.6's engine upgrade
+// regressed it. Fix: reject non-SQL files by extension BEFORE they
+// reach the engine, so no content is ever parsed and echoed.
+describe("isSqlFile — extension filter (v0.9.6 sanity regression)", () => {
+  test("accepts .sql (both cases)", () => {
+    expect(isSqlFile("query.sql")).toBe(true)
+    expect(isSqlFile("QUERY.SQL")).toBe(true)
+    expect(isSqlFile("/absolute/path/to/query.sql")).toBe(true)
+    expect(isSqlFile("relative/path/query.sql")).toBe(true)
+  })
+  test("accepts .ddl (both cases)", () => {
+    expect(isSqlFile("schema.ddl")).toBe(true)
+    expect(isSqlFile("SCHEMA.DDL")).toBe(true)
+  })
+  test("rejects the exact sanity-test path (system file, no extension)", () => {
+    // The exact input the sanity test at test/sanity/phases/security.sh:96
+    // was leaking through before the fix.
+    expect(isSqlFile("../../../../etc/passwd")).toBe(false)
+    expect(isSqlFile("/etc/passwd")).toBe(false)
+  })
+  test("rejects extensionless files", () => {
+    expect(isSqlFile("passwd")).toBe(false)
+    expect(isSqlFile("/tmp/no-extension")).toBe(false)
+  })
+  test("rejects unrelated extensions", () => {
+    expect(isSqlFile("foo.txt")).toBe(false)
+    expect(isSqlFile("query.yml")).toBe(false)
+    expect(isSqlFile("script.sh")).toBe(false)
+    expect(isSqlFile("archive.tar.gz")).toBe(false)
+  })
+  test("dotfiles without an extension are not SQL", () => {
+    // ``.hidden`` has a leading dot but no proper extension — the
+    // filename ``.hidden`` has ``extname === ""`` under Node's rules.
+    expect(isSqlFile(".hidden")).toBe(false)
+    expect(isSqlFile("/etc/.passwd")).toBe(false)
+  })
+  test("dotfiles with a SQL extension ARE accepted", () => {
+    // Edge case: ``.query.sql`` is a hidden file with a real .sql extension.
+    expect(isSqlFile(".query.sql")).toBe(true)
+  })
+  test("directory paths (trailing slash) are not SQL files", () => {
+    expect(isSqlFile("/path/to/dir/")).toBe(false)
+    expect(isSqlFile("relative/dir/")).toBe(false)
+  })
+  test("path with dots in directory names but no extension on the file", () => {
+    // ``foo.bar/baz`` — the ``.`` is in the directory, not the file.
+    expect(isSqlFile("foo.bar/baz")).toBe(false)
+    expect(isSqlFile("foo.bar/baz.sql")).toBe(true)
   })
 })
 // altimate_change end

--- a/packages/opencode/test/cli/check-e2e.test.ts
+++ b/packages/opencode/test/cli/check-e2e.test.ts
@@ -3,7 +3,7 @@
 // IMPORTANT: This file uses Dispatcher.register() / Dispatcher.reset() instead
 // of mock.module("@/altimate/native") to avoid Bun's mock.module leaking across
 // test files and breaking Glob/Dispatcher for all subsequent tests in CI.
-import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test"
+import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from "bun:test"
 import * as fs from "fs/promises"
 import path from "path"
 import os from "os"
@@ -153,6 +153,11 @@ beforeEach(async () => {
 afterEach(async () => {
   process.exit = origExit
   process.exitCode = 0
+  // Restore all spies (process.stdout.write, process.stderr.write,
+  // console.error) — Bun doesn't auto-restore spyOn mocks across test
+  // files, so without this the mocks leak into subsequent files' output.
+  // (coderabbit MAJOR on v0.9.6 hotfix.)
+  mock.restore()
   // Restore Dispatcher: clear our mocks and re-enable lazy registration
   Dispatcher.reset()
   // Re-install the registration hook so subsequent tests get real handlers
@@ -1146,6 +1151,39 @@ describe("check command adversarial", () => {
     expect(r.stderr).toContain("No SQL files found to check")
     // No content-leak surface at all when the file is rejected.
     expect(r.stdout).not.toContain("not-a-file")
+  })
+
+  test("handler rejects symlink whose target is NOT a SQL file", async () => {
+    // coderabbit MAJOR: statSync follows symlinks; without a lstat check the
+    // extension filter would accept `passwd.sql -> /etc/passwd` because the
+    // LINK's name ends in .sql, and readFileSync would then dutifully read
+    // /etc/passwd's content — the exact leak class this PR closes. Fix uses
+    // lstatSync + realpathSync to require the resolved target's extension
+    // to also be SQL.
+    const target = path.join(tmpDir.dir, "fake-passwd.txt")
+    const link = path.join(tmpDir.dir, "passwd.sql")
+    await fs.writeFile(target, "root:x:0:0:root:/root:/bin/bash\n", "utf-8")
+    await fs.symlink(target, link)
+    const r = await runHandler(baseArgs({ files: [link], checks: "safety" }))
+    expect(r.stderr).toMatch(/symlink target is not a SQL file/)
+    expect(r.stderr).toContain("passwd.sql")
+    expect(r.stderr).toContain("fake-passwd.txt")
+    expect(r.stderr).toContain("No SQL files found to check")
+    // Critical: no content leak — the file was never read.
+    expect(r.stdout).not.toMatch(/root:x:0/i)
+    expect(r.stderr).not.toMatch(/root:x:0/i)
+  })
+
+  test("handler ACCEPTS symlink whose target IS a SQL file", async () => {
+    // Sibling of the above — symlink-to-SQL is a legitimate use case
+    // (e.g. `link.sql -> real.sql`) and must still flow through.
+    const target = await writeSql(tmpDir.dir, "real.sql", "SELECT 1;")
+    const link = path.join(tmpDir.dir, "link.sql")
+    await fs.symlink(target, link)
+    const r = await runHandler(baseArgs({ files: [link], checks: "safety" }))
+    const j = parseJson(r.stdout)
+    expect(j.files_checked).toBe(1)
+    expect(r.stderr).not.toMatch(/symlink target is not/)
   })
 
   test("handler rejects a dotfile named exactly '.sql'", async () => {

--- a/packages/opencode/test/cli/check-e2e.test.ts
+++ b/packages/opencode/test/cli/check-e2e.test.ts
@@ -1153,37 +1153,41 @@ describe("check command adversarial", () => {
     expect(r.stdout).not.toContain("not-a-file")
   })
 
-  test("handler rejects symlink whose target is NOT a SQL file", async () => {
-    // coderabbit MAJOR: statSync follows symlinks; without a lstat check the
-    // extension filter would accept `passwd.sql -> /etc/passwd` because the
-    // LINK's name ends in .sql, and readFileSync would then dutifully read
-    // /etc/passwd's content — the exact leak class this PR closes. Fix uses
-    // lstatSync + realpathSync to require the resolved target's extension
-    // to also be SQL.
+  test("handler rejects ALL symlinks (TOCTOU-safe)", async () => {
+    // coderabbit MAJOR: even a "resolve target + extension check" approach
+    // opens a TOCTOU race — an attacker can swap the symlink target
+    // between validation and readFileSync. Simpler + fully safe: refuse
+    // symlinks entirely. Rejects both attack cases and previously-legit
+    // symlink-to-SQL — users pass the resolved target directly instead.
     const target = path.join(tmpDir.dir, "fake-passwd.txt")
     const link = path.join(tmpDir.dir, "passwd.sql")
     await fs.writeFile(target, "root:x:0:0:root:/root:/bin/bash\n", "utf-8")
     await fs.symlink(target, link)
     const r = await runHandler(baseArgs({ files: [link], checks: "safety" }))
-    expect(r.stderr).toMatch(/symlink target is not a SQL file/)
+    expect(r.stderr).toMatch(/symlinks are not accepted/)
     expect(r.stderr).toContain("passwd.sql")
-    expect(r.stderr).toContain("fake-passwd.txt")
     expect(r.stderr).toContain("No SQL files found to check")
     // Critical: no content leak — the file was never read.
     expect(r.stdout).not.toMatch(/root:x:0/i)
     expect(r.stderr).not.toMatch(/root:x:0/i)
   })
 
-  test("handler ACCEPTS symlink whose target IS a SQL file", async () => {
-    // Sibling of the above — symlink-to-SQL is a legitimate use case
-    // (e.g. `link.sql -> real.sql`) and must still flow through.
+  test("handler rejects symlink-to-SQL too (blanket ban is intentional)", async () => {
+    // Deliberate revert of an earlier round's behavior: cubic asked to
+    // accept `link.sql -> real.sql` in a prior round, then coderabbit
+    // flagged the TOCTOU race. Blanket-rejecting closes the race
+    // completely at the cost of legitimate symlink-to-SQL, which users
+    // can work around by passing the resolved target path directly.
     const target = await writeSql(tmpDir.dir, "real.sql", "SELECT 1;")
     const link = path.join(tmpDir.dir, "link.sql")
     await fs.symlink(target, link)
     const r = await runHandler(baseArgs({ files: [link], checks: "safety" }))
-    const j = parseJson(r.stdout)
+    expect(r.stderr).toMatch(/symlinks are not accepted/)
+    expect(r.stderr).toContain("link.sql")
+    // The user can still check the resolved target directly.
+    const r2 = await runHandler(baseArgs({ files: [target], checks: "safety" }))
+    const j = parseJson(r2.stdout)
     expect(j.files_checked).toBe(1)
-    expect(r.stderr).not.toMatch(/symlink target is not/)
   })
 
   test("handler rejects a dotfile named exactly '.sql'", async () => {
@@ -1464,14 +1468,20 @@ describe("check command adversarial", () => {
     expect(j.checks_run).toEqual(["lint", "safety"])
   })
 
-  test("handles symlinked SQL files", async () => {
+  test("symlinks are rejected (superseded by TOCTOU-safe policy)", async () => {
+    // Was: "handles symlinked SQL files" — asserted files_checked===1 when
+    // check followed a symlink. Behavior changed in the v0.9.6 hotfix:
+    // symlinks are blanket-rejected to close a TOCTOU race where an
+    // attacker could swap the symlink target between validate and read.
+    // See handler adversarial cases above.
     const real = await writeSql(tmpDir.dir, "real.sql", "SELECT 1;")
     const link = path.join(tmpDir.dir, "link.sql")
     await fs.symlink(real, link)
 
     const r = await runHandler(baseArgs({ files: [link], checks: "lint" }))
-    const j = parseJson(r.stdout)
-    expect(j.files_checked).toBe(1)
+    expect(r.stderr).toMatch(/symlinks are not accepted/)
+    expect(r.stderr).toContain("link.sql")
+    expect(r.stderr).toContain("No SQL files found to check")
   })
 
   test("handles binary content in .sql file without crashing", async () => {

--- a/packages/opencode/test/cli/check-e2e.test.ts
+++ b/packages/opencode/test/cli/check-e2e.test.ts
@@ -1112,6 +1112,56 @@ describe("check command E2E", () => {
 // ===========================================================================
 
 describe("check command adversarial", () => {
+  test("handler filters non-SQL files from positional args — no content parsed or echoed", async () => {
+    // Handler-level integration test (cubic P2 catch on the pure-helper-only
+    // test coverage). This test would fail if CheckCommand.handler stopped
+    // calling isSqlFile — proving the filter is wired end-to-end, not just
+    // present as an unused helper. Reproduces the exact regression path:
+    // a non-SQL file containing "root:x:0" must NOT flow through the engine
+    // path where a rule message could echo its content to stdout.
+    const sqlFile = await writeSql(tmpDir.dir, "real.sql", "SELECT 1;")
+    const nonSql = path.join(tmpDir.dir, "fake-passwd-no-ext")
+    await fs.writeFile(nonSql, "root:x:0:0:root:/root:/bin/bash\n", "utf-8")
+    const r = await runHandler(baseArgs({ files: [sqlFile, nonSql], checks: "safety" }))
+    const j = parseJson(r.stdout)
+    // Only the .sql file made it through.
+    expect(j.files_checked).toBe(1)
+    // The non-SQL file was rejected with a clear warning on stderr.
+    expect(r.stderr).toMatch(/not a SQL file.*fake-passwd-no-ext/)
+    // Critically: no content leak. Neither the SQL output nor the warning
+    // contains any part of the non-SQL file's content.
+    expect(r.stdout).not.toMatch(/root:x:0/i)
+    expect(r.stderr).not.toMatch(/root:x:0/i)
+  })
+
+  test("handler rejects a directory whose name ends in .sql", async () => {
+    // cubic P2: extension check alone would accept ``foo.sql/`` as a file.
+    // The isFile() stat gate must reject it. When ALL positional files
+    // are rejected, check.ts's early "No SQL files found" bail-out fires
+    // and there is no JSON body — assert on stderr instead of parseJson.
+    const dirLikeFile = path.join(tmpDir.dir, "not-a-file.sql")
+    await fs.mkdir(dirLikeFile, { recursive: true })
+    const r = await runHandler(baseArgs({ files: [dirLikeFile], checks: "safety" }))
+    expect(r.stderr).toMatch(/not a regular file.*not-a-file\.sql/)
+    expect(r.stderr).toContain("No SQL files found to check")
+    // No content-leak surface at all when the file is rejected.
+    expect(r.stdout).not.toContain("not-a-file")
+  })
+
+  test("handler rejects a dotfile named exactly '.sql'", async () => {
+    // cubic P2: ``.sql`` as a filename is a dotfile with no extension,
+    // not a SQL file. Must be rejected before reaching the engine.
+    const dotSql = path.join(tmpDir.dir, ".sql")
+    await fs.writeFile(dotSql, "root:x:0:0:root:/root:/bin/bash\n", "utf-8")
+    const r = await runHandler(baseArgs({ files: [dotSql], checks: "safety" }))
+    // Same as above — all files rejected → "No SQL files found" bail-out.
+    expect(r.stderr).toMatch(/not a SQL file.*\.sql$/m)
+    expect(r.stderr).toContain("No SQL files found to check")
+    // Critical: the file's content NEVER reaches stdout or stderr.
+    expect(r.stdout).not.toMatch(/root:x:0/i)
+    expect(r.stderr).not.toMatch(/root:x:0/i)
+  })
+
   test("handles SQL with embedded null bytes", async () => {
     const file = await writeSql(tmpDir.dir, "null.sql", "SELECT 1;\0DROP TABLE users;")
     const r = await runHandler(baseArgs({ files: [file], checks: "lint" }))
@@ -1294,14 +1344,19 @@ describe("check command adversarial", () => {
   })
 
   test("handles directory with .sql extension", async () => {
+    // Extension filter passes ``dir.sql`` (name ends in .sql) but the
+    // stat/isFile gate rejects it as "not a regular file" before it ever
+    // reaches the readFileSync call. The good.sql file still processes.
+    // (v0.9.6 hotfix: added statSync isFile() check.)
     const good = await writeSql(tmpDir.dir, "good.sql", "SELECT 1;")
     const dir = path.join(tmpDir.dir, "dir.sql")
     await fs.mkdir(dir)
 
     const r = await runHandler(baseArgs({ files: [good, dir], checks: "lint" }))
-    expect(r.stderr).toContain("Error reading")
+    expect(r.stderr).toContain("not a regular file")
+    expect(r.stderr).toContain("dir.sql")
     const j = parseJson(r.stdout)
-    expect(j.files_checked).toBe(2)
+    expect(j.files_checked).toBe(1)
   })
 
   test("processes duplicate file args (each checked separately)", async () => {
@@ -1452,6 +1507,15 @@ describe("isSqlFile — extension filter (v0.9.6 sanity regression)", () => {
   test("dotfiles with a SQL extension ARE accepted", () => {
     // Edge case: ``.query.sql`` is a hidden file with a real .sql extension.
     expect(isSqlFile(".query.sql")).toBe(true)
+  })
+  test("basename that is JUST the extension (bare dotfile) is NOT SQL", () => {
+    // ``.sql`` and ``.ddl`` as filenames are dotfiles per node's
+    // ``path.extname`` — they have NO extension, they're just dot-prefixed
+    // names. Must not be accepted. (cubic P2 catch on release/v0.9.6 hotfix.)
+    expect(isSqlFile(".sql")).toBe(false)
+    expect(isSqlFile(".ddl")).toBe(false)
+    expect(isSqlFile("/some/dir/.sql")).toBe(false)
+    expect(isSqlFile("/some/dir/.ddl")).toBe(false)
   })
   test("directory paths (trailing slash) are not SQL files", () => {
     expect(isSqlFile("/path/to/dir/")).toBe(false)

--- a/packages/opencode/test/skill/release-v0.9.6-adversarial.test.ts
+++ b/packages/opencode/test/skill/release-v0.9.6-adversarial.test.ts
@@ -29,25 +29,15 @@
  * hit ``await _registrationPromise`` by the time control returns to us —
  * we can immediately act on shared state without racing the call's setup.
  */
-import { afterEach, beforeAll, afterAll, beforeEach, describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 
 import * as Dispatcher from "../../src/altimate/native/dispatcher"
 
-let _priorTelemetryDisabled: string | undefined
-beforeAll(() => {
-  _priorTelemetryDisabled = process.env.ALTIMATE_TELEMETRY_DISABLED
-  process.env.ALTIMATE_TELEMETRY_DISABLED = "true"
-})
-afterAll(() => {
-  // Restore any pre-existing value rather than unconditionally deleting —
-  // an outer suite may have set it and expects to see its own value after
-  // this file runs. (cubic P2 round 3.)
-  if (_priorTelemetryDisabled === undefined) {
-    delete process.env.ALTIMATE_TELEMETRY_DISABLED
-  } else {
-    process.env.ALTIMATE_TELEMETRY_DISABLED = _priorTelemetryDisabled
-  }
-})
+// No process.env mutation — Dispatcher.call already wraps every
+// Telemetry.track in try/catch that swallows errors, so telemetry firing
+// during a test cannot fail the test. Prior save/restore of
+// ALTIMATE_TELEMETRY_DISABLED wasn't parallel-safe under bun test
+// (coderabbit MAJOR on v0.9.6 hotfix, issue #1130). Removed cleanly here.
 
 describe("v0.9.6 release: Dispatcher registration retry", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Fixes the v0.9.6 release-workflow sanity failure. The `Sanity (Verdaccio)` job's Phase 5 security test failed → `Publish to npm` and `Create GitHub Release` were skipped. Nothing shipped; the release is in limbo. This PR unblocks it.

## What actually happened — the test existed all along, `altimate-core` 0.7.0 regressed it

The failing test is at [test/sanity/phases/security.sh:96-103](https://github.com/AltimateAI/altimate-code/blob/main/test/sanity/phases/security.sh#L96-L103), introduced in [#844](https://github.com/AltimateAI/altimate-code/pull/844) (June 2026), and has been **present + passing on every release since — including v0.9.5 on Aug 10**. It runs:

```sh
altimate check "../../../../etc/passwd"
```

and greps case-insensitive for `root:x:0` in the output. Historically that output was `Warning: file not found, skipping: /...` (on macOS) or `No SQL files found` (on Linux) — no leak.

v0.9.6 shipped the `altimate-core` 0.5.1 → 0.7.0 upgrade in [#1090](https://github.com/AltimateAI/altimate-code/pull/1090). One of its new safety rules — `multi_statement` — **echoes the offending statement text back inside its error message**. When the CLI reads `/etc/passwd` on Linux CI, parses each line as SQL, and fails, the engine emits:

```
ERROR ... [multi_statement]: Disallowed statement type: ROOT:X:0:0:ROOT:/ROOT:/BIN/BASH
    suggestion: Statement type 'ROOT:X:0:0:ROOT:/ROOT:/BIN/BASH' is not in the allowed list: ["SELECT", "WITH"]
```

The sanity grep matches → test fails → publish skipped. **Not the test's fault; the engine change regressed it.** No customer would have seen this in practice (they're unlikely to `altimate check /etc/passwd`), but the sanity net catches the class of "CLI leaks file content to stdout" cleanly and it's right to fail-closed here.

## The fix

The prior file filter at [`packages/opencode/src/cli/cmd/check.ts`](https://github.com/AltimateAI/altimate-code/blob/main/packages/opencode/src/cli/cmd/check.ts) had a comment that said "Filter to only existing .sql files" — but the code only checked existence, not extension. That was the actual bug: `altimate check /etc/passwd` was accepted, parsed, and echoed. This PR makes the filter honor its own comment:

```ts
files = files.filter((f) => {
  if (!existsSync(f)) { console.error(`Warning: file not found, skipping: ${f}`); return false }
  if (!isSqlFile(f)) {
    const ext = path.extname(f).toLowerCase() || "none"
    console.error(`Warning: not a SQL file (extension "${ext}"), skipping: ${f}`)
    return false
  }
  return true
})
```

`isSqlFile()` accepts `.sql` / `.ddl` (case-insensitive) — extracted to `check-helpers.ts` so it's unit-testable independently.

**Non-SQL content no longer reaches the engine at all** — no parse, no error message, no leak. The sanity test now passes because the CLI output for `altimate check ../../../../etc/passwd` becomes:

```
Warning: not a SQL file (extension "none"), skipping: /.../etc/passwd
No SQL files found to check.
```

## Verification

- Rebuilt the darwin-arm64 binary with the fix and re-ran the exact sanity reproduction locally — pre-fix output leaked `ROOT:X:0:...`, post-fix skips cleanly with the warning above.
- 82/82 tests in [`test/cli/check-e2e.test.ts`](https://github.com/AltimateAI/altimate-code/blob/fix/check-sql-extension-filter/packages/opencode/test/cli/check-e2e.test.ts) pass — 9 new `isSqlFile` cases (accept .sql/.ddl in both cases; reject the exact sanity-test path, extensionless files, unrelated extensions, dotfiles, directory paths, dot-in-dir paths) + 73 pre-existing.
- `bun turbo typecheck` clean.
- `Marker Guard` (strict, vs `origin/main`) clean.

## Follow-ups (not in this PR)

- **Engine-side fix**: `altimate-core`'s `multi_statement` rule should surface statement TYPE NAMES (e.g. `SELECT`, `INSERT`), not the raw offending content. Will file with the core team.
- **Belt-and-braces**: cap `message` length across all check-finding mappers so a future engine change that echoes user content can't leak this way again.

## Release plan (after this merges)

1. Delete broken `v0.9.6` tag on remote (safe — nothing was published)
2. Tag `v0.9.6-beta.1` at the new `main` HEAD → `release.yml` re-runs, sanity now passes, publishes to npm `beta` dist-tag (existing `latest` users unaffected)
3. Once beta.1 is clean, tag `v0.9.6` at the same SHA → publishes to `latest`

## Test plan

- [x] Local rebuild + sanity-repro passes
- [x] 82/82 `check-e2e.test.ts` (9 new) pass
- [x] typecheck clean
- [x] Marker Guard clean
- [ ] CI on this PR
- [ ] Once merged: `release.yml` on `v0.9.6-beta.1` — full sanity path
- [ ] `release.yml` on `v0.9.6` — final promote to `latest`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks non-SQL, non-regular, and all symlinked files in `altimate check` to prevent parsing arbitrary content and leaking it via engine errors. Previously any existing path was parsed; now only regular `.sql`/`.ddl` files are processed, and symlinks are rejected to close a TOCTOU race.

- Accepts only case-insensitive `.sql`/`.ddl`; rejects bare `.sql`/`.ddl` dotfiles, directories or symlinks, and any non-SQL paths. Non-SQL paths warn and are skipped; if none remain, prints “No SQL files found to check.” Default discovery now scans `**/*.{sql,ddl}`.
- Adds `isSqlFile()` and `SQL_EXTENSIONS` in `packages/opencode/src/cli/cmd/check-helpers.ts`. In `packages/opencode/src/cli/cmd/check.ts`, adds `statSync(...).isFile()` and an `lstatSync` symlink gate that blanket-rejects links (TOCTOU-safe), dual-glob discovery, and clearer warnings.
- Tests add handler-level adversarial cases (mixed inputs, dotfiles, `.sql` directories, symlinks now rejected) and `isSqlFile` coverage; fixes spy restoration and removes test-only telemetry env mutations. All tests pass. No API changes beyond stricter file acceptance.
- Migration required: rename extensionless or non-`.sql`/`.ddl` SQL files, and replace symlinked inputs with their resolved file paths.
- Release: delete the broken `v0.9.6` tag, tag `v0.9.6-beta.1` to verify, then tag `v0.9.6` to publish to `latest`.

<sup>Written for commit c65af81e25c50b212f8f47013c97dc06d22f3838. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/1131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The check command recognizes `.sql` and `.ddl` files regardless of capitalization.
  - SQL files with names such as `.query.sql` are supported.

- **Bug Fixes**
  - Bare `.sql` and `.ddl` dotfiles, non-SQL inputs, SQL-named directories, symbolic links, and other non-file paths are rejected before parsing.
  - Broken links are handled safely, with diagnostic paths reported without exposing file contents.
  - Valid SQL files remain discoverable and checkable when referenced through their direct paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->