### PR TITLE
fix(scripts): declare minimatch at the repo root so the marker check runs in a fresh worktree

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "@typescript/native-preview": "catalog:",
         "glob": "13.0.5",
         "husky": "9.1.7",
+        "minimatch": "10.0.3",
         "oxlint": "1.60.0",
         "oxlint-tsgolint": "0.21.0",
         "prettier": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@typescript/native-preview": "catalog:",
     "glob": "13.0.5",
     "husky": "9.1.7",
+    "minimatch": "10.0.3",
     "oxlint": "1.60.0",
     "oxlint-tsgolint": "0.21.0",
     "prettier": "3.6.2",


### PR DESCRIPTION
### Issue for this PR

Closes #1176

### Type of change

- [x] Bug fix

### What does this PR do?

Declares `minimatch` in the root `devDependencies`.

`script/upstream/analyze.ts` imports `minimatch` (three call sites), but the script lives at the repo root, so it resolves against the root `node_modules`. The package was only declared in `packages/opencode/package.json`. In a fresh worktree the marker check therefore fails with `Cannot find package 'minimatch'` before it can evaluate anything — which is confusing, because the failure has nothing to do with the changes being checked.

One line, no behavior change.

### How did you verify your code works?

Reproduced and fixed in a clean worktree created off `main`:

- Before: `bun install` then `bun run script/upstream/analyze.ts --markers --base main --strict` → `Cannot find package 'minimatch'`.
- After: same sequence → `ok  All custom code in upstream-shared files is properly marked`.

### Screenshots / recordings

N/A

### Checklist

- [x] Verified in a clean worktree
- [x] No behavior change to shipped code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only dependency wiring for a root script; no changes to application or release artifacts.
> 
> **Overview**
> Adds **`minimatch` (10.0.3)** to the root **`devDependencies`** (and lockfile) so **`script/upstream/analyze.ts`** can resolve it when run from the repository root.
> 
> That script dynamically imports **`minimatch`** for glob-style **`keepOurs`** / **`skipFiles`** matching during upstream marker checks. The dependency lived only under **`packages/opencode`**, so a fresh worktree after **`bun install`** could fail with **`Cannot find package 'minimatch'`** before any marker logic ran. No runtime or shipped-product behavior changes—only dependency placement for root-level tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d559efbfdaa9aba1e69b22e46867136efea8f2a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declares `minimatch` at the repo root and commits the matching `bun.lock` entry so the upstream analyze marker check runs in a fresh worktree.

- `script/upstream/analyze.ts` imports `minimatch` but lives at the repo root, so a fresh checkout previously failed with `Cannot find package 'minimatch'` before the check could run, since the package was only declared in `packages/opencode`.
- Committing the lockfile entry keeps `bun install --frozen-lockfile` from rejecting a fresh install and a plain `bun install` from leaving a dirty tree. Closes #1176.

<sup>Written for commit d559efbfdaa9aba1e69b22e46867136efea8f2a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/1177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the `minimatch` development dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->