### PR TITLE
fix(core): prune dependency trees during startup scans

### DIFF
--- a/packages/core/src/util/glob.ts
+++ b/packages/core/src/util/glob.ts
@@ -46,9 +46,9 @@ export namespace Glob {
     "**/vendor/**",
     "**/coverage/**",
   ]
-  // altimate_change end
 
   /** Translate the wrapper contract to `glob` without dropping traversal ignores. */
+  // altimate_change end
   function toGlobOptions(options: Options): GlobOptions {
     return {
       cwd: options.cwd,

--- a/packages/core/src/util/glob.ts
+++ b/packages/core/src/util/glob.ts
@@ -2,13 +2,42 @@ import { glob, globSync, type GlobOptions } from "glob"
 import { minimatch } from "minimatch"
 
 export namespace Glob {
+  // altimate_change start — upstream_fix: restore the `ignore` option.
+  // Without it every `**/…` scan walks the entire tree (node_modules, .git,
+  // dist, …) and callers can only filter the *results*, after the directories
+  // have already been read. `glob` treats an ignore pattern ending in `/**` as
+  // "prune this subtree", so passing it through turns a full-tree walk into a
+  // source-tree walk. See DEFAULT_IGNORE below for the shared exclusion set.
   export interface Options {
     cwd?: string
     absolute?: boolean
     include?: "file" | "all"
     dot?: boolean
     symlink?: boolean
+    ignore?: string[]
   }
+
+  /**
+   * Directories that no project-tree scan should ever descend into: package
+   * manager stores, VCS metadata, and build output. Every pattern ends in
+   * `/**` so `glob` prunes the subtree instead of walking it and discarding
+   * the matches afterwards.
+   */
+  export const DEFAULT_IGNORE: readonly string[] = [
+    "**/node_modules/**",
+    "**/.git/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/.pnpm/**",
+    "**/target/**",
+    "**/.next/**",
+    "**/out/**",
+    "**/vendor/**",
+    "**/coverage/**",
+    "**/.venv/**",
+    "**/.turbo/**",
+  ]
+  // altimate_change end
 
   function toGlobOptions(options: Options): GlobOptions {
     return {
@@ -17,6 +46,9 @@ export namespace Glob {
       dot: options.dot,
       follow: options.symlink ?? false,
       nodir: options.include !== "all",
+      // altimate_change start — upstream_fix: pass `ignore` through so the walk is pruned
+      ignore: options.ignore,
+      // altimate_change end
     }
   }
 

--- a/packages/core/src/util/glob.ts
+++ b/packages/core/src/util/glob.ts
@@ -18,27 +18,37 @@ export namespace Glob {
   }
 
   /**
-   * Directories that no project-tree scan should ever descend into: package
-   * manager stores, VCS metadata, and build output. Every pattern ends in
-   * `/**` so `glob` prunes the subtree instead of walking it and discarding
-   * the matches afterwards.
+   * Dependency, VCS, and tool-cache trees that are never authored project
+   * content. Use this narrower set for content discovery that must still see
+   * user files under directories named `build`, `dist`, `out`, etc.
    */
-  export const DEFAULT_IGNORE: readonly string[] = [
+  export const DEPENDENCY_IGNORE: readonly string[] = [
     "**/node_modules/**",
     "**/.git/**",
+    "**/.pnpm/**",
+    "**/.venv/**",
+    "**/.turbo/**",
+  ]
+
+  /**
+   * Full generated/dependency exclusion set for discovery paths that already
+   * rejected these directories before traversal pruning was restored (notably
+   * MCP config discovery). Every pattern ends in `/**` so `glob` prunes the
+   * subtree instead of walking it and discarding the matches afterwards.
+   */
+  export const DEFAULT_IGNORE: readonly string[] = [
+    ...DEPENDENCY_IGNORE,
     "**/dist/**",
     "**/build/**",
-    "**/.pnpm/**",
     "**/target/**",
     "**/.next/**",
     "**/out/**",
     "**/vendor/**",
     "**/coverage/**",
-    "**/.venv/**",
-    "**/.turbo/**",
   ]
   // altimate_change end
 
+  /** Translate the wrapper contract to `glob` without dropping traversal ignores. */
   function toGlobOptions(options: Options): GlobOptions {
     return {
       cwd: options.cwd,

--- a/packages/core/src/util/glob.ts
+++ b/packages/core/src/util/glob.ts
@@ -24,6 +24,7 @@ export namespace Glob {
    */
   export const DEPENDENCY_IGNORE: readonly string[] = [
     "**/node_modules/**",
+    "**/vendor/**",
     "**/.git/**",
     "**/.pnpm/**",
     "**/.venv/**",
@@ -43,7 +44,6 @@ export namespace Glob {
     "**/target/**",
     "**/.next/**",
     "**/out/**",
-    "**/vendor/**",
     "**/coverage/**",
   ]
 

--- a/packages/core/test/util/glob.test.ts
+++ b/packages/core/test/util/glob.test.ts
@@ -50,6 +50,20 @@ describe("Glob.scan ignore", () => {
     expect(found).toEqual([".vscode/mcp.json", "src/mcp.json"])
   })
 
+  test("dependency ignore keeps project content under output-named directories", async () => {
+    const found = (
+      await Glob.scan("**/mcp.json", {
+        cwd: root,
+        absolute: true,
+        dot: true,
+        ignore: [...Glob.DEPENDENCY_IGNORE],
+      })
+    )
+      .map(rel)
+      .sort()
+    expect(found).toEqual([".vscode/mcp.json", "dist/mcp.json", "src/mcp.json"])
+  })
+
   test("scanSync honours ignore too", () => {
     const found = Glob.scanSync("**/mcp.json", {
       cwd: root,
@@ -85,6 +99,15 @@ describe("Glob.DEFAULT_IGNORE", () => {
   test("covers the package-manager, VCS and build output directories", () => {
     for (const dir of ["node_modules", ".git", "dist", "build", "target", ".venv"]) {
       expect(Glob.DEFAULT_IGNORE).toContain(`**/${dir}/**`)
+    }
+  })
+
+  test("the content-safe subset does not exclude user output directory names", () => {
+    for (const pattern of Glob.DEPENDENCY_IGNORE) {
+      expect(pattern.endsWith("/**")).toBe(true)
+    }
+    for (const dir of ["dist", "build", "out", "target", "vendor", "coverage"]) {
+      expect(Glob.DEPENDENCY_IGNORE).not.toContain(`**/${dir}/**`)
     }
   })
 })

--- a/packages/core/test/util/glob.test.ts
+++ b/packages/core/test/util/glob.test.ts
@@ -16,11 +16,13 @@ beforeAll(async () => {
   root = await mkdtemp(path.join(tmpdir(), "glob-ignore-"))
   await mkdir(path.join(root, "src"), { recursive: true })
   await mkdir(path.join(root, "node_modules", "pkg", ".vscode"), { recursive: true })
+  await mkdir(path.join(root, "vendor"), { recursive: true })
   await mkdir(path.join(root, "dist"), { recursive: true })
   await mkdir(path.join(root, ".vscode"), { recursive: true })
   await writeFile(path.join(root, ".vscode", "mcp.json"), "{}")
   await writeFile(path.join(root, "src", "mcp.json"), "{}")
   await writeFile(path.join(root, "node_modules", "pkg", ".vscode", "mcp.json"), "{}")
+  await writeFile(path.join(root, "vendor", "mcp.json"), "{}")
   await writeFile(path.join(root, "dist", "mcp.json"), "{}")
 })
 
@@ -33,7 +35,13 @@ const rel = (abs: string) => path.relative(root, abs).split(path.sep).join("/")
 describe("Glob.scan ignore", () => {
   test("without ignore, dependency and build trees are returned", async () => {
     const found = (await Glob.scan("**/mcp.json", { cwd: root, absolute: true, dot: true })).map(rel).sort()
-    expect(found).toEqual([".vscode/mcp.json", "dist/mcp.json", "node_modules/pkg/.vscode/mcp.json", "src/mcp.json"])
+    expect(found).toEqual([
+      ".vscode/mcp.json",
+      "dist/mcp.json",
+      "node_modules/pkg/.vscode/mcp.json",
+      "src/mcp.json",
+      "vendor/mcp.json",
+    ])
   })
 
   test("ignore excludes dependency and build trees but keeps source matches", async () => {
@@ -50,7 +58,7 @@ describe("Glob.scan ignore", () => {
     expect(found).toEqual([".vscode/mcp.json", "src/mcp.json"])
   })
 
-  test("dependency ignore keeps project content under output-named directories", async () => {
+  test("dependency ignore keeps output-named project content but prunes vendored trees", async () => {
     const found = (
       await Glob.scan("**/mcp.json", {
         cwd: root,
@@ -106,7 +114,8 @@ describe("Glob.DEFAULT_IGNORE", () => {
     for (const pattern of Glob.DEPENDENCY_IGNORE) {
       expect(pattern.endsWith("/**")).toBe(true)
     }
-    for (const dir of ["dist", "build", "out", "target", "vendor", "coverage"]) {
+    expect(Glob.DEPENDENCY_IGNORE).toContain("**/vendor/**")
+    for (const dir of ["dist", "build", "out", "target", "coverage"]) {
       expect(Glob.DEPENDENCY_IGNORE).not.toContain(`**/${dir}/**`)
     }
   })

--- a/packages/core/test/util/glob.test.ts
+++ b/packages/core/test/util/glob.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test, beforeAll, afterAll } from "bun:test"
+import { mkdtemp, mkdir, rm, writeFile } from "fs/promises"
+import { tmpdir } from "os"
+import path from "path"
+import { Glob } from "../../src/util/glob"
+
+// altimate_change start — regression cover for the dropped `ignore` option.
+// Without `ignore`, every `**/…` scan walks node_modules/.git/dist in full and
+// callers can only discard the matches afterwards — the directories have
+// already been read. These tests pin the plumbing and the prune-shaped default
+// pattern set that makes the walk cheap.
+
+let root: string
+
+beforeAll(async () => {
+  root = await mkdtemp(path.join(tmpdir(), "glob-ignore-"))
+  await mkdir(path.join(root, "src"), { recursive: true })
+  await mkdir(path.join(root, "node_modules", "pkg", ".vscode"), { recursive: true })
+  await mkdir(path.join(root, "dist"), { recursive: true })
+  await mkdir(path.join(root, ".vscode"), { recursive: true })
+  await writeFile(path.join(root, ".vscode", "mcp.json"), "{}")
+  await writeFile(path.join(root, "src", "mcp.json"), "{}")
+  await writeFile(path.join(root, "node_modules", "pkg", ".vscode", "mcp.json"), "{}")
+  await writeFile(path.join(root, "dist", "mcp.json"), "{}")
+})
+
+afterAll(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+const rel = (abs: string) => path.relative(root, abs).split(path.sep).join("/")
+
+describe("Glob.scan ignore", () => {
+  test("without ignore, dependency and build trees are returned", async () => {
+    const found = (await Glob.scan("**/mcp.json", { cwd: root, absolute: true, dot: true })).map(rel).sort()
+    expect(found).toEqual([".vscode/mcp.json", "dist/mcp.json", "node_modules/pkg/.vscode/mcp.json", "src/mcp.json"])
+  })
+
+  test("ignore excludes dependency and build trees but keeps source matches", async () => {
+    const found = (
+      await Glob.scan("**/mcp.json", {
+        cwd: root,
+        absolute: true,
+        dot: true,
+        ignore: [...Glob.DEFAULT_IGNORE],
+      })
+    )
+      .map(rel)
+      .sort()
+    expect(found).toEqual([".vscode/mcp.json", "src/mcp.json"])
+  })
+
+  test("scanSync honours ignore too", () => {
+    const found = Glob.scanSync("**/mcp.json", {
+      cwd: root,
+      absolute: true,
+      dot: true,
+      ignore: [...Glob.DEFAULT_IGNORE],
+    })
+      .map(rel)
+      .sort()
+    expect(found).toEqual([".vscode/mcp.json", "src/mcp.json"])
+  })
+
+  test("an explicit ignore list is honoured verbatim", async () => {
+    const found = (await Glob.scan("**/mcp.json", { cwd: root, absolute: true, dot: true, ignore: ["**/src/**"] })).map(
+      rel,
+    )
+    expect(found).not.toContain("src/mcp.json")
+    expect(found).toContain(".vscode/mcp.json")
+  })
+})
+
+describe("Glob.DEFAULT_IGNORE", () => {
+  // The whole point of the fix: `glob` prunes a subtree only when the ignore
+  // pattern ends in `/**`. A pattern like "**/node_modules" would filter the
+  // results and still walk the tree, which is the slow behaviour we removed.
+  test("every pattern ends in /** so the walk is pruned, not post-filtered", () => {
+    expect(Glob.DEFAULT_IGNORE.length).toBeGreaterThan(0)
+    for (const pattern of Glob.DEFAULT_IGNORE) {
+      expect(pattern.endsWith("/**")).toBe(true)
+    }
+  })
+
+  test("covers the package-manager, VCS and build output directories", () => {
+    for (const dir of ["node_modules", ".git", "dist", "build", "target", ".venv"]) {
+      expect(Glob.DEFAULT_IGNORE).toContain(`**/${dir}/**`)
+    }
+  })
+})
+// altimate_change end

--- a/packages/opencode/src/altimate/datamate-transport.ts
+++ b/packages/opencode/src/altimate/datamate-transport.ts
@@ -45,6 +45,7 @@ function extractServersMap(
  */
 async function findAllMcpJsonFiles(projectRootDir: string): Promise<string[]> {
   try {
+    const ignore = [...Glob.DEFAULT_IGNORE]
     const paths = await Glob.scan("**/mcp.json", {
       cwd: projectRootDir,
       absolute: true,
@@ -53,27 +54,16 @@ async function findAllMcpJsonFiles(projectRootDir: string): Promise<string[]> {
       // afterwards still reads every directory: on a monorepo with
       // node_modules installed that walk costs ~6 CPU-seconds per invocation
       // because it runs across the whole runtime I/O thread pool.
-      ignore: [...Glob.DEFAULT_IGNORE],
+      ignore,
     })
     // Belt and braces: keep the result filter so a pattern that slips past the
     // traversal prune (e.g. via a symlinked path) still never reaches
     // StdioClientTransport, which is handed `command` + `args` from whatever
     // mcp.json we discover.
-    const ignoredDirs = [
-      "node_modules",
-      ".git",
-      "dist",
-      "build",
-      ".pnpm",
-      "target",
-      ".next",
-      "out",
-      "vendor",
-      "coverage",
-      ".venv",
-      ".turbo",
-    ]
-    return paths.filter((p) => !ignoredDirs.some((dir) => p.includes(`/${dir}/`))).sort()
+    const toRelativeGlobPath = (file: string) => path.relative(projectRootDir, file).split(path.sep).join("/")
+    return paths
+      .filter((file) => !ignore.some((pattern) => Glob.match(pattern, toRelativeGlobPath(file))))
+      .sort()
   } catch {
     log.warn("findAllMcpJsonFiles: glob scan failed", { cwd: projectRootDir })
     return []
@@ -329,4 +319,3 @@ export async function syncDatamateUrlFromVscodeMcp(cwd: string): Promise<string[
   }
   return updated
 }
-

--- a/packages/opencode/src/altimate/datamate-transport.ts
+++ b/packages/opencode/src/altimate/datamate-transport.ts
@@ -49,11 +49,16 @@ async function findAllMcpJsonFiles(projectRootDir: string): Promise<string[]> {
       cwd: projectRootDir,
       absolute: true,
       dot: true,
+      // Prune dependency/build trees during traversal. Filtering the results
+      // afterwards still reads every directory: on a monorepo with
+      // node_modules installed that walk costs ~6 CPU-seconds per invocation
+      // because it runs across the whole runtime I/O thread pool.
+      ignore: [...Glob.DEFAULT_IGNORE],
     })
-    // Exclude build/dependency/output trees. command + args from a discovered
-    // mcp.json are passed to StdioClientTransport, so keep the scan to source the
-    // user actually authors and out of vendored/generated directories. The new core
-    // Glob.Options dropped the `ignore` field, so filter the results instead.
+    // Belt and braces: keep the result filter so a pattern that slips past the
+    // traversal prune (e.g. via a symlinked path) still never reaches
+    // StdioClientTransport, which is handed `command` + `args` from whatever
+    // mcp.json we discover.
     const ignoredDirs = [
       "node_modules",
       ".git",

--- a/packages/opencode/src/cli/cmd/check.ts
+++ b/packages/opencode/src/cli/cmd/check.ts
@@ -462,9 +462,9 @@ export const CheckCommand = cmd({
     let files: string[] = args.files ?? []
     if (files.length === 0) {
       console.error("No files specified, searching for **/*.{sql,ddl} in current directory...")
-      // Prune dependency/build trees: vendored SQL is not the user's SQL, and
-      // walking node_modules to find it burns seconds of CPU on a real repo.
-      const ignore = [...Glob.DEFAULT_IGNORE]
+      // Prune dependency stores without hiding authored SQL merely because a
+      // project uses a directory name such as build/, out/, or target/.
+      const ignore = [...Glob.DEPENDENCY_IGNORE]
       const sqls = await Glob.scan("**/*.sql", { cwd: process.cwd(), absolute: true, ignore })
       const ddls = await Glob.scan("**/*.ddl", { cwd: process.cwd(), absolute: true, ignore })
       files = [...new Set([...sqls, ...ddls])]

--- a/packages/opencode/src/cli/cmd/check.ts
+++ b/packages/opencode/src/cli/cmd/check.ts
@@ -462,8 +462,11 @@ export const CheckCommand = cmd({
     let files: string[] = args.files ?? []
     if (files.length === 0) {
       console.error("No files specified, searching for **/*.{sql,ddl} in current directory...")
-      const sqls = await Glob.scan("**/*.sql", { cwd: process.cwd(), absolute: true })
-      const ddls = await Glob.scan("**/*.ddl", { cwd: process.cwd(), absolute: true })
+      // Prune dependency/build trees: vendored SQL is not the user's SQL, and
+      // walking node_modules to find it burns seconds of CPU on a real repo.
+      const ignore = [...Glob.DEFAULT_IGNORE]
+      const sqls = await Glob.scan("**/*.sql", { cwd: process.cwd(), absolute: true, ignore })
+      const ddls = await Glob.scan("**/*.ddl", { cwd: process.cwd(), absolute: true, ignore })
       files = [...new Set([...sqls, ...ddls])]
     } else {
       // Expand globs in positional args

--- a/packages/opencode/src/mcp/discover.ts
+++ b/packages/opencode/src/mcp/discover.ts
@@ -316,27 +316,18 @@ export async function discoverExternalMcp(projectDir: string): Promise<{
   const toRel = (abs: string) => path.relative(projectDir, abs).split(path.sep).join("/")
   let mcpJsonFiles: string[] = []
   try {
-    // altimate_change start — Glob.scan dropped its `ignore` option in v1.17.9; filter
-    // the scan results manually against the same exclusion globs to preserve behavior.
-    const IGNORE_GLOBS = [
-      "**/node_modules/**",
-      "**/.git/**",
-      "**/dist/**",
-      "**/build/**",
-      "**/.pnpm/**",
-      "**/target/**",
-      "**/.next/**",
-      "**/out/**",
-      "**/vendor/**",
-      "**/coverage/**",
-      "**/.venv/**",
-      "**/.turbo/**",
-    ]
+    // altimate_change start — prune dependency/build trees during traversal.
+    // Filtering results after an unrestricted `**/mcp.json` walk still reads
+    // every directory in the project: on a monorepo with node_modules present
+    // that costs ~6 CPU-seconds per invocation, spread across the whole runtime
+    // I/O thread pool. The post-filter stays as defence in depth.
+    const IGNORE_GLOBS = [...Glob.DEFAULT_IGNORE]
     const scanned = (
       await Glob.scan("**/mcp.json", {
         cwd: projectDir,
         absolute: true,
         dot: true,
+        ignore: IGNORE_GLOBS,
       })
     ).filter((abs) => {
       const rel = toRel(abs)

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -393,10 +393,9 @@ export namespace Project {
       cwd: input.worktree,
       absolute: true,
       include: "file",
-      // altimate_change start — prune dependency/build trees; an unrestricted walk of
-      // the worktree costs seconds of CPU on a repo with node_modules installed, and a
-      // dependency's favicon is never the project icon anyway.
-      ignore: [...Glob.DEFAULT_IGNORE],
+      // altimate_change start — prune dependency stores while preserving icons
+      // intentionally committed or generated under build/, dist/, out/, etc.
+      ignore: [...Glob.DEPENDENCY_IGNORE],
       // altimate_change end
     })
     const shortest = matches.sort((a, b) => a.length - b.length)[0]
@@ -674,8 +673,8 @@ export namespace Project {
             cwd: input.worktree,
             absolute: true,
             include: "file",
-            // altimate_change start — prune dependency/build trees; see Project.discover above.
-            ignore: [...Glob.DEFAULT_IGNORE],
+            // altimate_change start — prune dependency stores; see Project.discover above.
+            ignore: [...Glob.DEPENDENCY_IGNORE],
             // altimate_change end
           }),
         )

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -393,6 +393,11 @@ export namespace Project {
       cwd: input.worktree,
       absolute: true,
       include: "file",
+      // altimate_change start — prune dependency/build trees; an unrestricted walk of
+      // the worktree costs seconds of CPU on a repo with node_modules installed, and a
+      // dependency's favicon is never the project icon anyway.
+      ignore: [...Glob.DEFAULT_IGNORE],
+      // altimate_change end
     })
     const shortest = matches.sort((a, b) => a.length - b.length)[0]
     if (!shortest) return
@@ -669,6 +674,9 @@ export namespace Project {
             cwd: input.worktree,
             absolute: true,
             include: "file",
+            // altimate_change start — prune dependency/build trees; see Project.discover above.
+            ignore: [...Glob.DEFAULT_IGNORE],
+            // altimate_change end
           }),
         )
         const shortest = matches.sort((a, b) => a.length - b.length)[0]

--- a/packages/opencode/test/cli/check-e2e.test.ts
+++ b/packages/opencode/test/cli/check-e2e.test.ts
@@ -215,6 +215,7 @@ describe("check command E2E", () => {
     await writeSql(tmpDir.dir, "build/model.sql", "SELECT 1;")
     await writeSql(tmpDir.dir, "out/schema.ddl", "CREATE TABLE t (id INT);")
     await writeSql(tmpDir.dir, "node_modules/pkg/vendored.sql", "SELECT 2;")
+    await writeSql(tmpDir.dir, "vendor/pkg/vendored.sql", "SELECT 3;")
 
     const r = await runHandler(baseArgs({ files: [], checks: "lint" }))
     const j = parseJson(r.stdout)

--- a/packages/opencode/test/cli/check-e2e.test.ts
+++ b/packages/opencode/test/cli/check-e2e.test.ts
@@ -211,6 +211,18 @@ function parseJson(stdout: string): any {
 // ===========================================================================
 
 describe("check command E2E", () => {
+  test("default discovery keeps output-directory SQL while pruning dependencies", async () => {
+    await writeSql(tmpDir.dir, "build/model.sql", "SELECT 1;")
+    await writeSql(tmpDir.dir, "out/schema.ddl", "CREATE TABLE t (id INT);")
+    await writeSql(tmpDir.dir, "node_modules/pkg/vendored.sql", "SELECT 2;")
+
+    const r = await runHandler(baseArgs({ files: [], checks: "lint" }))
+    const j = parseJson(r.stdout)
+
+    expect(j.files_checked).toBe(2)
+    expect(r.stderr).toContain("Found 2 SQL file(s)")
+  })
+
   test("runs lint on a single SQL file — JSON output", async () => {
     const file = await writeSql(tmpDir.dir, "model.sql", "SELECT * FROM users;")
 

--- a/packages/opencode/test/mcp/discover.test.ts
+++ b/packages/opencode/test/mcp/discover.test.ts
@@ -454,4 +454,31 @@ describe("discoverExternalMcp", () => {
   // NOTE: env-var interpolation in discover only applies to `env` and `headers`
   // fields (see resolveServerEnvVars in discover.ts), NOT to `command` args.
   // Tests for command-level interpolation were removed as invalid.
+
+  // altimate_change start — the `**/mcp.json` scan is now pruned during traversal
+  // instead of filtered afterwards. Pin that the exclusion still holds and that
+  // real project files are still discovered.
+  test("mcp.json inside dependency and build trees is not discovered", async () => {
+    await mkdir(path.join(tempDir, "node_modules/some-pkg/.vscode"), { recursive: true })
+    await writeFile(
+      path.join(tempDir, "node_modules/some-pkg/.vscode/mcp.json"),
+      JSON.stringify({ servers: { vendored: { command: "should-not-appear" } } }),
+    )
+    await mkdir(path.join(tempDir, "dist"), { recursive: true })
+    await writeFile(
+      path.join(tempDir, "dist/mcp.json"),
+      JSON.stringify({ servers: { built: { command: "should-not-appear" } } }),
+    )
+    await mkdir(path.join(tempDir, ".vscode"), { recursive: true })
+    await writeFile(
+      path.join(tempDir, ".vscode/mcp.json"),
+      JSON.stringify({ servers: { real: { command: "real-cmd" } } }),
+    )
+
+    const { servers: result } = await discoverExternalMcp(tempDir)
+    expect(result["vendored"]).toBeUndefined()
+    expect(result["built"]).toBeUndefined()
+    expect(result["real"]).toMatchObject({ type: "local", command: ["real-cmd"] })
+  })
+  // altimate_change end
 })

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -2,6 +2,7 @@ import { describe, expect } from "bun:test"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { Project } from "@/project/project"
 import { $ } from "bun"
+import { mkdir } from "fs/promises"
 import path from "path"
 import { tmpdirScoped } from "../fixture/fixture"
 import { GlobalBus } from "../../src/bus/global"
@@ -468,6 +469,29 @@ describe("Project.discover", () => {
       expect(updated!.icon?.url).toStartWith("data:")
       expect(updated!.icon?.url).toContain("base64")
       expect(updated!.icon?.color).toBeUndefined()
+    }),
+  )
+
+  it.live("keeps output-directory favicons while pruning dependency stores", () =>
+    Effect.gen(function* () {
+      const project = yield* Project.Service
+      const tmp = yield* tmpdirScoped({ git: true })
+      const result = yield* project.fromDirectory(tmp)
+      const dependencyPng = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x01])
+      const outputPng = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x02])
+
+      yield* Effect.promise(async () => {
+        await mkdir(path.join(tmp, "node_modules", "pkg"), { recursive: true })
+        await mkdir(path.join(tmp, "out"), { recursive: true })
+        await Bun.write(path.join(tmp, "node_modules", "pkg", "favicon.png"), dependencyPng)
+        await Bun.write(path.join(tmp, "out", "favicon.png"), outputPng)
+      })
+
+      yield* project.discover(result.project)
+
+      const updated = yield* project.get(result.project.id)
+      expect(updated?.icon?.url).toContain(outputPng.toString("base64"))
+      expect(updated?.icon?.url).not.toContain(dependencyPng.toString("base64"))
     }),
   )
 

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -472,19 +472,22 @@ describe("Project.discover", () => {
     }),
   )
 
-  it.live("keeps output-directory favicons while pruning dependency stores", () =>
+  it.live("keeps output-directory favicons while pruning dependency and vendor stores", () =>
     Effect.gen(function* () {
       const project = yield* Project.Service
       const tmp = yield* tmpdirScoped({ git: true })
       const result = yield* project.fromDirectory(tmp)
       const dependencyPng = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x01])
       const outputPng = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x02])
+      const vendorPng = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x03])
 
       yield* Effect.promise(async () => {
         await mkdir(path.join(tmp, "node_modules", "pkg"), { recursive: true })
-        await mkdir(path.join(tmp, "out"), { recursive: true })
+        await mkdir(path.join(tmp, "vendor"), { recursive: true })
+        await mkdir(path.join(tmp, "build", "assets"), { recursive: true })
         await Bun.write(path.join(tmp, "node_modules", "pkg", "favicon.png"), dependencyPng)
-        await Bun.write(path.join(tmp, "out", "favicon.png"), outputPng)
+        await Bun.write(path.join(tmp, "vendor", "favicon.png"), vendorPng)
+        await Bun.write(path.join(tmp, "build", "assets", "favicon.png"), outputPng)
       })
 
       yield* project.discover(result.project)
@@ -492,6 +495,7 @@ describe("Project.discover", () => {
       const updated = yield* project.get(result.project.id)
       expect(updated?.icon?.url).toContain(outputPng.toString("base64"))
       expect(updated?.icon?.url).not.toContain(dependencyPng.toString("base64"))
+      expect(updated?.icon?.url).not.toContain(vendorPng.toString("base64"))
     }),
   )
 

--- a/packages/opencode/test/release-validation/mcp-datamate-893-codex.test.ts
+++ b/packages/opencode/test/release-validation/mcp-datamate-893-codex.test.ts
@@ -160,12 +160,20 @@ describe("PR #893 datamate IDE transport selection", () => {
     })
   })
 
-  test("ignores vendored datamate mcp.json entries during transport selection", async () => {
+  test("ignores dependency and generated datamate configs before transport selection", async () => {
     await using project = await tmpdir()
     await writeJson(path.join(project.path, "node_modules/pkg/mcp.json"), {
       servers: { datamate: { url: "https://vendored.example.com/sse" } },
     })
-    await writeJson(path.join(project.path, ".vscode/mcp.json"), {
+    await writeJson(path.join(project.path, "build/mcp.json"), {
+      servers: { datamate: { url: "https://build-output.example.com/sse" } },
+    })
+    await writeJson(path.join(project.path, "dist/mcp.json"), {
+      servers: { datamate: { url: "https://dist-output.example.com/sse" } },
+    })
+    // Keep the authored config lexically last: without the broad exclusion,
+    // build/mcp.json would win the deterministic sorted-first selection.
+    await writeJson(path.join(project.path, "z-authored/mcp.json"), {
       servers: { datamate: { command: "datamate", args: ["start-stdio"] } },
     })
 


### PR DESCRIPTION
### Issue for this PR

Closes #1183

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Recursive startup scans were walking the whole project tree—including `node_modules`, `.git`, and generated output—and only filtering matching files afterward. On a dependency-installed monorepo, the two startup MCP scans alone consumed about 12.93 CPU-seconds per launch.

The root cause was that `Glob.Options` declared no `ignore` field and the wrapper did not pass one to `glob`. This PR restores that contract so callers can prune subtrees during traversal.

The final design uses two policies:

- `Glob.DEPENDENCY_IGNORE`: dependency, vendored, VCS, virtual-environment, and tool-cache trees. Content discovery uses this so authored SQL, DDL, and favicons under directories named `build`, `dist`, `out`, or `target` remain visible.
- `Glob.DEFAULT_IGNORE`: the dependency set plus generated/output directories. MCP discovery uses this stricter policy because discovered configuration can select local commands or remote endpoints.

Applied at four scan sites:

- Datamate MCP transport discovery
- External MCP config discovery
- Project favicon discovery
- Default `altimate-code check` SQL/DDL discovery

Both MCP consumers retain a defence-in-depth result filter. Datamate now derives that filter from the shared policy and normalizes relative paths to forward slashes before matching, removing its duplicated POSIX-only directory list.

### Review fixes included

This revision addresses every validated review comment, including the late vendor-policy warning:

- Output-directory favicons remain eligible while dependency favicons are pruned.
- Authored SQL/DDL under output-like directory names remains eligible while vendored SQL is pruned.
- Datamate traversal and post-filtering share one broad policy.
- `vendor/**` is now part of the narrow dependency policy and remains inherited by the broad policy; shared glob, default SQL/DDL, and favicon regressions cover it.

A direct Datamate regression makes malicious `node_modules`, `build`, and `dist` configs lexically earlier than a safe authored config and proves that only the authored transport wins.

### Performance evidence

Measured on a 16-core M4 with this repository and dependencies installed:

| Scan | Before | After |
| --- | ---: | ---: |
| `syncDatamateUrlFromVscodeMcp` | 10.32 CPU-s | 0.07 CPU-s |
| `discoverExternalMcp` | 2.61 CPU-s | 0.07 CPU-s |
| Combined | **12.93 CPU-s** | **0.14 CPU-s** |
| Raw `**/mcp.json` glob | 6.24 CPU-s | 0.06 CPU-s |

Whole-process development `serve` startup dropped from 21.3 CPU-s to 4.1 CPU-s before idle.

### Verification on final head

Final head: `22b3fdacadfb2b2b1237dc245b550bf5948f8bef`

- `bun test test/util` in `packages/core`: 35 passed, 0 failed.
- Project/check suites before the late policy correction: 180 passed, 0 failed. On final head, the directly affected suites pass 38 project and 89 check-command tests.
- MCP/Datamate suites: 56 passed, 3 skipped, 1 todo, 1 known pre-existing home-config isolation failure. Every directly relevant MCP/Datamate regression passed.
- `bun run typecheck`: 13/13 tasks passed, including the push hook.
- Targeted lint across all eight touched files: 0 errors.
- Council consensus: ship after a direct Datamate consumer regression; that gate is satisfied.
- Codex Security full-PR diff scan `7fb0f303-9139-4dff-88fb-bc42e00ea9d5`: complete coverage through `a3d21a957c`, 0 findings. Supplemental final-head scan `3cb61974-5908-4d90-962f-0a52478bc944` covers `a3d21a957c..22b3fdacad`, complete coverage, 0 findings. Marker Guard, require-markers, and typecheck pass on final head.
- All review threads are resolved.

### Known baseline limitations

- No release binary was rebuilt for the after measurements.
- No concurrent Linux reproduction was rerun for this PR.
- Performance measurements are macOS/arm64; the pruning mechanism is platform-independent.
- Full-repository lint currently reports 5,870 warnings and one unrelated baseline error, so touched files were linted separately.
- One release-validation test leaks the developer's real home MCP configuration; the same documented baseline failure remains unrelated to this diff.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
- [x] I have addressed and resolved all actionable review comments
- [x] I have completed consensus and security review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standard exclusion patterns for dependency, version-control, build, and virtual-environment directories.
  * Added support for custom exclusions during recursive file scans.

* **Improvements**
  * SQL, DDL, MCP configuration, and favicon discovery now skips dependency folders while preserving authored files in output directories.
  * Ignored subtrees are pruned earlier for more accurate and efficient scans.

* **Tests**
  * Added coverage for custom exclusions and consistent synchronous and asynchronous scanning behavior.
  * Added validation for discovery across dependency, generated, and authored configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> MCP and Datamate discovery still gate which local commands run; behavior is tightened with shared ignore policies and retained post-filters, but any glob policy mistake could miss or expose configs.
> 
> **Overview**
> Restores **`ignore` on `Glob.Options`** and forwards it to `glob`, so recursive `**/…` scans prune `node_modules`, `.git`, and build trees during traversal instead of walking the full tree and filtering matches afterward. That behavior had been dropped from the wrapper, which made startup MCP scans very expensive on dependency-installed monorepos.
> 
> Introduces shared **`Glob.DEPENDENCY_IGNORE`** (deps/VCS/tool caches only) and **`Glob.DEFAULT_IGNORE`** (deps plus `dist`, `build`, `target`, etc.), with patterns shaped as `/**/dir/**` so subtrees are pruned, not post-filtered.
> 
> **MCP discovery** (Datamate transport + external `discoverExternalMcp`) now passes `DEFAULT_IGNORE` into the scan and keeps a **`Glob.match` post-filter** so symlink edge cases still cannot surface vendored commands. Datamate drops its duplicated POSIX path-segment filter in favor of the shared policy.
> 
> **Content discovery** uses the narrower set: default **`check`** SQL/DDL globbing and **project favicon** scans skip dependency/vendor trees but still see files under output-style directory names (`build/`, `out/`, …).
> 
> Adds **core glob regression tests** plus consumer tests for check discovery, MCP exclusion, favicon selection, and Datamate transport when malicious configs appear earlier in sort order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22b3fdacadfb2b2b1237dc245b550bf5948f8bef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


