### PR TITLE
fix: keep the GlobalBus emit override assignable to EventEmitter

### DIFF
--- a/packages/opencode/src/bus/global.ts
+++ b/packages/opencode/src/bus/global.ts
@@ -11,12 +11,24 @@ export type GlobalEvent = {
 class GlobalBusEmitter extends EventEmitter<{
   event: [GlobalEvent]
 }> {
-  override emit(eventName: "event", event: GlobalEvent): boolean {
-    if (event.payload && typeof event.payload === "object" && !("id" in event.payload)) {
+  // altimate_change start — upstream_fix: keep the override assignable to the base.
+  // `EventEmitter<T>` declares `emit` across several overloads, one of which is
+  // `(eventName: string | symbol, ...args: any[])`. An override has to be
+  // assignable to all of them, and a lone `(eventName: "event", event:
+  // GlobalEvent)` is not — newer `@types/node` rejects it with "Type 'any[]' is
+  // not assignable to type '[event: GlobalEvent]'", which fails `bun typecheck`
+  // and so blocks `git push` on unmodified code. The public overload keeps call
+  // sites typed; the implementation signature is what satisfies the base.
+  override emit(eventName: "event", event: GlobalEvent): boolean
+  override emit(eventName: string | symbol, ...args: any[]): boolean
+  override emit(eventName: string | symbol, ...args: any[]): boolean {
+    const event = args[0] as GlobalEvent | undefined
+    if (eventName === "event" && event?.payload && typeof event.payload === "object" && !("id" in event.payload)) {
       event.payload.id = event.payload.syncEvent?.id ?? Identifier.create("evt", "ascending")
     }
-    return super.emit(eventName, event)
+    return super.emit(eventName as "event", ...(args as [GlobalEvent]))
   }
+  // altimate_change end
 }
 
 export const GlobalBus = new GlobalBusEmitter()

--- a/packages/opencode/test/bus/global-emit.test.ts
+++ b/packages/opencode/test/bus/global-emit.test.ts
@@ -1,0 +1,57 @@
+// altimate_change start — upstream_fix: pin the override's assignability to the base.
+import { describe, expect, test } from "bun:test"
+import { GlobalBus, type GlobalEvent } from "@/bus/global"
+
+describe("GlobalBusEmitter.emit", () => {
+  // The regression this guards is a COMPILE error, not a runtime one: a lone
+  // `(eventName: "event", event: GlobalEvent)` override is not assignable to
+  // the base `EventEmitter<T>` overload set, which newer `@types/node` rejects
+  // with "Type 'any[]' is not assignable to type '[event: GlobalEvent]'". That
+  // failed `bun typecheck`, and so blocked `git push` via the pre-push hook, on
+  // code nobody had touched. This assignment only compiles while the override
+  // keeps the wide implementation signature, so `tsgo` fails if it is narrowed
+  // again — the test body below merely keeps the reference alive.
+  test("stays assignable to the base EventEmitter signature", () => {
+    const wide: (eventName: string | symbol, ...args: any[]) => boolean = GlobalBus.emit.bind(GlobalBus)
+    expect(typeof wide).toBe("function")
+  })
+
+  test("stamps an id onto a payload that has none", () => {
+    const seen: GlobalEvent[] = []
+    const on = (event: GlobalEvent) => void seen.push(event)
+    GlobalBus.on("event", on)
+    try {
+      GlobalBus.emit("event", { payload: { kind: "test" } })
+      expect(seen).toHaveLength(1)
+      expect(typeof seen[0]!.payload.id).toBe("string")
+      expect(seen[0]!.payload.id).toStartWith("evt")
+    } finally {
+      GlobalBus.off("event", on)
+    }
+  })
+
+  test("leaves an existing id alone", () => {
+    const seen: GlobalEvent[] = []
+    const on = (event: GlobalEvent) => void seen.push(event)
+    GlobalBus.on("event", on)
+    try {
+      GlobalBus.emit("event", { payload: { id: "evt_already_set" } })
+      expect(seen[0]!.payload.id).toBe("evt_already_set")
+    } finally {
+      GlobalBus.off("event", on)
+    }
+  })
+
+  test("prefers the syncEvent id when the payload has none", () => {
+    const seen: GlobalEvent[] = []
+    const on = (event: GlobalEvent) => void seen.push(event)
+    GlobalBus.on("event", on)
+    try {
+      GlobalBus.emit("event", { payload: { syncEvent: { id: "evt_from_sync" } } })
+      expect(seen[0]!.payload.id).toBe("evt_from_sync")
+    } finally {
+      GlobalBus.off("event", on)
+    }
+  })
+})
+// altimate_change end


### PR DESCRIPTION
### Issue for this PR

Closes #1165

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`GlobalBusEmitter` overrode `emit` with a single narrow signature:

```ts
override emit(eventName: "event", event: GlobalEvent): boolean
```

`EventEmitter<T>` declares `emit` across several overloads, one of them `(eventName: string | symbol, ...args: any[])`. An override must be assignable to all of them, and that narrow one is not. Newer `@types/node` rejects it with `Type 'any[]' is not assignable to type '[event: GlobalEvent]'`, which fails `bun typecheck` — and therefore blocks `git push` through the pre-push hook, on a file the contributor never touched.

The failure is indistinguishable from a real type error the contributor introduced, so the workaround people reach for is `git push --no-verify`, which disables the only pre-push gate the repo has.

This keeps the public overload so call sites stay typed exactly as before (26 of them across the repo), and widens only the *implementation* signature, which is the part that has to satisfy the base. Runtime behaviour is unchanged: an `"event"` payload without an `id` still gets one, still preferring `syncEvent.id`.

### How did you verify your code works?

The regression is a **compile** error, not a runtime one, so the test pins it with an assignment that only compiles while the wide signature stays:

```ts
const wide: (eventName: string | symbol, ...args: any[]) => boolean = GlobalBus.emit.bind(GlobalBus)
```

Reverting `global.ts` to the previous override and running `tsgo --noEmit` fails with the same assignability error the reports show:

```
test/bus/global-emit.test.ts(15,11): error TS2322:
  Type '(eventName: "event", event: GlobalEvent) => boolean' is not assignable to
  type '(eventName: string | symbol, ...args: any[]) => boolean'.
```

With the fix: **0 errors**. So `tsgo` fails if anyone narrows it again.

Also:
- `bun typecheck` — 13 tasks successful.
- `bun test test/bus test/server` — 289 pass, 0 fail.
- Three runtime tests covering id stamping, an id already present, and the `syncEvent.id` preference.
- Marker Guard passes.

**One caveat, stated plainly:** I could not reproduce the original failure locally. On a clean worktree at `origin/main` with the catalog-pinned `@types/node@24.12.2`, `typescript@7.29.7` and `@typescript/native-preview@7.0.0-dev.20251207.1`, `global.ts` typechecks clean — which also matches `main`'s CI, where the `TypeScript` job passes. What is demonstrated above is that the old override genuinely is not assignable to the base signature and the new one is, which is the root cause the reported error names. Whether a toolchain version skew is *also* in play is tracked separately in #1165 — this PR does not address that half.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fJ3X7pcGT4R9yzjsJnqsV


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `GlobalBusEmitter.emit` so it stays assignable to the base `EventEmitter` overload set, which unblocks `bun typecheck` and `git push` on untouched code.

Previously, the override had a single narrow signature that newer `@types/node` rejects. Now the implementation signature is widened while the public overload is preserved, so call sites keep their exact types. Runtime behavior is unchanged. Adds a compile-time test that fails if the wide signature is narrowed again.

Closes #1165.

<sup>Written for commit ac7c3bc4d23bc76e36e38f49434db5ef51059aa6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/1166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compatibility with standard event emitter usage and type checking.
  * Preserved existing event behavior, including automatic identifier assignment and synchronization identifier preference.

* **Tests**
  * Added coverage for event emitter compatibility, identifier assignment, existing identifier preservation, and synchronized event identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->