### PR TITLE
fix(codex): add gpt-5.5 + gpt-5.6 to ChatGPT-subscription allowlist (closes #1132)

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -17,22 +17,29 @@ const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
 
 /** Non-codex ChatGPT-subscription (OAuth) allowlist. Any modelId
- * containing "codex" is auto-allowed elsewhere; this set only enumerates
- * the plain main/mini variants OpenAI exposes on Codex-tier accounts.
- * Bump whenever a new gpt-5.N is generally available on the subscription.
- * Exported for unit-test coverage — see test/plugin/codex-allowlist.test.ts. */
+ * containing "codex" is auto-allowed by ``shouldAllowOAuthModel`` below,
+ * so this set only enumerates the plain non-codex main/mini variants
+ * OpenAI exposes on Codex-tier accounts. Bump whenever a new gpt-5.N
+ * is generally available on the subscription. Exported for unit-test
+ * coverage — see test/plugin/codex-allowlist.test.ts. */
 export const OAUTH_ALLOWED_MODELS = new Set([
-  "gpt-5.1-codex",
-  "gpt-5.1-codex-max",
-  "gpt-5.1-codex-mini",
   "gpt-5.2",
-  "gpt-5.2-codex",
-  "gpt-5.3-codex",
   "gpt-5.4",
   "gpt-5.4-mini",
   "gpt-5.5",
   "gpt-5.6",
 ])
+
+/** Single source of truth for OAuth (ChatGPT-subscription) model filtering.
+ * A model is kept if either (a) its id contains ``"codex"`` (all codex
+ * variants ship on the subscription), or (b) its id is an exact member of
+ * ``OAUTH_ALLOWED_MODELS`` (the curated non-codex releases). Reused across
+ * plugin/codex.ts and plugin/openai/codex.ts to prevent drift between the
+ * two implementations during the in-flight refactor. */
+export function shouldAllowOAuthModel(modelId: string): boolean {
+  if (modelId.includes("codex")) return true
+  return OAUTH_ALLOWED_MODELS.has(modelId)
+}
 
 interface PkceCodes {
   verifier: string
@@ -416,18 +423,14 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
         const auth = await getAuth()
         if (auth.type !== "oauth") return {}
 
-        // Filter models to only allowed Codex models for OAuth. Any modelId
-        // whose id includes "codex" is auto-allowed by the loop below, so
-        // this set only enumerates the non-codex ChatGPT-subscription
-        // main/mini variants. Keep in sync with what OpenAI's ChatGPT
-        // Pro/Plus subscription actually accepts — bump when a new
-        // release (gpt-5.5, 5.6, 5.7, ...) is available on the
-        // subscription tier. (Closes #1132 — GPT 5.6 missing from picker.)
-        const allowedModels = OAUTH_ALLOWED_MODELS
+        // Filter models to only those the ChatGPT-subscription (Codex) tier
+        // accepts. Delegates to ``shouldAllowOAuthModel`` (module-level, above)
+        // so this filter and the sibling in plugin/openai/codex.ts share one
+        // source of truth. See OAUTH_ALLOWED_MODELS + shouldAllowOAuthModel
+        // for the criteria + how to add new gpt-5.N releases.
+        // (Closes #1132 — GPT 5.6 missing from picker.)
         for (const modelId of Object.keys(provider.models)) {
-          if (modelId.includes("codex")) continue
-          if (allowedModels.has(modelId)) continue
-          delete provider.models[modelId]
+          if (!shouldAllowOAuthModel(modelId)) delete provider.models[modelId]
         }
 
         // Zero out costs for Codex (included with ChatGPT subscription)

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -30,12 +30,17 @@ export const OAUTH_ALLOWED_MODELS = new Set([
   "gpt-5.6",
 ])
 
-/** Single source of truth for OAuth (ChatGPT-subscription) model filtering.
- * A model is kept if either (a) its id contains ``"codex"`` (all codex
- * variants ship on the subscription), or (b) its id is an exact member of
- * ``OAUTH_ALLOWED_MODELS`` (the curated non-codex releases). Reused across
- * plugin/codex.ts and plugin/openai/codex.ts to prevent drift between the
- * two implementations during the in-flight refactor. */
+/** OAuth (ChatGPT-subscription) model-filter policy for the ACTIVE plugin
+ * (this file — wired via plugin/index.ts). A model is kept if either
+ * (a) its id contains ``"codex"`` (all codex variants ship on the
+ * subscription), or (b) its id is an exact member of
+ * ``OAUTH_ALLOWED_MODELS`` (the curated non-codex releases).
+ *
+ * The sibling file plugin/openai/codex.ts (an in-progress refactor,
+ * currently NOT wired) has its own separate filter with a
+ * ``parseFloat(match[1]) > 5.4`` fallback. Adopting this helper is
+ * followup work on that refactor — do NOT assume the two files share
+ * this policy today. */
 export function shouldAllowOAuthModel(modelId: string): boolean {
   if (modelId.includes("codex")) return true
   return OAUTH_ALLOWED_MODELS.has(modelId)

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -16,6 +16,24 @@ const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
 const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
 
+/** Non-codex ChatGPT-subscription (OAuth) allowlist. Any modelId
+ * containing "codex" is auto-allowed elsewhere; this set only enumerates
+ * the plain main/mini variants OpenAI exposes on Codex-tier accounts.
+ * Bump whenever a new gpt-5.N is generally available on the subscription.
+ * Exported for unit-test coverage — see test/plugin/codex-allowlist.test.ts. */
+export const OAUTH_ALLOWED_MODELS = new Set([
+  "gpt-5.1-codex",
+  "gpt-5.1-codex-max",
+  "gpt-5.1-codex-mini",
+  "gpt-5.2",
+  "gpt-5.2-codex",
+  "gpt-5.3-codex",
+  "gpt-5.4",
+  "gpt-5.4-mini",
+  "gpt-5.5",
+  "gpt-5.6",
+])
+
 interface PkceCodes {
   verifier: string
   challenge: string
@@ -398,17 +416,14 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
         const auth = await getAuth()
         if (auth.type !== "oauth") return {}
 
-        // Filter models to only allowed Codex models for OAuth
-        const allowedModels = new Set([
-          "gpt-5.1-codex",
-          "gpt-5.1-codex-max",
-          "gpt-5.1-codex-mini",
-          "gpt-5.2",
-          "gpt-5.2-codex",
-          "gpt-5.3-codex",
-          "gpt-5.4",
-          "gpt-5.4-mini",
-        ])
+        // Filter models to only allowed Codex models for OAuth. Any modelId
+        // whose id includes "codex" is auto-allowed by the loop below, so
+        // this set only enumerates the non-codex ChatGPT-subscription
+        // main/mini variants. Keep in sync with what OpenAI's ChatGPT
+        // Pro/Plus subscription actually accepts — bump when a new
+        // release (gpt-5.5, 5.6, 5.7, ...) is available on the
+        // subscription tier. (Closes #1132 — GPT 5.6 missing from picker.)
+        const allowedModels = OAUTH_ALLOWED_MODELS
         for (const modelId of Object.keys(provider.models)) {
           if (modelId.includes("codex")) continue
           if (allowedModels.has(modelId)) continue

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -429,10 +429,15 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
         if (auth.type !== "oauth") return {}
 
         // Filter models to only those the ChatGPT-subscription (Codex) tier
-        // accepts. Delegates to ``shouldAllowOAuthModel`` (module-level, above)
-        // so this filter and the sibling in plugin/openai/codex.ts share one
-        // source of truth. See OAUTH_ALLOWED_MODELS + shouldAllowOAuthModel
-        // for the criteria + how to add new gpt-5.N releases.
+        // accepts. Delegates to ``shouldAllowOAuthModel`` (module-level,
+        // above). See OAUTH_ALLOWED_MODELS + shouldAllowOAuthModel for the
+        // criteria + how to add new gpt-5.N releases.
+        //
+        // NOTE: this file is the ACTIVE plugin (wired via plugin/index.ts).
+        // The sibling plugin/openai/codex.ts is an unwired in-progress
+        // refactor that keeps its OWN ALLOWED_MODELS + parseFloat > 5.4
+        // fallback — this filter does NOT share a source of truth with it.
+        // Adopting shouldAllowOAuthModel there is followup on that refactor.
         // (Closes #1132 — GPT 5.6 missing from picker.)
         for (const modelId of Object.keys(provider.models)) {
           if (!shouldAllowOAuthModel(modelId)) delete provider.models[modelId]

--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -12,17 +12,7 @@ const ISSUER = "https://auth.openai.com"
 const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
 const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
-// Non-codex ChatGPT-subscription (OAuth) allowlist. Keep in sync with
-// the sibling ALLOWED_MODELS in ../codex.ts — both files exist during a
-// refactor in flight; whichever is wired via plugin/index.ts is the
-// active one. (Closes #1132 — GPT 5.6 missing from picker.)
-const ALLOWED_MODELS = new Set([
-  "gpt-5.3-codex-spark",
-  "gpt-5.4",
-  "gpt-5.4-mini",
-  "gpt-5.5",
-  "gpt-5.6",
-])
+const ALLOWED_MODELS = new Set(["gpt-5.5", "gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.4-mini"])
 
 interface PkceCodes {
   verifier: string

--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -12,7 +12,17 @@ const ISSUER = "https://auth.openai.com"
 const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
 const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
-const ALLOWED_MODELS = new Set(["gpt-5.5", "gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.4-mini"])
+// Non-codex ChatGPT-subscription (OAuth) allowlist. Keep in sync with
+// the sibling ALLOWED_MODELS in ../codex.ts — both files exist during a
+// refactor in flight; whichever is wired via plugin/index.ts is the
+// active one. (Closes #1132 — GPT 5.6 missing from picker.)
+const ALLOWED_MODELS = new Set([
+  "gpt-5.3-codex-spark",
+  "gpt-5.4",
+  "gpt-5.4-mini",
+  "gpt-5.5",
+  "gpt-5.6",
+])
 
 interface PkceCodes {
   verifier: string

--- a/packages/opencode/test/plugin/codex-allowlist.test.ts
+++ b/packages/opencode/test/plugin/codex-allowlist.test.ts
@@ -1,0 +1,64 @@
+// Regression coverage for the ChatGPT-subscription (OAuth) allowlist in
+// packages/opencode/src/plugin/codex.ts.
+//
+// Filed as issue #1132: GPT 5.6 was released but the allowlist stopped
+// at 5.4, so users on ChatGPT Pro/Plus (Codex tier) couldn't pick it in
+// the model picker even though the underlying models.dev catalog had it.
+//
+// Sibling test file test/plugin/codex.test.ts covers `plugin/openai/codex.ts`
+// (a parallel implementation currently NOT wired into plugin/index.ts).
+// This file covers the ACTIVE plugin at `plugin/codex.ts`.
+import { describe, expect, test } from "bun:test"
+import { OAUTH_ALLOWED_MODELS } from "../../src/plugin/codex"
+
+describe("codex OAUTH_ALLOWED_MODELS — subscription model picker regression barrier", () => {
+  test("issue #1132: gpt-5.6 is present", () => {
+    // If this test starts failing again, someone dropped gpt-5.6 from
+    // the allowlist without moving forward to a newer generation —
+    // rejecting a shipped OpenAI model users have subscription access to.
+    expect(OAUTH_ALLOWED_MODELS.has("gpt-5.6")).toBe(true)
+  })
+
+  test("gpt-5.5 is present (added alongside 5.6 for parity)", () => {
+    expect(OAUTH_ALLOWED_MODELS.has("gpt-5.5")).toBe(true)
+  })
+
+  test("prior generations stay allowlisted (no accidental removal)", () => {
+    for (const id of [
+      "gpt-5.1-codex",
+      "gpt-5.1-codex-max",
+      "gpt-5.1-codex-mini",
+      "gpt-5.2",
+      "gpt-5.2-codex",
+      "gpt-5.3-codex",
+      "gpt-5.4",
+      "gpt-5.4-mini",
+    ]) {
+      expect(OAUTH_ALLOWED_MODELS.has(id)).toBe(true)
+    }
+  })
+
+  test("allowlist does NOT include API-tier-only variants (defensive)", () => {
+    // Pro / luna / sol / terra variants ship on models.dev but are not
+    // confirmed available on the ChatGPT-subscription (Codex) tier —
+    // showing them in the picker would surface a request-time failure.
+    // If OpenAI extends subscription coverage to them, add them here
+    // deliberately (with a link to the announcement).
+    for (const id of [
+      "gpt-5.4-pro",
+      "gpt-5.5-pro",
+      "gpt-5.6-luna",
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+    ]) {
+      expect(OAUTH_ALLOWED_MODELS.has(id)).toBe(false)
+    }
+  })
+
+  test("allowlist size never regresses below current baseline", () => {
+    // A trip-wire: if someone truncates the allowlist by mistake (or in
+    // a bad rebase), the count drops and this test catches it before
+    // shipping. Bump when a real new addition lands.
+    expect(OAUTH_ALLOWED_MODELS.size).toBeGreaterThanOrEqual(10)
+  })
+})

--- a/packages/opencode/test/plugin/codex-allowlist.test.ts
+++ b/packages/opencode/test/plugin/codex-allowlist.test.ts
@@ -1,16 +1,19 @@
 // Regression coverage for the ChatGPT-subscription (OAuth) model filter
-// in packages/opencode/src/plugin/codex.ts (the ACTIVE plugin wired via
-// plugin/index.ts). The sibling file plugin/openai/codex.ts is an
-// in-progress refactor that reuses ``shouldAllowOAuthModel`` from this
-// same module — so the filter behavior is tested once here.
+// in packages/opencode/src/plugin/codex.ts — the ACTIVE plugin wired
+// via plugin/index.ts.
 //
 // Filed as issue #1132: GPT 5.6 was released but the allowlist stopped
 // at 5.4, so users on ChatGPT Pro/Plus (Codex tier) couldn't pick it in
 // the model picker even though the underlying models.dev catalog had it.
 //
-// Sibling test file test/plugin/codex.test.ts covers the OAuth-flow +
-// JWT parsing internals of plugin/openai/codex.ts. This file covers
-// only the OAuth model-filter policy shared by both files.
+// Sibling file plugin/openai/codex.ts is an in-progress refactor of the
+// same plugin, currently NOT wired via plugin/index.ts, and NOT covered
+// by this file — it has its own separate ``ALLOWED_MODELS`` + a
+// ``parseFloat > 5.4`` fallback in its ``models()`` filter, and its
+// existing test file (test/plugin/codex.test.ts) already covers its
+// OAuth-flow + JWT parsing internals. When that refactor is wired,
+// adopting ``shouldAllowOAuthModel`` here (and expanding this file's
+// coverage to the newly-active filter) is followup work.
 import { describe, expect, test } from "bun:test"
 import { OAUTH_ALLOWED_MODELS, shouldAllowOAuthModel } from "../../src/plugin/codex"
 

--- a/packages/opencode/test/plugin/codex-allowlist.test.ts
+++ b/packages/opencode/test/plugin/codex-allowlist.test.ts
@@ -1,21 +1,24 @@
-// Regression coverage for the ChatGPT-subscription (OAuth) allowlist in
-// packages/opencode/src/plugin/codex.ts.
+// Regression coverage for the ChatGPT-subscription (OAuth) model filter
+// in packages/opencode/src/plugin/codex.ts (the ACTIVE plugin wired via
+// plugin/index.ts). The sibling file plugin/openai/codex.ts is an
+// in-progress refactor that reuses ``shouldAllowOAuthModel`` from this
+// same module — so the filter behavior is tested once here.
 //
 // Filed as issue #1132: GPT 5.6 was released but the allowlist stopped
 // at 5.4, so users on ChatGPT Pro/Plus (Codex tier) couldn't pick it in
 // the model picker even though the underlying models.dev catalog had it.
 //
-// Sibling test file test/plugin/codex.test.ts covers `plugin/openai/codex.ts`
-// (a parallel implementation currently NOT wired into plugin/index.ts).
-// This file covers the ACTIVE plugin at `plugin/codex.ts`.
+// Sibling test file test/plugin/codex.test.ts covers the OAuth-flow +
+// JWT parsing internals of plugin/openai/codex.ts. This file covers
+// only the OAuth model-filter policy shared by both files.
 import { describe, expect, test } from "bun:test"
-import { OAUTH_ALLOWED_MODELS } from "../../src/plugin/codex"
+import { OAUTH_ALLOWED_MODELS, shouldAllowOAuthModel } from "../../src/plugin/codex"
 
-describe("codex OAUTH_ALLOWED_MODELS — subscription model picker regression barrier", () => {
+describe("OAUTH_ALLOWED_MODELS — subscription model picker regression barrier", () => {
   test("issue #1132: gpt-5.6 is present", () => {
-    // If this test starts failing again, someone dropped gpt-5.6 from
-    // the allowlist without moving forward to a newer generation —
-    // rejecting a shipped OpenAI model users have subscription access to.
+    // If this fails again, someone dropped gpt-5.6 from the non-codex
+    // allowlist without moving forward to a newer generation — rejecting
+    // a shipped OpenAI model users have subscription access to.
     expect(OAUTH_ALLOWED_MODELS.has("gpt-5.6")).toBe(true)
   })
 
@@ -23,23 +26,23 @@ describe("codex OAUTH_ALLOWED_MODELS — subscription model picker regression ba
     expect(OAUTH_ALLOWED_MODELS.has("gpt-5.5")).toBe(true)
   })
 
-  test("prior generations stay allowlisted (no accidental removal)", () => {
-    for (const id of [
-      "gpt-5.1-codex",
-      "gpt-5.1-codex-max",
-      "gpt-5.1-codex-mini",
-      "gpt-5.2",
-      "gpt-5.2-codex",
-      "gpt-5.3-codex",
-      "gpt-5.4",
-      "gpt-5.4-mini",
-    ]) {
+  test("prior non-codex generations stay allowlisted (no accidental removal)", () => {
+    for (const id of ["gpt-5.2", "gpt-5.4", "gpt-5.4-mini"]) {
       expect(OAUTH_ALLOWED_MODELS.has(id)).toBe(true)
     }
   })
 
+  test("codex-tagged variants are NOT in the non-codex set (they're auto-allowed instead)", () => {
+    // The non-codex set is deliberately minimal — every codex-tagged id
+    // is auto-allowed by shouldAllowOAuthModel's `includes("codex")` check
+    // below, so listing them here would be redundant + a maintenance trap.
+    for (const id of ["gpt-5.1-codex", "gpt-5.2-codex", "gpt-5.3-codex"]) {
+      expect(OAUTH_ALLOWED_MODELS.has(id)).toBe(false)
+    }
+  })
+
   test("allowlist does NOT include API-tier-only variants (defensive)", () => {
-    // Pro / luna / sol / terra variants ship on models.dev but are not
+    // Pro / luna / sol / terra variants ship on models.dev but aren't
     // confirmed available on the ChatGPT-subscription (Codex) tier —
     // showing them in the picker would surface a request-time failure.
     // If OpenAI extends subscription coverage to them, add them here
@@ -56,9 +59,68 @@ describe("codex OAUTH_ALLOWED_MODELS — subscription model picker regression ba
   })
 
   test("allowlist size never regresses below current baseline", () => {
-    // A trip-wire: if someone truncates the allowlist by mistake (or in
+    // Trip-wire: if someone truncates the allowlist by mistake (or in
     // a bad rebase), the count drops and this test catches it before
     // shipping. Bump when a real new addition lands.
-    expect(OAUTH_ALLOWED_MODELS.size).toBeGreaterThanOrEqual(10)
+    expect(OAUTH_ALLOWED_MODELS.size).toBeGreaterThanOrEqual(5)
+  })
+})
+
+describe("shouldAllowOAuthModel — behavior of the filter itself", () => {
+  // Behavior-level coverage: even if a refactor stops passing
+  // OAUTH_ALLOWED_MODELS through, the filter function is what the
+  // loader actually calls, so this catches breakage the constant-only
+  // tests above would miss. (cubic P3 catch.)
+
+  test("allowlist members pass (spot-check each generation)", () => {
+    for (const id of ["gpt-5.2", "gpt-5.4", "gpt-5.4-mini", "gpt-5.5", "gpt-5.6"]) {
+      expect(shouldAllowOAuthModel(id)).toBe(true)
+    }
+  })
+
+  test("codex-tagged ids pass regardless of exact allowlist membership", () => {
+    // Any id containing "codex" auto-passes — covers gpt-5.1-codex,
+    // gpt-5.3-codex-spark, plus any future codex variant OpenAI ships.
+    for (const id of [
+      "gpt-5.1-codex",
+      "gpt-5.1-codex-max",
+      "gpt-5.1-codex-mini",
+      "gpt-5.2-codex",
+      "gpt-5.3-codex",
+      "gpt-5.3-codex-spark",
+      "gpt-5.3-codex-xhigh",
+      "codex-hypothetical-future-name",
+    ]) {
+      expect(shouldAllowOAuthModel(id)).toBe(true)
+    }
+  })
+
+  test("API-tier-only variants are rejected (the whole point of the filter)", () => {
+    // These are the models the previous parseFloat > 5.4 fallback in
+    // plugin/openai/codex.ts was incorrectly admitting; the shared
+    // filter must reject them so the picker stays honest about what
+    // the subscription actually accepts.
+    for (const id of [
+      "gpt-5.4-pro",
+      "gpt-5.4-nano",
+      "gpt-5.5-pro",
+      "gpt-5.6-luna",
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+    ]) {
+      expect(shouldAllowOAuthModel(id)).toBe(false)
+    }
+  })
+
+  test("completely unrelated ids are rejected", () => {
+    for (const id of [
+      "claude-3.5-sonnet",
+      "gemini-2.5-pro",
+      "gpt-4o",
+      "gpt-4-turbo",
+      "",
+    ]) {
+      expect(shouldAllowOAuthModel(id)).toBe(false)
+    }
   })
 })


### PR DESCRIPTION
## Summary

Fixes [altimate-code#1132](https://github.com/AltimateAI/altimate-code/issues/1132) — ChatGPT Pro/Plus (Codex tier) users could not pick **`gpt-5.6`** in the model picker even though OpenAI shipped it and the upstream `models.dev` catalog has it.

## Repro

1. Connect ChatGPT subscription via OAuth
2. Open the model picker under the openai provider
3. Only `gpt-5.1-codex` through `gpt-5.4-mini` show; `gpt-5.6` is absent

## Root cause

The OAuth loader in [`packages/opencode/src/plugin/codex.ts:412-416`](https://github.com/AltimateAI/altimate-code/blob/main/packages/opencode/src/plugin/codex.ts#L412) filters `provider.models` (which the build regenerates from `models.dev` and DOES contain `gpt-5.6`) against a **hard-coded allowlist**:

```ts
const allowedModels = new Set([
  "gpt-5.1-codex", "gpt-5.1-codex-max", "gpt-5.1-codex-mini",
  "gpt-5.2", "gpt-5.2-codex",
  "gpt-5.3-codex",
  "gpt-5.4", "gpt-5.4-mini",
])
for (const modelId of Object.keys(provider.models)) {
  if (modelId.includes("codex")) continue
  if (allowedModels.has(modelId)) continue
  delete provider.models[modelId]      // ← gpt-5.6 gets deleted here
}
```

The allowlist hadn't been bumped since gpt-5.4-mini, so every newer non-`codex` model — `gpt-5.5`, `gpt-5.6`, and their variants — gets deleted before it reaches the picker.

## Fix

- Add `gpt-5.5` + `gpt-5.6` to the allowlist. Matches the existing precedent of allowlisting the plain "main" version per release (`gpt-5.2`, `gpt-5.4`).
- Refactor the allowlist into an exported module-level `OAUTH_ALLOWED_MODELS` constant so it's unit-testable independently.
- **Not added** (deliberately): `gpt-5.4-pro`, `gpt-5.5-pro`, `gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-terra`. These show up on `models.dev` but aren't confirmed available on the ChatGPT-subscription (Codex) tier — showing them in the picker would surface as a request-time 4xx, not a UX improvement. Extend later once OpenAI announces subscription coverage.

## Also touched: `plugin/openai/codex.ts`

There's a sibling file `packages/opencode/src/plugin/openai/codex.ts` with its OWN parallel `ALLOWED_MODELS` set — appears to be an in-progress refactor of the same plugin (currently NOT wired via `plugin/index.ts`; the `./codex` import at [plugin/index.ts:14](https://github.com/AltimateAI/altimate-code/blob/main/packages/opencode/src/plugin/index.ts#L14) resolves to the file I fixed above, not the openai/ variant). Updated its allowlist for parity so the bug doesn't resurrect the moment that refactor lands.

## Regression barrier

New test at `packages/opencode/test/plugin/codex-allowlist.test.ts` asserts:
- `gpt-5.5` + `gpt-5.6` present (the issue this PR closes)
- Prior generations retained (no accidental removal)
- API-tier-only variants stay OUT of the allowlist (defensive)
- Allowlist size never regresses below 10 (trip-wire for bad rebases)

## Test plan

- [x] `bun test test/plugin/codex-allowlist.test.ts test/plugin/codex.test.ts` — 21/21 pass
- [x] `bun turbo typecheck` — clean
- [x] `Marker Guard` (`--strict` vs `origin/main`) — clean
- [ ] CI on this PR
- [ ] Once merged, ship in next release (probably v0.9.7); users on ChatGPT-subscription should see gpt-5.5 + gpt-5.6 in the picker

## Follow-ups (not in this PR)

- Reconcile the two `codex.ts` files. Having two parallel allowlists is a maintenance footgun; the winner needs to be picked and the other deleted.
- Consider a data-driven approach where the allowlist is sourced from a config file or an OpenAI-published capability endpoint, so new model releases don't require a code push. Filed as a note in-code but not tracked as an issue yet.

Closes #1132

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `gpt-5.5` and `gpt-5.6` to the ChatGPT-subscription (OAuth) model allowlist so Pro/Plus users can select them. Previously `gpt-5.6` was filtered out by a stale allowlist; now it appears while API-tier-only variants remain excluded.

- Centralizes the OAuth model filter as `OAUTH_ALLOWED_MODELS` + `shouldAllowOAuthModel` in `packages/opencode/src/plugin/codex.ts`; the loader now delegates to it. Auto-allows ids containing "codex"; the set enumerates only non-codex main/mini releases.
- Adds `packages/opencode/test/plugin/codex-allowlist.test.ts` for membership and filter behavior (with a size floor). Clarifies in-code comments and fixes the loader comment to avoid implying a shared policy with the unwired sibling `packages/opencode/src/plugin/openai/codex.ts` (which keeps its own `parseFloat > 5.4` filter).
- No migration; after release, ChatGPT-subscription users see `gpt-5.5` and `gpt-5.6` in the model picker.

<sup>Written for commit aa4a956b44e08de54208bce25105b07824eed710. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/1133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth model selection now supports all model IDs containing “codex,” including new variants.
  * Non-Codex models continue to be limited to the approved model list.

* **Bug Fixes**
  * Prevented API-only and unrelated models from being incorrectly included in OAuth model selection.
  * Improved filtering consistency so only supported models are available through OAuth.
  * Added safeguards to maintain reliable model selection as new Codex variants are introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->