### PR TITLE
fix(drivers): name a location when the missing-driver error searched nothing

### DIFF
--- a/packages/drivers/src/resolve.ts
+++ b/packages/drivers/src/resolve.ts
@@ -90,11 +90,21 @@ export class DriverNotInstalledError extends Error {
 
   constructor(driver: DriverName, packages: readonly string[], searched: readonly string[]) {
     const label = DRIVER_LABELS[driver]
+    const installDir = driverInstallDir()
+    // `driverSearchRoots()` only returns directories that exist, so on a machine
+    // that has never installed a driver it returns nothing at all — the normal
+    // first-run state, given drivers are deliberately not shipped. That left the
+    // message ending in a bare "Searched 0 locations:" with nothing after the
+    // colon, which names nowhere and reads like a bug. Say plainly that there was
+    // nothing to search, and name the directory the install command creates.
+    const searchedLine = searched.length
+      ? `Searched ${searched.length} location${searched.length === 1 ? "" : "s"}: ${searched.join(", ")}`
+      : `Searched nothing: no driver directory exists yet, not even ${path.join(installDir, "node_modules")}.`
     super(
       `${label} driver not installed.\n` +
         `Install it with the warehouse_install_driver tool, or run:\n` +
-        `  npm install --prefix ${shellQuote(driverInstallDir())} ${packages.join(" ")}\n` +
-        `Searched ${searched.length} location${searched.length === 1 ? "" : "s"}: ${searched.join(", ")}`,
+        `  npm install --prefix ${shellQuote(installDir)} ${packages.join(" ")}\n` +
+        searchedLine,
     )
     this.name = "DriverNotInstalledError"
     this.driver = driver

--- a/packages/drivers/src/resolve.ts
+++ b/packages/drivers/src/resolve.ts
@@ -92,15 +92,13 @@ export class DriverNotInstalledError extends Error {
   constructor(driver: DriverName, packages: readonly string[], searched: readonly string[]) {
     const label = DRIVER_LABELS[driver]
     const installDir = driverInstallDir()
-    // `driverSearchRoots()` only returns directories that exist, so on a machine
-    // that has never installed a driver it returns nothing at all — the normal
-    // first-run state, given drivers are deliberately not shipped. That left the
-    // message ending in a bare "Searched 0 locations:" with nothing after the
-    // colon, which names nowhere and reads like a bug. Say plainly that there was
-    // nothing to search, and name the directory the install command creates.
+    // `driverSearchRoots()` only returns directories that exist, so a compiled
+    // first run can have no searchable roots at all. The old message then ended
+    // in a bare "Searched 0 locations:" with nothing after the colon. Describe
+    // only what the empty list proves and name the managed location users need.
     const searchedLine = searched.length
       ? `Searched ${searched.length} location${searched.length === 1 ? "" : "s"}: ${searched.join(", ")}`
-      : `Searched nothing: no driver directory exists yet, not even ${path.join(installDir, "node_modules")}.`
+      : `No searchable driver locations were found. Expected managed location: ${path.join(installDir, "node_modules")}.`
     super(
       `${label} driver not installed.\n` +
         `Install it with the warehouse_install_driver tool, or run:\n` +

--- a/packages/drivers/test/resolve-unit.test.ts
+++ b/packages/drivers/test/resolve-unit.test.ts
@@ -608,6 +608,31 @@ describe("manual-install hints are copy-pasteable", () => {
     expect(prefix!.startsWith("'") || prefix!.startsWith('"')).toBe(true)
   })
 
+  test("DriverNotInstalledError names a location when nothing was searched", () => {
+    process.env["ALTIMATE_DRIVER_DIR"] = path.join(path.sep, "tmp", "altimate-drivers-absent")
+
+    // The first-run state: no driver directory exists, so driverSearchRoots()
+    // returns nothing. The message must still name somewhere.
+    const err = new DriverNotInstalledError("duckdb", DRIVER_PACKAGES.duckdb, [])
+
+    expect(err.message).not.toContain("Searched 0 locations:")
+    expect(err.message).toContain("Searched nothing")
+    expect(err.message).toContain(path.join("altimate-drivers-absent", "node_modules"))
+    // Still distinguishable from a broken install, and still actionable.
+    expect(err.message).toContain("DuckDB driver not installed.")
+    expect(err.message).toContain("npm install --prefix")
+  })
+
+  test("DriverNotInstalledError lists the roots it did search", () => {
+    const roots = [path.join(path.sep, "a", "node_modules"), path.join(path.sep, "b", "node_modules")]
+
+    const err = new DriverNotInstalledError("duckdb", DRIVER_PACKAGES.duckdb, roots)
+
+    expect(err.message).toContain("Searched 2 locations:")
+    for (const root of roots) expect(err.message).toContain(root)
+    expect(err.message).not.toContain("Searched nothing")
+  })
+
   test("no source builds a --prefix hint without shellQuote", () => {
     // Structural, because the behavioural tests can only cover the sites someone
     // remembered to write a case for. This fails when a NEW unquoted hint is

--- a/packages/drivers/test/resolve-unit.test.ts
+++ b/packages/drivers/test/resolve-unit.test.ts
@@ -826,16 +826,18 @@ describe("manual-install hints are copy-pasteable", () => {
     expect(prefix!.startsWith("'") || prefix!.startsWith('"')).toBe(true)
   })
 
-  test("DriverNotInstalledError names a location when nothing was searched", () => {
-    process.env["ALTIMATE_DRIVER_DIR"] = path.join(path.sep, "tmp", "altimate-drivers-absent")
+  test("DriverNotInstalledError names a location for an empty searched list", () => {
+    const installDir = path.join(tmpRoot, "absent")
+    process.env["ALTIMATE_DRIVER_DIR"] = installDir
 
-    // The first-run state: no driver directory exists, so driverSearchRoots()
-    // returns nothing. The message must still name somewhere.
+    // Model the possible empty-root result directly. A unit-test checkout has
+    // legitimate executable/package roots, so forcing driverSearchRoots() to
+    // return [] here would be host-dependent.
     const err = new DriverNotInstalledError("duckdb", DRIVER_PACKAGES.duckdb, [])
 
     expect(err.message).not.toContain("Searched 0 locations:")
-    expect(err.message).toContain("Searched nothing")
-    expect(err.message).toContain(path.join("altimate-drivers-absent", "node_modules"))
+    expect(err.message).toContain("No searchable driver locations were found.")
+    expect(err.message).toContain(`Expected managed location: ${path.join(installDir, "node_modules")}.`)
     // Still distinguishable from a broken install, and still actionable.
     expect(err.message).toContain("DuckDB driver not installed.")
     expect(err.message).toContain("npm install --prefix")

--- a/packages/drivers/test/resolve-unit.test.ts
+++ b/packages/drivers/test/resolve-unit.test.ts
@@ -313,7 +313,9 @@ describe("loadOptionalDriver", () => {
   })
 
   test("throws DriverNotInstalledError naming the searched roots", async () => {
-    process.env["ALTIMATE_DRIVER_DIR"] = path.join(tmpRoot, "empty")
+    const managedRoot = path.join(tmpRoot, "empty", "node_modules")
+    fs.mkdirSync(managedRoot, { recursive: true })
+    process.env["ALTIMATE_DRIVER_DIR"] = path.dirname(managedRoot)
     delete process.env["ALTIMATE_BIN_DIR"]
     delete process.env["NODE_PATH"]
 
@@ -332,6 +334,7 @@ describe("loadOptionalDriver", () => {
     // target directory and no account of where we had looked.
     expect(err.message).toContain("--prefix")
     expect(err.message).toContain("Searched")
+    expect(err.message).toContain(managedRoot)
   })
 
   test("reports a disk-resolved package that throws on import as a load failure", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #1191.

This PR targets `fix/warehouse-driver-bootstrap` (#1122), not `main`; it builds on the optional-driver resolver introduced by that PR and includes the latest parent head.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When optional-driver resolution fails and `driverSearchRoots()` returns an empty list, the old error ended with a dangling `Searched 0 locations:` line. The first version of this PR improved that line but overclaimed that the driver directory itself did not exist.

The final wording states only what the empty list proves and still gives the user an actionable destination:

```text
DuckDB driver not installed.
Install it with the warehouse_install_driver tool, or run:
  npm install --prefix /home/user/.local/share/altimate-code/drivers duckdb
No searchable driver locations were found. Expected managed location: /home/user/.local/share/altimate-code/drivers/node_modules.
```

When roots exist, the existing `Searched N location(s): ...` message is unchanged. Resolution, root precedence, package selection, dynamic import, installation, and permissions are unchanged. In particular, the parent branch deliberately excludes project and ancestor `node_modules`; it retains the consent-gated managed root and explicitly configured/runtime roots.

### Review feedback addressed

The empty-list regression test explicitly models the constructor boundary. Forcing `driverSearchRoots()` to return `[]` in a unit-test checkout would be host-dependent because executable- or package-adjacent roots may legitimately exist.

A late review found the complementary portability problem in the older non-empty-root test: it asserted `Searched` without creating any root, so it could fail in a dependency-free checkout. The final test-only commit creates its own managed `node_modules` root, points `ALTIMATE_DRIVER_DIR` at its parent, and asserts that exact root. The direct-constructor test still covers the genuine empty-root wording.

Codebase graph tracing confirms that `loadOptionalDriver()` passes the exact `driverSearchRoots()` array to `DriverNotInstalledError` without transformation.

### Verification

| Gate | Result |
|---|---|
| Focused resolver tests | 68 pass, 0 fail |
| Combined `packages/drivers` full suite | 225 pass, 0 fail |
| Driver catalogue consistency | 7 pass, 0 fail |
| `bun run typecheck` | 13/13 successful |
| `git diff --check` | pass |
| Three-seat Council consensus review | unanimous ship-after-fix, high confidence |
| Codex Security exact-final-head diff scan | complete coverage, 0 reportable findings |

The source branch was synchronized with final #1122 head `c49149a26f` using a normal merge. Final reviewed/pushed head: `212f4546a7`. No rebase or force-push was used.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing error text only in the drivers package; no changes to resolution, install paths, or security-sensitive logic.
> 
> **Overview**
> When optional driver resolution fails and **`driverSearchRoots()`** returns no existing directories (common on a first compiled run), **`DriverNotInstalledError`** no longer ends with a useless **`Searched 0 locations:`** line. It now says that no searchable locations were found and points at the **expected managed `node_modules` path** under **`driverInstallDir()`**, while keeping the existing **`Searched N location(s): …`** wording when roots were actually checked.
> 
> The **`npm install --prefix`** hint still uses the same install directory (now via a single **`installDir`** variable). Resolver behavior is unchanged.
> 
> Tests cover the empty-**`searched`** message directly (host-independent), assert listed roots when **`searched`** is non-empty, and tighten the integration case so the error mentions the managed root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 212f4546a70255155f5efb4284517f3ab4d2271a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

