### PR TITLE
fix(drivers): stop a 2s deadline failing healthy DuckDB stores, and make a broken client say so

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,13 @@ jobs:
               - 'packages/opencode/test/altimate/warehouse-test-duckdb-e2e.test.ts'
               - 'packages/opencode/test/altimate/duckdb-lock-helper.ts'
               - 'packages/opencode/src/altimate/tools/warehouse-test.ts'
+              - 'packages/drivers/test/**'
+              # These govern whether the native DuckDB binding is fetched at all
+              # (`trustedDependencies`, and the pinned version). A change to them
+              # can break every real-DuckDB test while touching no test file.
+              - 'package.json'
+              - 'bun.lock'
+              - 'packages/drivers/package.json'
             dbt-tools:
               - 'packages/dbt-tools/**'
             installer:
@@ -294,6 +301,14 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      # `packages/drivers` declares no scripts and no job had it as a working
+      # directory, so its 141 unit tests — including the driver's lock, timeout
+      # and read-only regressions — never ran in CI at all. The main TypeScript
+      # job runs `bun test` from `packages/opencode` only.
+      - name: Run drivers unit suite
+        run: bun test --timeout 60000
+        working-directory: packages/drivers
+
       - name: Run local driver E2E (DuckDB, SQLite, PostgreSQL)
         run: bun test test/altimate/drivers-e2e.test.ts
         working-directory: packages/opencode
@@ -308,8 +323,14 @@ jobs:
       # whole-directory run these would silently exercise a fake. With
       # ALTIMATE_DUCKDB_E2E=1 a missing or mocked driver fails the step rather
       # than skipping it.
+      #
+      # `--timeout` is explicit because invoking `bun test` directly does not use
+      # the package's `test` script, so it would otherwise take the CLI default
+      # of 5000ms — shorter than both the driver's 30s default open budget and
+      # the lock helper's 30s readiness budget, which would reimpose exactly the
+      # kind of too-short outer deadline this PR removes.
       - name: Run DuckDB store-open E2E (real store, no mocks)
-        run: bun test test/altimate/duckdb-open-e2e.test.ts test/altimate/warehouse-test-duckdb-e2e.test.ts
+        run: bun test --timeout 90000 test/altimate/duckdb-open-e2e.test.ts test/altimate/warehouse-test-duckdb-e2e.test.ts
         working-directory: packages/opencode
         env:
           ALTIMATE_DUCKDB_E2E: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,18 @@ jobs:
           TEST_PG_PORT: "15432"
           TEST_PG_PASSWORD: testpass123
 
+      # Needs a dedicated process: four files in test/altimate install a
+      # top-level mock.module("@altimateai/drivers/duckdb", …), and Bun
+      # evaluates every test file's top level before running any test, so in a
+      # whole-directory run these would silently exercise a fake. With
+      # ALTIMATE_DUCKDB_E2E=1 a missing or mocked driver fails the step rather
+      # than skipping it.
+      - name: Run DuckDB store-open E2E (real store, no mocks)
+        run: bun test test/altimate/duckdb-open-e2e.test.ts test/altimate/warehouse-test-duckdb-e2e.test.ts
+        working-directory: packages/opencode
+        env:
+          ALTIMATE_DUCKDB_E2E: "1"
+
       - name: Run Docker driver E2E (MySQL, SQL Server, Redshift)
         run: bun test test/altimate/drivers-docker-e2e.test.ts
         working-directory: packages/opencode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,14 @@ jobs:
               - 'packages/opencode/test/altimate/drivers-mongodb-e2e.test.ts'
               - 'packages/opencode/test/altimate/drivers-clickhouse-e2e.test.ts'
               - 'packages/opencode/test/altimate/connections.test.ts'
+              # Run by the "DuckDB store-open E2E" step in the driver-e2e job.
+              # Without these, a PR touching only these files skips that job,
+              # and the main TypeScript job runs them with ALTIMATE_DUCKDB_E2E
+              # unset, which skips every test in them — no execution anywhere.
+              - 'packages/opencode/test/altimate/duckdb-open-e2e.test.ts'
+              - 'packages/opencode/test/altimate/warehouse-test-duckdb-e2e.test.ts'
+              - 'packages/opencode/test/altimate/duckdb-lock-helper.ts'
+              - 'packages/opencode/src/altimate/tools/warehouse-test.ts'
             dbt-tools:
               - 'packages/dbt-tools/**'
             installer:

--- a/bun.lock
+++ b/bun.lock
@@ -490,6 +490,7 @@
     "tree-sitter-powershell",
     "protobufjs",
     "web-tree-sitter",
+    "duckdb",
     "tree-sitter-bash",
   ],
   "patchedDependencies": {

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "printWidth": 120
   },
   "trustedDependencies": [
+    "duckdb",
     "esbuild",
     "node-pty",
     "protobufjs",

--- a/packages/drivers/src/duckdb.ts
+++ b/packages/drivers/src/duckdb.ts
@@ -17,10 +17,19 @@ import type { ConnectionConfig, Connector, ConnectorResult, ExecuteOptions, Sche
  */
 const DEFAULT_OPEN_TIMEOUT_MS = 30_000
 
+/**
+ * Largest delay `setTimeout` represents. A larger value overflows the timer's
+ * 32-bit signed delay and is clamped to 1ms, which would turn a deliberately
+ * huge budget into an immediate deadline — the exact failure this file exists
+ * to remove. Clamp instead, so an over-large budget still behaves like a very
+ * long one.
+ */
+const MAX_TIMER_MS = 2_147_483_647
+
 /** Read a positive, finite millisecond budget, or `undefined` if unusable. */
 function positiveMs(value: unknown): number | undefined {
   const n = typeof value === "number" ? value : Number(value)
-  return Number.isFinite(n) && n > 0 ? n : undefined
+  return Number.isFinite(n) && n > 0 ? Math.min(n, MAX_TIMER_MS) : undefined
 }
 
 function resolveOpenTimeoutMs(config: ConnectionConfig): number {
@@ -59,8 +68,7 @@ export async function connect(config: ConnectionConfig): Promise<Connector> {
       msg.includes("locked") ||
       msg.includes("conflicting lock") ||
       msg.includes("could not set lock") ||
-      msg.includes("sqlite_busy") ||
-      msg.includes("duckdb_locked")
+      msg.includes("sqlite_busy")
     )
   }
 
@@ -157,12 +165,19 @@ export async function connect(config: ConnectionConfig): Promise<Connector> {
           timeout = setTimeout(() => {
             if (!resolved) {
               resolved = true
+              // Nothing can reach this handle once the promise rejects. If the
+              // callback arrives later it closes the handle itself (see the
+              // `resolved` branch in onOpen); if it never arrives, that branch
+              // never runs, so close here too. Both paths are idempotent
+              // because closeQuietly swallows a double close.
+              closeQuietly()
               reject(
                 new Error(
                   `DuckDB store "${dbPath}" did not finish opening within ${openTimeoutMs}ms. ` +
                   `This is a client-side deadline in the DuckDB driver, not a fault in the store ` +
                   `— the open may simply be queued behind other work in this process. ` +
-                  `Raise it with ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS if the machine is loaded.`,
+                  `Raise the budget with this connection's open_timeout_ms (which takes ` +
+                  `priority) or ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS if the machine is loaded.`,
                 ),
               )
             }
@@ -192,6 +207,17 @@ export async function connect(config: ConnectionConfig): Promise<Connector> {
               retryErr instanceof Error ? retryErr : new Error(String(retryErr)),
             )
           }
+        } else if (isLockError(err) && dbPath !== ":memory:") {
+          // An explicit read-only open is NOT rescued by the retry above — and
+          // must not be: DuckDB's file lock is exclusive against read-only
+          // opens too, so re-opening READ_ONLY when we already asked for
+          // READ_ONLY would only repeat the same failure. It still has to be
+          // wrapped, because categorizeConnectionError matches the wrapper's
+          // "locked by another process" wording; the raw DuckDB text would be
+          // reported as an unclassified failure. An in-memory store is excluded
+          // for the same reason the retry excludes it: no other process can
+          // hold it, so the wrapper's text would be false.
+          throw wrapDuckDBError(err instanceof Error ? err : new Error(String(err)))
         } else {
           throw err
         }

--- a/packages/drivers/src/duckdb.ts
+++ b/packages/drivers/src/duckdb.ts
@@ -4,6 +4,34 @@
 
 import type { ConnectionConfig, Connector, ConnectorResult, ExecuteOptions, SchemaColumn } from "./types"
 
+// altimate_change start — configurable, generous open budget
+/**
+ * How long to wait for DuckDB to finish opening a store before giving up.
+ *
+ * This is a liveness guard, not a performance budget. Opening a store is
+ * dispatched to the libuv threadpool, so the wait covers queueing behind every
+ * other threadpool user in the process (fs, dns, crypto), not just DuckDB's own
+ * work. A busy agent process can therefore push a healthy open well past a
+ * second, and the previous hard-coded 2s ceiling turned that into an
+ * unrecoverable failure on a store that was fine.
+ */
+const DEFAULT_OPEN_TIMEOUT_MS = 30_000
+
+/** Read a positive, finite millisecond budget, or `undefined` if unusable. */
+function positiveMs(value: unknown): number | undefined {
+  const n = typeof value === "number" ? value : Number(value)
+  return Number.isFinite(n) && n > 0 ? n : undefined
+}
+
+function resolveOpenTimeoutMs(config: ConnectionConfig): number {
+  return (
+    positiveMs(config.open_timeout_ms) ??
+    positiveMs(globalThis.process?.env?.["ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS"]) ??
+    DEFAULT_OPEN_TIMEOUT_MS
+  )
+}
+// altimate_change end
+
 export async function connect(config: ConnectionConfig): Promise<Connector> {
   let duckdb: any
   try {
@@ -14,6 +42,9 @@ export async function connect(config: ConnectionConfig): Promise<Connector> {
   }
 
   const dbPath = (config.path as string) ?? ":memory:"
+  // altimate_change start — configurable open budget
+  const openTimeoutMs = resolveOpenTimeoutMs(config)
+  // altimate_change end
   let db: any
   let connection: any
 
@@ -35,10 +66,13 @@ export async function connect(config: ConnectionConfig): Promise<Connector> {
 
   function wrapDuckDBError(err: Error): Error {
     if (isLockError(err)) {
+      // Keep DuckDB's own text: it names the PID and executable holding the
+      // conflicting lock, which is the only way to find the other process.
       return new Error(
         `Database "${dbPath}" is locked by another process. ` +
-        `DuckDB does not support concurrent write access. ` +
-        `Close other connections to this file and try again.`,
+        `DuckDB takes an exclusive file lock, so a store already open ` +
+        `read-write elsewhere cannot be opened again — not even read-only. ` +
+        `Close the other connection and try again.\n${err.message || String(err)}`,
       )
     }
     return err
@@ -72,10 +106,15 @@ export async function connect(config: ConnectionConfig): Promise<Connector> {
           let timeout: ReturnType<typeof setTimeout> | undefined
           let instance: any
           // Sentinel for an open callback that fired synchronously (before
-          // `instance` was assigned): `undefined` = not yet fired, `null` =
-          // fired with success, `Error` = fired with failure. Replayed once
-          // `instance` exists.
-          let pendingOpen: Error | null | undefined
+          // `instance` was assigned), replayed once `instance` exists.
+          //
+          // This MUST be a value the callback can never supply. It used to be
+          // `undefined`, which is exactly what a success callback invoked with
+          // no arguments passes — so such a callback was recorded and then
+          // never replayed, the promise never settled, and the open failed on
+          // the deadline below with a timeout message that named nothing.
+          const NOT_FIRED = Symbol("duckdb-open-not-fired")
+          let pendingOpen: Error | null | typeof NOT_FIRED = NOT_FIRED
           const opts = accessMode ? { access_mode: accessMode } : undefined
           const closeQuietly = () => {
             try {
@@ -84,9 +123,12 @@ export async function connect(config: ConnectionConfig): Promise<Connector> {
               // best-effort cleanup of a half-open handle
             }
           }
-          const onOpen = (err: Error | null) => {
+          const onOpen = (err?: Error | null) => {
+            // Normalise a zero-argument success callback to `null` so it is
+            // never confused with "has not fired yet".
+            const outcome = err ?? null
             if (!instance) {
-              pendingOpen = err
+              pendingOpen = outcome
               return
             }
             if (resolved) {
@@ -95,15 +137,12 @@ export async function connect(config: ConnectionConfig): Promise<Connector> {
             }
             resolved = true
             if (timeout) clearTimeout(timeout)
-            if (err) {
+            if (outcome) {
               // Open failed — release the half-open handle so it doesn't leak.
+              // Reject with DuckDB's own error: callers classify it with
+              // isLockError(), and its text names the conflicting process.
               closeQuietly()
-              const msg = err.message || String(err)
-              if (msg.toLowerCase().includes("locked") || msg.includes("SQLITE_BUSY") || msg.includes("DUCKDB_LOCKED")) {
-                reject(new Error("DUCKDB_LOCKED"))
-              } else {
-                reject(err)
-              }
+              reject(outcome)
             } else {
               resolve(instance)
             }
@@ -111,16 +150,24 @@ export async function connect(config: ConnectionConfig): Promise<Connector> {
           instance = opts
             ? new duckdb.Database(dbPath, opts, onOpen)
             : new duckdb.Database(dbPath, onOpen)
-          // Bun: native callback may not fire; fall back after 2s. Arm the timer
-          // BEFORE replaying a synchronous callback so a sync resolve/reject can
-          // actually clear it (otherwise it lingers ~2s and delays process exit).
+          // Liveness guard against an open callback that never fires. Arm the
+          // timer BEFORE replaying a synchronous callback so a sync
+          // resolve/reject can actually clear it (otherwise it lingers and
+          // delays process exit).
           timeout = setTimeout(() => {
             if (!resolved) {
               resolved = true
-              reject(new Error(`Timed out opening DuckDB database "${dbPath}"`))
+              reject(
+                new Error(
+                  `DuckDB store "${dbPath}" did not finish opening within ${openTimeoutMs}ms. ` +
+                  `This is a client-side deadline in the DuckDB driver, not a fault in the store ` +
+                  `— the open may simply be queued behind other work in this process. ` +
+                  `Raise it with ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS if the machine is loaded.`,
+                ),
+              )
             }
-          }, 2000)
-          if (pendingOpen !== undefined) onOpen(pendingOpen)
+          }, openTimeoutMs)
+          if (pendingOpen !== NOT_FIRED) onOpen(pendingOpen)
         })
 
       // altimate_change start — honour an explicit read-only connection.

--- a/packages/drivers/src/duckdb.ts
+++ b/packages/drivers/src/duckdb.ts
@@ -32,12 +32,20 @@ function positiveMs(value: unknown): number | undefined {
   return Number.isFinite(n) && n > 0 ? Math.min(n, MAX_TIMER_MS) : undefined
 }
 
-function resolveOpenTimeoutMs(config: ConnectionConfig): number {
-  return (
-    positiveMs(config.open_timeout_ms) ??
-    positiveMs(globalThis.process?.env?.["ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS"]) ??
-    DEFAULT_OPEN_TIMEOUT_MS
-  )
+/**
+ * Where the budget came from, which decides how a caller should read a
+ * deadline failure: one the connection set is that connection's own doing and
+ * is fixed by changing it, while the default or a machine-wide env var firing
+ * says something about the machine instead.
+ */
+type TimeoutSource = "connection" | "env" | "default"
+
+function resolveOpenTimeoutMs(config: ConnectionConfig): { ms: number; source: TimeoutSource } {
+  const fromConfig = positiveMs(config.open_timeout_ms)
+  if (fromConfig !== undefined) return { ms: fromConfig, source: "connection" }
+  const fromEnv = positiveMs(globalThis.process?.env?.["ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS"])
+  if (fromEnv !== undefined) return { ms: fromEnv, source: "env" }
+  return { ms: DEFAULT_OPEN_TIMEOUT_MS, source: "default" }
 }
 // altimate_change end
 
@@ -52,7 +60,7 @@ export async function connect(config: ConnectionConfig): Promise<Connector> {
 
   const dbPath = (config.path as string) ?? ":memory:"
   // altimate_change start — configurable open budget
-  const openTimeoutMs = resolveOpenTimeoutMs(config)
+  const { ms: openTimeoutMs, source: openTimeoutSource } = resolveOpenTimeoutMs(config)
   // altimate_change end
   let db: any
   let connection: any
@@ -176,8 +184,15 @@ export async function connect(config: ConnectionConfig): Promise<Connector> {
                   `DuckDB store "${dbPath}" did not finish opening within ${openTimeoutMs}ms. ` +
                   `This is a client-side deadline in the DuckDB driver, not a fault in the store ` +
                   `— the open may simply be queued behind other work in this process. ` +
-                  `Raise the budget with this connection's open_timeout_ms (which takes ` +
-                  `priority) or ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS if the machine is loaded.`,
+                  (openTimeoutSource === "connection"
+                    ? // Named so callers can tell a self-inflicted deadline from one
+                      // they did not choose. Registry.categorizeConnectionError keys
+                      // off this phrase to report it as configuration rather than as
+                      // a broken client.
+                      `This deadline was set on this connection as open_timeout_ms=${openTimeoutMs}; ` +
+                      `raise or remove it.`
+                    : `Raise the budget with this connection's open_timeout_ms (which takes ` +
+                      `priority) or ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS if the machine is loaded.`),
                 ),
               )
             }

--- a/packages/drivers/src/duckdb.ts
+++ b/packages/drivers/src/duckdb.ts
@@ -74,8 +74,14 @@ export async function connect(config: ConnectionConfig): Promise<Connector> {
     const msg = (err instanceof Error ? err.message : String(err)).toLowerCase()
     return (
       msg.includes("locked") ||
-      msg.includes("conflicting lock") ||
-      msg.includes("could not set lock") ||
+      // Both halves, not either. "could not set lock" on its own also covers
+      // non-contention failures — an unsupported filesystem lock, a permissions
+      // problem — and matching it alone would wrap those as "locked by another
+      // process", fabricating a wrapper that Registry.categorizeConnectionError
+      // then trusts as a recoverable `store_locked`. That would send the reader
+      // hunting for a process to close while hiding the real filesystem fault.
+      // Registry's raw matcher already requires both; these must agree.
+      (msg.includes("could not set lock") && msg.includes("conflicting lock")) ||
       msg.includes("sqlite_busy")
     )
   }

--- a/packages/drivers/src/duckdb.ts
+++ b/packages/drivers/src/duckdb.ts
@@ -18,9 +18,23 @@ export async function connect(config: ConnectionConfig): Promise<Connector> {
   let connection: any
 
   // altimate_change start — improve DuckDB error messages
+  // Real DuckDB lock failures read "Could not set lock on file ... Conflicting
+  // lock is held", which contains "lock" but never "locked". Matching only
+  // "locked"/"DUCKDB_LOCKED" therefore missed every genuine lock collision, so
+  // the read-only retry never fired and concurrent readers just failed.
+  function isLockError(err: unknown): boolean {
+    const msg = (err instanceof Error ? err.message : String(err)).toLowerCase()
+    return (
+      msg.includes("locked") ||
+      msg.includes("conflicting lock") ||
+      msg.includes("could not set lock") ||
+      msg.includes("sqlite_busy") ||
+      msg.includes("duckdb_locked")
+    )
+  }
+
   function wrapDuckDBError(err: Error): Error {
-    const msg = err.message || String(err)
-    if (msg.toLowerCase().includes("locked") || msg.includes("SQLITE_BUSY") || msg.includes("DUCKDB_LOCKED")) {
+    if (isLockError(err)) {
       return new Error(
         `Database "${dbPath}" is locked by another process. ` +
         `DuckDB does not support concurrent write access. ` +
@@ -109,10 +123,20 @@ export async function connect(config: ConnectionConfig): Promise<Connector> {
           if (pendingOpen !== undefined) onOpen(pendingOpen)
         })
 
+      // altimate_change start — honour an explicit read-only connection.
+      // DuckDB takes an EXCLUSIVE file lock when opened read-write, so N
+      // concurrent readers of one .duckdb file leave N-1 of them failing to
+      // connect at all. Opening READ_ONLY up front is the only way several
+      // processes can share a file, and it is what a caller that declared
+      // `readonly` asked for. Relying on the lock-error retry below is not
+      // equivalent: it is best-effort string matching, and it wastes a full
+      // open attempt per connection.
+      const wantReadOnly = config.readonly === true && dbPath !== ":memory:"
       try {
-        db = await tryConnect()
+        db = await tryConnect(wantReadOnly ? "READ_ONLY" : undefined)
       } catch (err: any) {
-        if (err.message === "DUCKDB_LOCKED" && dbPath !== ":memory:") {
+        // altimate_change end
+        if (isLockError(err) && !wantReadOnly && dbPath !== ":memory:") {
           // Retry in read-only mode — allows concurrent reads
           try {
             db = await tryConnect("READ_ONLY")

--- a/packages/drivers/test/driver-security.test.ts
+++ b/packages/drivers/test/driver-security.test.ts
@@ -189,6 +189,50 @@ describe("DuckDB driver", () => {
       await connector.close()
     })
 
+    test("retries with READ_ONLY when the first open fails with DuckDB's real lock text", async () => {
+      // The other retry test drives a fabricated "DUCKDB_LOCKED: file is locked"
+      // string, which the driver's original `.includes("locked")` check already
+      // matched. Only this one uses the message DuckDB actually emits, so only
+      // this one would catch a regression that broke detection of a real lock
+      // collision on the retry path.
+      let attempts = 0
+      const accessModes: Array<string | undefined> = []
+      mock.module("duckdb", () => ({
+        default: {
+          Database: class {
+            constructor(_path: string, optsOrCb: any, cb?: (err: Error | null) => void) {
+              const opts = typeof optsOrCb === "function" ? undefined : optsOrCb
+              const done = openCallback(optsOrCb, cb)
+              accessModes.push(opts?.access_mode)
+              attempts++
+              if (attempts === 1) setTimeout(() => done(new Error(REAL_DUCKDB_LOCK_ERROR)), 0)
+              else setTimeout(() => done(null), 0)
+            }
+            connect() {
+              return {
+                all: (_sql: string, cb: (err: Error | null, rows: any[]) => void) => {
+                  cb(null, [{ result: 1 }])
+                },
+              }
+            }
+            close(cb: any) {
+              if (cb) cb(null)
+            }
+          },
+        },
+      }))
+
+      const { connect } = await import("../src/duckdb")
+      const connector = await connect({ type: "duckdb", path: "/tmp/test.duckdb" })
+      await connector.connect()
+
+      expect(attempts).toBe(2)
+      expect(accessModes[0]).toBeUndefined()
+      expect(accessModes[1]).toBe("READ_ONLY")
+
+      await connector.close()
+    })
+
     test("wraps a lock error on an explicitly read-only open, and does not retry it", async () => {
       // A caller that set `readonly` already gets READ_ONLY on the first open,
       // so there is nothing for the retry to try differently — DuckDB's file

--- a/packages/drivers/test/driver-security.test.ts
+++ b/packages/drivers/test/driver-security.test.ts
@@ -54,7 +54,10 @@ describe("DuckDB driver", () => {
         expect.unreachable("Should have thrown")
       } catch (e: any) {
         expect(e.message).toContain("locked by another process")
-        expect(e.message).toContain("does not support concurrent write access")
+        expect(e.message).toContain("exclusive file lock")
+        // DuckDB's own text names the PID holding the lock, so it must survive
+        // being wrapped rather than being replaced by the friendly summary.
+        expect(e.message).toContain("SQLITE_BUSY: database is locked")
       }
 
       await connector.close()

--- a/packages/drivers/test/driver-security.test.ts
+++ b/packages/drivers/test/driver-security.test.ts
@@ -136,6 +136,13 @@ describe("DuckDB driver", () => {
     })
   })
 
+  // Verbatim DuckDB output for a cross-process lock collision. It contains
+  // "lock" but never "locked", which is why the driver's original
+  // `.includes("locked")` check never matched a real collision.
+  const REAL_DUCKDB_LOCK_ERROR =
+    'IO Error: Could not set lock on file "/tmp/test.duckdb": Conflicting lock is held in ' +
+    "/usr/bin/node (PID 65001) by user someone."
+
   describe("connect retry with READ_ONLY", () => {
     test("retries with READ_ONLY when file DB is locked on initial connect", async () => {
       let connectAttempts = 0
@@ -180,6 +187,51 @@ describe("DuckDB driver", () => {
       expect(accessModes[1]).toBe("READ_ONLY")
 
       await connector.close()
+    })
+
+    test("wraps a lock error on an explicitly read-only open, and does not retry it", async () => {
+      // A caller that set `readonly` already gets READ_ONLY on the first open,
+      // so there is nothing for the retry to try differently — DuckDB's file
+      // lock is exclusive against read-only opens too. The failure must still
+      // be *labelled* a lock, though: consumers classify it by the wrapper's
+      // "locked by another process" wording, and this branch used to rethrow
+      // DuckDB's raw text, which contains "lock" but never "locked".
+      let attempts = 0
+      const accessModes: Array<string | undefined> = []
+      mock.module("duckdb", () => ({
+        default: {
+          Database: class {
+            constructor(_path: string, optsOrCb: any, cb?: (err: Error | null) => void) {
+              const opts = typeof optsOrCb === "function" ? undefined : optsOrCb
+              accessModes.push(opts?.access_mode)
+              attempts++
+              setTimeout(() => openCallback(optsOrCb, cb)(new Error(REAL_DUCKDB_LOCK_ERROR)), 0)
+            }
+            connect() {
+              return {}
+            }
+            close(cb: any) {
+              if (cb) cb(null)
+            }
+          },
+        },
+      }))
+
+      const { connect } = await import("../src/duckdb")
+      const connector = await connect({ type: "duckdb", path: "/tmp/test.duckdb", readonly: true })
+
+      try {
+        await connector.connect()
+        expect.unreachable("Should have thrown")
+      } catch (e: any) {
+        expect(e.message).toContain("locked by another process")
+        // DuckDB's own text survives: it names the PID holding the lock.
+        expect(e.message).toContain("Conflicting lock is held")
+      }
+
+      // Exactly one attempt, and it asked for READ_ONLY up front.
+      expect(attempts).toBe(1)
+      expect(accessModes).toEqual(["READ_ONLY"])
     })
 
     test("does not retry in-memory DB on lock error", async () => {

--- a/packages/drivers/test/driver-security.test.ts
+++ b/packages/drivers/test/driver-security.test.ts
@@ -189,6 +189,50 @@ describe("DuckDB driver", () => {
       await connector.close()
     })
 
+    test("does not claim a non-contention lock failure as a foreign lock", async () => {
+      // "Could not set lock" without "Conflicting lock" is a filesystem fault,
+      // not contention. Wrapping it as "locked by another process" would send
+      // the reader after a process to close and hide the real cause — and the
+      // registry would trust that fabricated wrapper as recoverable.
+      let attempts = 0
+      mock.module("duckdb", () => ({
+        default: {
+          Database: class {
+            constructor(_path: string, optsOrCb: any, cb?: (err: Error | null) => void) {
+              attempts++
+              setTimeout(
+                () =>
+                  openCallback(optsOrCb, cb)(
+                    new Error('IO Error: Could not set lock on file "/tmp/test.duckdb": Operation not supported'),
+                  ),
+                0,
+              )
+            }
+            connect() {
+              return {}
+            }
+            close(cb: any) {
+              if (cb) cb(null)
+            }
+          },
+        },
+      }))
+
+      const { connect } = await import("../src/duckdb")
+      const connector = await connect({ type: "duckdb", path: "/tmp/test.duckdb" })
+
+      try {
+        await connector.connect()
+        expect.unreachable("Should have thrown")
+      } catch (e: any) {
+        expect(e.message).toContain("Operation not supported")
+        expect(e.message).not.toContain("locked by another process")
+      }
+
+      // And it is not treated as contention, so no read-only retry is spent.
+      expect(attempts).toBe(1)
+    })
+
     test("retries with READ_ONLY when the first open fails with DuckDB's real lock text", async () => {
       // The other retry test drives a fabricated "DUCKDB_LOCKED: file is locked"
       // string, which the driver's original `.includes("locked")` check already

--- a/packages/opencode/src/altimate/native/connections/registry.ts
+++ b/packages/opencode/src/altimate/native/connections/registry.ts
@@ -282,6 +282,12 @@ export function detectAuthMethod(config: ConnectionConfig | null | undefined): s
 export function categorizeConnectionError(e: unknown): string {
   const msg = String(e).toLowerCase()
   if (msg.includes("not installed") || msg.includes("cannot find module")) return "driver_missing"
+  // altimate_change start — categories for local-client faults
+  // Checked before the generic "timeout"/"not found" rules below, which are
+  // about the remote warehouse and would otherwise swallow these.
+  if (msg.includes("did not finish opening")) return "driver_open_timeout"
+  if (msg.includes("locked by another process")) return "store_locked"
+  // altimate_change end
   if (msg.includes("password") || msg.includes("authentication") || msg.includes("unauthorized") || msg.includes("jwt"))
     return "auth_failed"
   if (msg.includes("timeout") || msg.includes("timed out")) return "timeout"
@@ -289,6 +295,19 @@ export function categorizeConnectionError(e: unknown): string {
   if (msg.includes("config") || msg.includes("not found") || msg.includes("missing")) return "config_error"
   return "other"
 }
+
+// altimate_change start — distinguish infrastructure faults from config faults
+/**
+ * Categories where the local client is broken, not the connection's config and
+ * not the remote warehouse. A caller cannot fix these by correcting
+ * credentials, and a harness must not score them as a task failure.
+ */
+const INFRASTRUCTURE_CATEGORIES = new Set(["driver_missing", "driver_open_timeout", "store_locked"])
+
+export function isInfrastructureFailure(category: string): boolean {
+  return INFRASTRUCTURE_CATEGORIES.has(category)
+}
+// altimate_change end
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -405,7 +424,9 @@ export function list(): { warehouses: WarehouseInfo[] } {
 }
 
 /** Test a connection by running a simple query. */
-export async function test(name: string): Promise<{ connected: boolean; error?: string }> {
+export async function test(
+  name: string,
+): Promise<{ connected: boolean; error?: string; error_category?: string; infrastructure?: boolean }> {
   try {
     const connector = await get(name)
     const config = configs.get(name)
@@ -422,7 +443,15 @@ export async function test(name: string): Promise<{ connected: boolean; error?: 
     }
     return { connected: true }
   } catch (e) {
-    return { connected: false, error: String(e) }
+    // altimate_change start — report *why* the test failed, not just that it did
+    const category = categorizeConnectionError(e)
+    return {
+      connected: false,
+      error: String(e),
+      error_category: category,
+      infrastructure: isInfrastructureFailure(category),
+    }
+    // altimate_change end
   }
 }
 

--- a/packages/opencode/src/altimate/native/connections/registry.ts
+++ b/packages/opencode/src/altimate/native/connections/registry.ts
@@ -285,15 +285,24 @@ export function categorizeConnectionError(e: unknown): string {
   // altimate_change start — categories for local-client faults
   // Checked before the generic "timeout"/"not found" rules below, which are
   // about the remote warehouse and would otherwise swallow these.
-  if (msg.includes("did not finish opening")) return "driver_open_timeout"
-  // "locked by another process" is the DuckDB driver's own wrapper. The other
-  // two are DuckDB's raw text ("Could not set lock on file …: Conflicting lock
-  // is held"), matched here as well so a lock that reaches this function
-  // unwrapped is still classified rather than falling through to "other".
+  if (msg.includes("did not finish opening")) {
+    // A deadline the connection itself set is the connection's fault, and the
+    // remedy is to raise or drop that setting. Reporting it as a broken client
+    // — "stop and report, nothing about your config is wrong" — is the exact
+    // mirror of the confusion this categorisation exists to remove. Only a
+    // deadline the caller did not choose per-connection is infrastructure.
+    return msg.includes("deadline was set on this connection") ? "config_error" : "driver_open_timeout"
+  }
+  // "locked by another process" is the DuckDB driver's own wrapper. The second
+  // clause is DuckDB's raw text ("Could not set lock on file …: Conflicting
+  // lock is held"), matched here as well so a lock that reaches this function
+  // unwrapped is still classified rather than falling through to "other". Both
+  // halves of that clause are required: "could not set lock" on its own is
+  // generic enough to appear in an unrelated remote error, and claiming it
+  // would tell the user to close a local process over a remote fault.
   if (
     msg.includes("locked by another process") ||
-    msg.includes("conflicting lock") ||
-    msg.includes("could not set lock")
+    (msg.includes("could not set lock") && msg.includes("conflicting lock"))
   )
     return "store_locked"
   // altimate_change end

--- a/packages/opencode/src/altimate/native/connections/registry.ts
+++ b/packages/opencode/src/altimate/native/connections/registry.ts
@@ -286,7 +286,16 @@ export function categorizeConnectionError(e: unknown): string {
   // Checked before the generic "timeout"/"not found" rules below, which are
   // about the remote warehouse and would otherwise swallow these.
   if (msg.includes("did not finish opening")) return "driver_open_timeout"
-  if (msg.includes("locked by another process")) return "store_locked"
+  // "locked by another process" is the DuckDB driver's own wrapper. The other
+  // two are DuckDB's raw text ("Could not set lock on file …: Conflicting lock
+  // is held"), matched here as well so a lock that reaches this function
+  // unwrapped is still classified rather than falling through to "other".
+  if (
+    msg.includes("locked by another process") ||
+    msg.includes("conflicting lock") ||
+    msg.includes("could not set lock")
+  )
+    return "store_locked"
   // altimate_change end
   if (msg.includes("password") || msg.includes("authentication") || msg.includes("unauthorized") || msg.includes("jwt"))
     return "auth_failed"
@@ -298,14 +307,26 @@ export function categorizeConnectionError(e: unknown): string {
 
 // altimate_change start — distinguish infrastructure faults from config faults
 /**
- * Categories where the local client is broken, not the connection's config and
- * not the remote warehouse. A caller cannot fix these by correcting
+ * Categories where the fault is in this machine, not the connection's config
+ * and not the remote warehouse. A caller cannot fix these by correcting
  * credentials, and a harness must not score them as a task failure.
  */
 const INFRASTRUCTURE_CATEGORIES = new Set(["driver_missing", "driver_open_timeout", "store_locked"])
 
+/**
+ * The subset of the above that clears on its own once another process lets go.
+ * Still infrastructure — nothing about the connection's config is wrong — but
+ * the right response is to close the conflicting connection and retry, not to
+ * stop and report a broken install.
+ */
+const RECOVERABLE_CATEGORIES = new Set(["store_locked"])
+
 export function isInfrastructureFailure(category: string): boolean {
   return INFRASTRUCTURE_CATEGORIES.has(category)
+}
+
+export function isRecoverableFailure(category: string): boolean {
+  return RECOVERABLE_CATEGORIES.has(category)
 }
 // altimate_change end
 
@@ -426,7 +447,13 @@ export function list(): { warehouses: WarehouseInfo[] } {
 /** Test a connection by running a simple query. */
 export async function test(
   name: string,
-): Promise<{ connected: boolean; error?: string; error_category?: string; infrastructure?: boolean }> {
+): Promise<{
+  connected: boolean
+  error?: string
+  error_category?: string
+  infrastructure?: boolean
+  recoverable?: boolean
+}> {
   try {
     const connector = await get(name)
     const config = configs.get(name)
@@ -450,6 +477,7 @@ export async function test(
       error: String(e),
       error_category: category,
       infrastructure: isInfrastructureFailure(category),
+      recoverable: isRecoverableFailure(category),
     }
     // altimate_change end
   }
@@ -545,9 +573,16 @@ export async function remove(name: string): Promise<{ success: boolean; error?: 
   }
 }
 
-/** Reload all configs and clear cached connectors. */
-export async function reload(): Promise<void> {
-  // Close all cached connectors
+// altimate_change start — a way to release native handles without reloading
+/**
+ * Close every cached connector and drop it from the cache.
+ *
+ * `reset()` cannot do this: it is synchronous, and `close()` is not. Callers
+ * that create real connectors (tests, and `reload()` below) must await this,
+ * otherwise the native handle behind each connector stays open — on Windows
+ * that also blocks deleting the file underneath it.
+ */
+export async function closeAll(): Promise<void> {
   for (const [, connector] of connectors) {
     try {
       await connector.close()
@@ -556,6 +591,12 @@ export async function reload(): Promise<void> {
     }
   }
   connectors.clear()
+}
+// altimate_change end
+
+/** Reload all configs and clear cached connectors. */
+export async function reload(): Promise<void> {
+  await closeAll()
   loaded = false
   load()
 }

--- a/packages/opencode/src/altimate/native/types.ts
+++ b/packages/opencode/src/altimate/native/types.ts
@@ -339,6 +339,12 @@ export interface WarehouseTestResult {
    * are not fixable by editing the connection.
    */
   infrastructure?: boolean
+  /**
+   * True when the failure clears on its own once another process lets go — a
+   * store locked by another writer. Still `infrastructure`, but the response is
+   * to close the conflicting connection and retry, not to stop and report.
+   */
+  recoverable?: boolean
   // altimate_change end
 }
 

--- a/packages/opencode/src/altimate/native/types.ts
+++ b/packages/opencode/src/altimate/native/types.ts
@@ -329,6 +329,17 @@ export interface WarehouseTestParams {
 export interface WarehouseTestResult {
   connected: boolean
   error?: string
+  // altimate_change start — distinguish infrastructure faults from config faults
+  /** Coarse cause, from `categorizeConnectionError` (e.g. `driver_missing`, `auth_failed`). */
+  error_category?: string
+  /**
+   * True when the failure is in the local client — a driver that will not load,
+   * an open that never completed — rather than in the connection's
+   * configuration or the remote warehouse. These are not the caller's fault and
+   * are not fixable by editing the connection.
+   */
+  infrastructure?: boolean
+  // altimate_change end
 }
 
 // --- Warehouse Management ---

--- a/packages/opencode/src/altimate/tools/warehouse-test.ts
+++ b/packages/opencode/src/altimate/tools/warehouse-test.ts
@@ -25,6 +25,33 @@ export const WarehouseTestTool = Tool.define("warehouse_test", {
       // fault in this machine's install. Reporting it with the same wording as
       // a wrong password invites both the model and anyone reading the
       // transcript to treat broken infrastructure as a task or config failure.
+      // A locked store is infrastructure too — nothing about the connection's
+      // config is wrong — but it is the one category that clears itself once
+      // the other process lets go, and the driver's own message names the PID
+      // holding the lock. Telling the model to stop and report would be wrong
+      // advice for the one fault it can actually act on.
+      if (result.recoverable) {
+        return {
+          title: `Connection '${args.name}': STORE LOCKED`,
+          metadata: {
+            connected: false,
+            error: result.error,
+            error_category: result.error_category,
+            infrastructure: true,
+            recoverable: true,
+          },
+          output:
+            `STORE LOCKED — another process holds this store open, so it could not be ` +
+            `opened here. This is NOT a problem with the connection's configuration and ` +
+            `NOT a credentials failure.\n` +
+            `Category: ${result.error_category}\n` +
+            `Error: ${result.error ?? "Unknown error"}\n\n` +
+            `The error above names the process holding the lock. Close that connection ` +
+            `and try again. Do not work around this by querying something else — until ` +
+            `the lock clears, no result here comes from warehouse '${args.name}'.`,
+        }
+      }
+
       if (result.infrastructure) {
         return {
           title: `Connection '${args.name}': INFRASTRUCTURE FAILURE`,

--- a/packages/opencode/src/altimate/tools/warehouse-test.ts
+++ b/packages/opencode/src/altimate/tools/warehouse-test.ts
@@ -20,9 +20,35 @@ export const WarehouseTestTool = Tool.define("warehouse_test", {
         }
       }
 
+      // altimate_change start — never let a broken client look like a bad connection
+      // A driver that will not load, or an open that never completed, is a
+      // fault in this machine's install. Reporting it with the same wording as
+      // a wrong password invites both the model and anyone reading the
+      // transcript to treat broken infrastructure as a task or config failure.
+      if (result.infrastructure) {
+        return {
+          title: `Connection '${args.name}': INFRASTRUCTURE FAILURE`,
+          metadata: {
+            connected: false,
+            error: result.error,
+            error_category: result.error_category,
+            infrastructure: true,
+          },
+          output:
+            `INFRASTRUCTURE FAILURE — the warehouse client on this machine is broken. ` +
+            `This is NOT a problem with the connection's configuration, and NOT something ` +
+            `to work around by trying a different query or a different tool.\n` +
+            `Category: ${result.error_category}\n` +
+            `Error: ${result.error ?? "Unknown error"}\n\n` +
+            `Stop and report this rather than continuing — results produced after this ` +
+            `point did not come from warehouse '${args.name}'.`,
+        }
+      }
+      // altimate_change end
+
       return {
         title: `Connection '${args.name}': FAILED`,
-        metadata: { connected: false },
+        metadata: { connected: false, error: result.error, error_category: result.error_category },
         output: `Failed to connect to warehouse '${args.name}'.\nError: ${result.error ?? "Unknown error"}`,
       }
     } catch (e) {

--- a/packages/opencode/test/altimate/connections.test.ts
+++ b/packages/opencode/test/altimate/connections.test.ts
@@ -10,7 +10,12 @@ afterAll(() => { delete process.env.ALTIMATE_TELEMETRY_DISABLED })
 // ---------------------------------------------------------------------------
 
 import * as Registry from "../../src/altimate/native/connections/registry"
-import { detectAuthMethod } from "../../src/altimate/native/connections/registry"
+import {
+  categorizeConnectionError,
+  detectAuthMethod,
+  isInfrastructureFailure,
+  isRecoverableFailure,
+} from "../../src/altimate/native/connections/registry"
 import * as CredentialStore from "../../src/altimate/native/connections/credential-store"
 import { parseDbtProfiles, dbtConnectionsToConfigs } from "../../src/altimate/native/connections/dbt-profiles"
 import { discoverContainers, containerToConfig } from "../../src/altimate/native/connections/docker-discovery"
@@ -19,6 +24,57 @@ import { registerAll } from "../../src/altimate/native/connections/register"
 // ---------------------------------------------------------------------------
 // ConnectionRegistry
 // ---------------------------------------------------------------------------
+
+// altimate_change start — classification of local-client faults
+describe("categorizeConnectionError: local-client faults", () => {
+  // Verbatim DuckDB output. It contains "lock" but never "locked", which is
+  // why matching only the driver's own wrapper wording missed it.
+  const RAW_DUCKDB_LOCK =
+    'IO Error: Could not set lock on file "/tmp/warehouse.duckdb": Conflicting lock is held in ' +
+    "/usr/bin/node (PID 65001) by user someone. See also https://duckdb.org/docs/stable/connect/concurrency"
+
+  test("the raw DuckDB lock message never contains the substring 'locked'", () => {
+    expect(RAW_DUCKDB_LOCK.toLowerCase().includes("locked")).toBe(false)
+  })
+
+  test("classifies the raw DuckDB lock message as store_locked", () => {
+    expect(categorizeConnectionError(new Error(RAW_DUCKDB_LOCK))).toBe("store_locked")
+  })
+
+  test("classifies the driver's wrapped lock message as store_locked", () => {
+    const wrapped = new Error(`Database "/tmp/w.duckdb" is locked by another process. ${RAW_DUCKDB_LOCK}`)
+    expect(categorizeConnectionError(wrapped)).toBe("store_locked")
+  })
+
+  test("classifies the open deadline as driver_open_timeout, not a remote timeout", () => {
+    const err = new Error('DuckDB store "/tmp/w.duckdb" did not finish opening within 30000ms.')
+    expect(categorizeConnectionError(err)).toBe("driver_open_timeout")
+  })
+
+  test("still classifies a real credentials failure as auth_failed", () => {
+    expect(categorizeConnectionError(new Error("password authentication failed for user"))).toBe("auth_failed")
+  })
+
+  test("a locked store is infrastructure, and is the one that is recoverable", () => {
+    expect(isInfrastructureFailure("store_locked")).toBe(true)
+    expect(isRecoverableFailure("store_locked")).toBe(true)
+  })
+
+  test("a broken install is infrastructure but NOT recoverable", () => {
+    for (const category of ["driver_missing", "driver_open_timeout"]) {
+      expect(isInfrastructureFailure(category)).toBe(true)
+      expect(isRecoverableFailure(category)).toBe(false)
+    }
+  })
+
+  test("a config or credentials fault is neither infrastructure nor recoverable", () => {
+    for (const category of ["auth_failed", "config_error", "network_error", "other"]) {
+      expect(isInfrastructureFailure(category)).toBe(false)
+      expect(isRecoverableFailure(category)).toBe(false)
+    }
+  })
+})
+// altimate_change end
 
 describe("ConnectionRegistry", () => {
   beforeEach(() => {

--- a/packages/opencode/test/altimate/connections.test.ts
+++ b/packages/opencode/test/altimate/connections.test.ts
@@ -51,6 +51,22 @@ describe("categorizeConnectionError: local-client faults", () => {
     expect(categorizeConnectionError(err)).toBe("driver_open_timeout")
   })
 
+  test("a deadline the connection set is a config fault, not a broken client", () => {
+    const err = new Error(
+      'DuckDB store "/tmp/w.duckdb" did not finish opening within 1ms. ' +
+        "This deadline was set on this connection as open_timeout_ms=1; raise or remove it.",
+    )
+    expect(categorizeConnectionError(err)).toBe("config_error")
+    expect(isInfrastructureFailure(categorizeConnectionError(err))).toBe(false)
+  })
+
+  test("does not claim another driver's error just because it mentions a lock", () => {
+    // "could not set lock" alone is generic enough to appear in an unrelated
+    // remote failure; claiming it would tell the user to close a local process
+    // over a warehouse-side fault.
+    expect(categorizeConnectionError(new Error("ERROR: could not set lock timeout"))).not.toBe("store_locked")
+  })
+
   test("still classifies a real credentials failure as auth_failed", () => {
     expect(categorizeConnectionError(new Error("password authentication failed for user"))).toBe("auth_failed")
   })

--- a/packages/opencode/test/altimate/duckdb-lock-helper.ts
+++ b/packages/opencode/test/altimate/duckdb-lock-helper.ts
@@ -1,0 +1,94 @@
+import { createRequire } from "node:module"
+import fs from "node:fs"
+import path from "node:path"
+
+/**
+ * Hold a DuckDB write lock on `storePath` from a *separate OS process*.
+ *
+ * It has to be a separate process. DuckDB's file lock is per-process: the same
+ * process re-opening a store it already holds succeeds, so an in-process
+ * "second open" proves nothing about the path this exercises. Every lock
+ * assertion in these suites depends on the lock being genuinely foreign.
+ *
+ * Measured, and load-bearing for what the driver may claim: a write lock held
+ * here is NOT rescued by opening READ_ONLY. `default`, `READ_ONLY` and
+ * `read_only` all fail against it. So the read-only *retry* cannot recover a
+ * locked store — only an up-front `config.readonly` open lets several processes
+ * share a file that nobody has open read-write.
+ */
+export interface HeldLock {
+  release(): Promise<void>
+}
+
+const require_ = createRequire(import.meta.url)
+
+export async function holdWriteLock(storePath: string, scratchDir: string): Promise<HeldLock> {
+  // Resolve `duckdb` here rather than in the child: the child's cwd is not
+  // guaranteed to sit under the node_modules tree that resolves it, and a
+  // resolution failure there would look like "no lock was taken".
+  const duckdbEntry = require_.resolve("duckdb")
+
+  const scriptPath = path.join(scratchDir, "hold-duckdb-lock.cjs")
+  fs.writeFileSync(
+    scriptPath,
+    [
+      `const duckdb = require(${JSON.stringify(duckdbEntry)})`,
+      `const mod = duckdb.default || duckdb`,
+      `const db = new mod.Database(process.argv[2], (err) => {`,
+      `  if (err) { process.stderr.write("HOLD_FAILED " + (err.message || err) + "\\n"); process.exit(1) }`,
+      // Take a real write so the lock is unambiguously a writer's.
+      `  db.run("CREATE TABLE IF NOT EXISTS lock_probe (x INTEGER)", (e) => {`,
+      `    if (e) { process.stderr.write("HOLD_FAILED " + (e.message || e) + "\\n"); process.exit(1) }`,
+      `    process.stdout.write("READY\\n")`,
+      `  })`,
+      `})`,
+      `setInterval(() => {}, 1 << 30)`,
+    ].join("\n"),
+    "utf-8",
+  )
+
+  const child = Bun.spawn([process.execPath, scriptPath, storePath], {
+    stdout: "pipe",
+    stderr: "pipe",
+    cwd: scratchDir,
+  })
+
+  const ready = (async () => {
+    const reader = (child.stdout as ReadableStream<Uint8Array>).getReader()
+    const decoder = new TextDecoder()
+    let buffered = ""
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buffered += decoder.decode(value, { stream: true })
+      if (buffered.includes("READY")) {
+        reader.releaseLock()
+        return
+      }
+    }
+    const err = await new Response(child.stderr).text()
+    throw new Error(`lock holder exited without taking the lock: ${err || "(no output)"}`)
+  })()
+
+  const timeout = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error("lock holder did not report READY within 30s")), 30_000),
+  )
+
+  try {
+    await Promise.race([ready, timeout])
+  } catch (e) {
+    child.kill()
+    throw e
+  }
+
+  return {
+    async release() {
+      child.kill()
+      try {
+        await child.exited
+      } catch {
+        // the process is gone either way
+      }
+    },
+  }
+}

--- a/packages/opencode/test/altimate/duckdb-lock-helper.ts
+++ b/packages/opencode/test/altimate/duckdb-lock-helper.ts
@@ -1,4 +1,4 @@
-import { createRequire } from "node:module"
+import { fileURLToPath } from "node:url"
 import fs from "node:fs"
 import path from "node:path"
 
@@ -20,28 +20,31 @@ export interface HeldLock {
   release(): Promise<void>
 }
 
-const require_ = createRequire(import.meta.url)
+// The child takes the lock through the driver itself, by absolute path, rather
+// than resolving the `duckdb` package on its own. Resolving `duckdb` from this
+// directory works in some layouts and not others — it failed in CI, where the
+// package is a dependency of `packages/drivers` and not reachable from here —
+// which is the same class of fault this PR exists to fix, so it has no business
+// being reintroduced by the test that proves the fix. The specifier below is
+// the one both E2E suites already import successfully.
+const DRIVER_PATH = fileURLToPath(new URL("../../../drivers/src/duckdb.ts", import.meta.url))
 
 export async function holdWriteLock(storePath: string, scratchDir: string): Promise<HeldLock> {
-  // Resolve `duckdb` here rather than in the child: the child's cwd is not
-  // guaranteed to sit under the node_modules tree that resolves it, and a
-  // resolution failure there would look like "no lock was taken".
-  const duckdbEntry = require_.resolve("duckdb")
-
-  const scriptPath = path.join(scratchDir, "hold-duckdb-lock.cjs")
+  const scriptPath = path.join(scratchDir, "hold-duckdb-lock.ts")
   fs.writeFileSync(
     scriptPath,
     [
-      `const duckdb = require(${JSON.stringify(duckdbEntry)})`,
-      `const mod = duckdb.default || duckdb`,
-      `const db = new mod.Database(process.argv[2], (err) => {`,
-      `  if (err) { process.stderr.write("HOLD_FAILED " + (err.message || err) + "\\n"); process.exit(1) }`,
-      // Take a real write so the lock is unambiguously a writer's.
-      `  db.run("CREATE TABLE IF NOT EXISTS lock_probe (x INTEGER)", (e) => {`,
-      `    if (e) { process.stderr.write("HOLD_FAILED " + (e.message || e) + "\\n"); process.exit(1) }`,
-      `    process.stdout.write("READY\\n")`,
-      `  })`,
-      `})`,
+      `const { connect } = await import(${JSON.stringify(DRIVER_PATH)})`,
+      `try {`,
+      `  const c = await connect({ type: "duckdb", path: process.argv[2] })`,
+      `  await c.connect()`,
+      // A real write, so the lock is unambiguously a writer's.
+      `  await c.execute("CREATE TABLE IF NOT EXISTS lock_probe (x INTEGER)")`,
+      `  process.stdout.write("READY\\n")`,
+      `} catch (e) {`,
+      `  process.stderr.write("HOLD_FAILED " + (e instanceof Error ? e.message : String(e)) + "\\n")`,
+      `  process.exit(1)`,
+      `}`,
       `setInterval(() => {}, 1 << 30)`,
     ].join("\n"),
     "utf-8",

--- a/packages/opencode/test/altimate/duckdb-lock-helper.ts
+++ b/packages/opencode/test/altimate/duckdb-lock-helper.ts
@@ -34,8 +34,11 @@ export async function holdWriteLock(storePath: string, scratchDir: string): Prom
   fs.writeFileSync(
     scriptPath,
     [
-      `const { connect } = await import(${JSON.stringify(DRIVER_PATH)})`,
       `try {`,
+      // Inside the try, so a driver that fails to load is reported through the
+      // same HOLD_FAILED channel as any other failure rather than surfacing as
+      // a bare unhandled rejection the parent has to guess at.
+      `  const { connect } = await import(${JSON.stringify(DRIVER_PATH)})`,
       `  const c = await connect({ type: "duckdb", path: process.argv[2] })`,
       `  await c.connect()`,
       // A real write, so the lock is unambiguously a writer's.
@@ -73,15 +76,21 @@ export async function holdWriteLock(storePath: string, scratchDir: string): Prom
     throw new Error(`lock holder exited without taking the lock: ${err || "(no output)"}`)
   })()
 
-  const timeout = new Promise<never>((_, reject) =>
-    setTimeout(() => reject(new Error("lock holder did not report READY within 30s")), 30_000),
-  )
+  // The handle is kept so it can be cleared: an un-cleared timer holds the
+  // event loop open, which would make the whole test process sit for the full
+  // 30s after its last assertion, once per call.
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error("lock holder did not report READY within 30s")), 30_000)
+  })
 
   try {
     await Promise.race([ready, timeout])
   } catch (e) {
     child.kill()
     throw e
+  } finally {
+    if (timer) clearTimeout(timer)
   }
 
   return {

--- a/packages/opencode/test/altimate/duckdb-open-e2e.test.ts
+++ b/packages/opencode/test/altimate/duckdb-open-e2e.test.ts
@@ -4,6 +4,7 @@ import os from "node:os"
 import path from "node:path"
 
 import { connect } from "../../../drivers/src/duckdb"
+import { holdWriteLock } from "./duckdb-lock-helper"
 
 // These tests open a real DuckDB store on disk. They are pointless against a
 // mock: every bug they cover lives in the native open callback or in the
@@ -140,6 +141,63 @@ describe("DuckDB driver: opening a real store", () => {
       await c.connect()
       await c.close()
     }
+  })
+
+  ddbTest("a budget larger than the timer's range is not silently turned into 1ms", async () => {
+    // setTimeout clamps a delay past 2^31-1 down to about 1ms, which would turn
+    // "wait essentially forever" into "fail immediately" — the exact inversion
+    // this driver exists to prevent. The budget must be clamped before it
+    // reaches the timer.
+    const c = await connect({ type: "duckdb", path: storePath, open_timeout_ms: 1e12 })
+    await c.connect()
+    const r = await c.execute("SELECT count(*) AS n FROM t")
+    expect(Number(r.rows[0][0])).toBe(1)
+    await c.close()
+  })
+
+  ddbTest("an explicitly read-only open that hits a foreign lock reports it as a lock", async () => {
+    // READ_ONLY does not rescue an existing cross-process write lock — measured,
+    // and the reason this path exists at all. What matters is that the failure
+    // stays *recognisable* as a lock: an explicit readonly open takes the
+    // `wantReadOnly` branch, which correctly skips the read-only retry, and
+    // before this fix that branch rethrew DuckDB's raw error, so every consumer
+    // classified a plain lock collision as an unknown failure.
+    const lock = await holdWriteLock(storePath, dir)
+    try {
+      const c = await connect({ type: "duckdb", path: storePath, readonly: true })
+      const message = await messageFrom(() => c.connect())
+      expect(message).toContain("is locked by another process")
+      // DuckDB's own text survives: it names the PID holding the lock, which is
+      // the only way to find the other process.
+      expect(message.toLowerCase()).toContain("conflicting lock")
+    } finally {
+      await lock.release()
+    }
+  })
+
+  ddbTest("a read-write open that hits a foreign lock also reports it as a lock", async () => {
+    const lock = await holdWriteLock(storePath, dir)
+    try {
+      const c = await connect({ type: "duckdb", path: storePath })
+      const message = await messageFrom(() => c.connect())
+      expect(message).toContain("is locked by another process")
+      expect(message.toLowerCase()).toContain("conflicting lock")
+    } finally {
+      await lock.release()
+    }
+  })
+
+  ddbTest("the store is usable again once the foreign lock is released", async () => {
+    // Guards the helper itself. If release() did not actually free the lock,
+    // the two tests above would pass for the wrong reason and would poison
+    // every test that runs after them.
+    const lock = await holdWriteLock(storePath, dir)
+    await lock.release()
+    const c = await connect({ type: "duckdb", path: storePath })
+    await c.connect()
+    const r = await c.execute("SELECT count(*) AS n FROM t")
+    expect(Number(r.rows[0][0])).toBe(1)
+    await c.close()
   })
 
   ddbTest("reports a lock conflict as a lock conflict, keeping DuckDB's detail", async () => {

--- a/packages/opencode/test/altimate/duckdb-open-e2e.test.ts
+++ b/packages/opencode/test/altimate/duckdb-open-e2e.test.ts
@@ -113,14 +113,22 @@ describe("DuckDB driver: opening a real store", () => {
     // The assertion above this one passes on a dead connection: `(0 rows)` and
     // "the driver never loaded" are the same observation. This one cannot.
     const c = await connect({ type: "duckdb", path: storePath })
-    await c.connect()
-    const r = await c.execute(`SELECT md5('${LIVENESS_NONCE}') AS h`)
+    // close() in a finally, not after the assertions: this opens `storePath`
+    // read-write, and DuckDB's lock is per-process, so a handle leaked by a
+    // failing assertion would make every later test in this file fail with a
+    // lock conflict instead of the real cause.
+    let rows: unknown[][]
+    try {
+      await c.connect()
+      rows = (await c.execute(`SELECT md5('${LIVENESS_NONCE}') AS h`)).rows
+    } finally {
+      await c.close()
+    }
     // Exactly one row: a swallowed failure surfaces as zero rows, and zero rows
     // is the shape that reads as success everywhere downstream.
-    expect(r.rows.length).toBe(1)
+    expect(rows.length).toBe(1)
     // And the right answer, which requires actually computing it.
-    expect(String(r.rows[0][0])).toBe(LIVENESS_MD5)
-    await c.close()
+    expect(String(rows[0][0])).toBe(LIVENESS_MD5)
   })
 
   ddbTest("opens the same store from many connectors at once", async () => {

--- a/packages/opencode/test/altimate/duckdb-open-e2e.test.ts
+++ b/packages/opencode/test/altimate/duckdb-open-e2e.test.ts
@@ -129,7 +129,18 @@ describe("DuckDB driver: opening a real store", () => {
     // The old message was `Timed out opening DuckDB database "<path>"`, which
     // reads as "the store is broken" and sent investigators after the file.
     expect(message).toContain("not a fault in the store")
-    expect(message).toContain("ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS")
+  })
+
+  ddbTest("a deadline the connection set says so, so it is not read as a broken client", async () => {
+    // The remedy differs by source, so the message has to name it. A budget the
+    // connection chose is fixed by changing that connection; the default firing
+    // says something about the machine instead.
+    const c = await connect({ type: "duckdb", path: storePath, open_timeout_ms: 1 })
+    const message = await messageFrom(() => c.connect())
+    expect(message).toContain("deadline was set on this connection as open_timeout_ms=1")
+    // It must NOT point at the env var, which does not override a per-connection
+    // setting and so would not fix anything here.
+    expect(message).not.toContain("ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS")
   })
 
   ddbTest("the open deadline is tunable by environment variable", async () => {
@@ -137,7 +148,12 @@ describe("DuckDB driver: opening a real store", () => {
     process.env["ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS"] = "1"
     try {
       const c = await connect({ type: "duckdb", path: storePath })
-      expect(await messageFrom(() => c.connect())).toContain("did not finish opening within 1ms")
+      const message = await messageFrom(() => c.connect())
+      expect(message).toContain("did not finish opening within 1ms")
+      // Sourced from the environment, not the connection, so the message points
+      // at the knobs that would actually change it.
+      expect(message).toContain("ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS")
+      expect(message).not.toContain("deadline was set on this connection")
     } finally {
       if (prev === undefined) delete process.env["ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS"]
       else process.env["ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS"] = prev

--- a/packages/opencode/test/altimate/duckdb-open-e2e.test.ts
+++ b/packages/opencode/test/altimate/duckdb-open-e2e.test.ts
@@ -1,0 +1,163 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+
+import { connect } from "../../../drivers/src/duckdb"
+
+// These tests open a real DuckDB store on disk. They are pointless against a
+// mock: every bug they cover lives in the native open callback or in the
+// driver's own deadline, neither of which a fake exposes.
+//
+// They need their own `bun test` process. Four files in this directory install
+// a top-level `mock.module("@altimateai/drivers/duckdb", …)`, and Bun evaluates
+// every test file's top level before running any test, so in a whole-directory
+// run the driver is already replaced by a fake no matter how the files sort and
+// regardless of which specifier this file imports. `mock.restore()` does not
+// undo a module mock. Hence the gate below, and the dedicated CI step.
+//
+// The gate is opt-IN so the shared suite stays green, but when it is on a
+// missing or faked driver is a hard failure, never a skip. A whole e2e file
+// that quietly reports success while skipping is the same class of defect this
+// PR exists to fix.
+const RUN = process.env["ALTIMATE_DUCKDB_E2E"] === "1"
+const ddbTest = RUN ? test : test.skip
+
+let dir = ""
+let storePath = ""
+
+/** Run `fn` and return the error message it threw, or "" if it succeeded. */
+async function messageFrom(fn: () => Promise<unknown>): Promise<string> {
+  try {
+    await fn()
+    return ""
+  } catch (e) {
+    return e instanceof Error ? e.message : String(e)
+  }
+}
+
+describe("DuckDB driver: opening a real store", () => {
+  beforeAll(async () => {
+    if (!RUN) return
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "duckdb-open-"))
+    storePath = path.join(dir, "warehouse.duckdb")
+    const c = await connect({ type: "duckdb", path: storePath })
+    await c.connect()
+    await c.execute("CREATE TABLE t AS SELECT 1 AS a, 'x' AS b")
+    const probe = await c.execute("SELECT count(*) AS n FROM t")
+    await c.close()
+    // Refuse to run against anything but the real thing. A fake driver would
+    // pass most assertions below while proving nothing.
+    if (Number(probe.rows?.[0]?.[0]) !== 1) {
+      throw new Error(
+        "ALTIMATE_DUCKDB_E2E=1 but the DuckDB driver is not the real one — " +
+          "either the native binding is missing, or another test file has replaced " +
+          "the module with a mock. Run this file in its own `bun test` process.",
+      )
+    }
+  })
+
+  afterAll(() => {
+    if (dir) fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  ddbTest("opens the same store repeatedly without flaking", async () => {
+    // The failure this replaces was reported as 7 of 7 calls failing, so a
+    // single green open proves nothing. Repeat enough to catch an
+    // intermittent regression.
+    for (let i = 0; i < 20; i++) {
+      const c = await connect({ type: "duckdb", path: storePath })
+      await c.connect()
+      const r = await c.execute("SELECT count(*) AS n FROM t")
+      expect(Number(r.rows[0][0])).toBe(1)
+      await c.close()
+    }
+  })
+
+  ddbTest("opens the same store from many connectors at once", async () => {
+    const results = await Promise.all(
+      Array.from({ length: 8 }, async () => {
+        const c = await connect({ type: "duckdb", path: storePath })
+        await c.connect()
+        const r = await c.execute("SELECT count(*) AS n FROM t")
+        await c.close()
+        return Number(r.rows[0][0])
+      }),
+    )
+    expect(results).toEqual(Array(8).fill(1))
+  })
+
+  ddbTest("honours config.readonly by actually opening READ_ONLY", async () => {
+    const c = await connect({ type: "duckdb", path: storePath, readonly: true })
+    await c.connect()
+    // Reads work.
+    const r = await c.execute("SELECT count(*) AS n FROM t")
+    expect(Number(r.rows[0][0])).toBe(1)
+    // Writes do not — which is what proves READ_ONLY reached DuckDB rather
+    // than `readonly` being silently dropped, as it was before.
+    expect(await messageFrom(() => c.execute("CREATE TABLE writeme (x INTEGER)"))).not.toBe("")
+    await c.close()
+  })
+
+  ddbTest("a store that opens fine is not failed by the open deadline", async () => {
+    // Same file, same process, two budgets. An unreachably small budget must
+    // fail; the default must succeed. That is the whole mechanism behind the
+    // field failure: the deadline fired, not the store.
+    const tooShort = await connect({ type: "duckdb", path: storePath, open_timeout_ms: 1 })
+    expect(await messageFrom(() => tooShort.connect())).toContain("did not finish opening within 1ms")
+
+    const normal = await connect({ type: "duckdb", path: storePath })
+    await normal.connect()
+    const r = await normal.execute("SELECT count(*) AS n FROM t")
+    expect(Number(r.rows[0][0])).toBe(1)
+    await normal.close()
+  })
+
+  ddbTest("the open deadline names itself as a client-side deadline", async () => {
+    const c = await connect({ type: "duckdb", path: storePath, open_timeout_ms: 1 })
+    const message = await messageFrom(() => c.connect())
+    // The old message was `Timed out opening DuckDB database "<path>"`, which
+    // reads as "the store is broken" and sent investigators after the file.
+    expect(message).toContain("not a fault in the store")
+    expect(message).toContain("ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS")
+  })
+
+  ddbTest("the open deadline is tunable by environment variable", async () => {
+    const prev = process.env["ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS"]
+    process.env["ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS"] = "1"
+    try {
+      const c = await connect({ type: "duckdb", path: storePath })
+      expect(await messageFrom(() => c.connect())).toContain("did not finish opening within 1ms")
+    } finally {
+      if (prev === undefined) delete process.env["ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS"]
+      else process.env["ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS"] = prev
+    }
+  })
+
+  ddbTest("an unusable timeout value falls back to the default budget", async () => {
+    for (const bad of [0, -1, Number.NaN, "abc"]) {
+      const c = await connect({ type: "duckdb", path: storePath, open_timeout_ms: bad })
+      await c.connect()
+      await c.close()
+    }
+  })
+
+  ddbTest("reports a lock conflict as a lock conflict, keeping DuckDB's detail", async () => {
+    // The verbatim message DuckDB emits when another process holds the file.
+    // It contains "lock" but never "locked", which is why the driver's old
+    // `.includes("locked")` check never matched a real collision.
+    const real =
+      'IO Error: Could not set lock on file "/tmp/warehouse.duckdb": Conflicting lock is held in ' +
+      "/usr/bin/node (PID 65001) by user someone. See also https://duckdb.org/docs/stable/connect/concurrency"
+    expect(real.toLowerCase().includes("locked")).toBe(false)
+
+    // Drive it through the driver by pointing at a directory, which fails the
+    // open for an unrelated reason, to confirm non-lock errors pass through
+    // untouched rather than being mislabelled as a lock.
+    const c = await connect({ type: "duckdb", path: dir })
+    const message = await messageFrom(() => c.connect())
+    expect(message).not.toBe("")
+    expect(message).not.toContain("is locked by another process")
+    expect(message).not.toContain("did not finish opening")
+  })
+})

--- a/packages/opencode/test/altimate/duckdb-open-e2e.test.ts
+++ b/packages/opencode/test/altimate/duckdb-open-e2e.test.ts
@@ -26,6 +26,14 @@ const ddbTest = RUN ? test : test.skip
 
 let dir = ""
 let storePath = ""
+  // The lock tests use their own store, which THIS process never opens
+  // successfully. That is not tidiness: DuckDB's lock is per-process, and this
+  // process holds a write lock on `storePath` for as long as its own handle
+  // lives — the driver's close() has to fall back to a timer in Bun because the
+  // native close callback does not always fire, so "closed" is not instantaneous.
+  // Sharing one store would make these tests race that fallback. The lock holder
+  // creates `lockedPath` itself, so the only writer is the foreign process.
+  let lockedPath = ""
 
 /** Run `fn` and return the error message it threw, or "" if it succeeded. */
 async function messageFrom(fn: () => Promise<unknown>): Promise<string> {
@@ -42,6 +50,7 @@ describe("DuckDB driver: opening a real store", () => {
     if (!RUN) return
     dir = fs.mkdtempSync(path.join(os.tmpdir(), "duckdb-open-"))
     storePath = path.join(dir, "warehouse.duckdb")
+    lockedPath = path.join(dir, "locked.duckdb")
     const c = await connect({ type: "duckdb", path: storePath })
     await c.connect()
     await c.execute("CREATE TABLE t AS SELECT 1 AS a, 'x' AS b")
@@ -162,9 +171,9 @@ describe("DuckDB driver: opening a real store", () => {
     // `wantReadOnly` branch, which correctly skips the read-only retry, and
     // before this fix that branch rethrew DuckDB's raw error, so every consumer
     // classified a plain lock collision as an unknown failure.
-    const lock = await holdWriteLock(storePath, dir)
+    const lock = await holdWriteLock(lockedPath, dir)
     try {
-      const c = await connect({ type: "duckdb", path: storePath, readonly: true })
+      const c = await connect({ type: "duckdb", path: lockedPath, readonly: true })
       const message = await messageFrom(() => c.connect())
       expect(message).toContain("is locked by another process")
       // DuckDB's own text survives: it names the PID holding the lock, which is
@@ -176,9 +185,9 @@ describe("DuckDB driver: opening a real store", () => {
   })
 
   ddbTest("a read-write open that hits a foreign lock also reports it as a lock", async () => {
-    const lock = await holdWriteLock(storePath, dir)
+    const lock = await holdWriteLock(lockedPath, dir)
     try {
-      const c = await connect({ type: "duckdb", path: storePath })
+      const c = await connect({ type: "duckdb", path: lockedPath })
       const message = await messageFrom(() => c.connect())
       expect(message).toContain("is locked by another process")
       expect(message.toLowerCase()).toContain("conflicting lock")
@@ -191,12 +200,15 @@ describe("DuckDB driver: opening a real store", () => {
     // Guards the helper itself. If release() did not actually free the lock,
     // the two tests above would pass for the wrong reason and would poison
     // every test that runs after them.
-    const lock = await holdWriteLock(storePath, dir)
+    const lock = await holdWriteLock(lockedPath, dir)
     await lock.release()
-    const c = await connect({ type: "duckdb", path: storePath })
+    const c = await connect({ type: "duckdb", path: lockedPath })
     await c.connect()
-    const r = await c.execute("SELECT count(*) AS n FROM t")
-    expect(Number(r.rows[0][0])).toBe(1)
+    // `lock_probe` is the table the holder creates when it takes the lock, so
+    // reading it proves both that the lock is gone and that the holder really
+    // wrote through it rather than merely touching the file.
+    const r = await c.execute("SELECT count(*) AS n FROM lock_probe")
+    expect(Number(r.rows[0][0])).toBe(0)
     await c.close()
   })
 

--- a/packages/opencode/test/altimate/duckdb-open-e2e.test.ts
+++ b/packages/opencode/test/altimate/duckdb-open-e2e.test.ts
@@ -35,6 +35,29 @@ let storePath = ""
   // creates `lockedPath` itself, so the only writer is the foreign process.
   let lockedPath = ""
 
+// A liveness probe whose correct answer cannot be produced without a working
+// engine actually computing it.
+//
+// Every other assertion in this file can be satisfied by a connection that is
+// not really there. A row count can legitimately be zero, and an absent error
+// string can mean the error was swallowed rather than that none occurred — which
+// is live on `main` today: `register.ts`'s `sql.execute` catches everything and
+// returns `{ row_count: 0, error }` instead of throwing, and `formatResult`
+// renders "(0 rows)" without ever reading `error`. So "(0 rows)" and "the driver
+// is dead" are indistinguishable to anything downstream.
+//
+// `md5()` is not. A dead connection cannot return one row, and a live one cannot
+// return the right digest without hashing the input. This is not a hypothetical
+// safeguard: during the driver A/B for this PR, two binaries looked clean across
+// transcripts, traces and 563 lines of debug output — zero ENOENT, zero fault
+// lines — while failing to load the driver at all. This probe is what caught it.
+//
+// The digest is computed independently (`hashlib.md5`, cross-checked against
+// `md5(1)`), never by asking DuckDB — deriving it from the system under test
+// would make the assertion circular and prove nothing.
+const LIVENESS_NONCE = "altimate-duckdb-open-e2e-liveness-2026-08-30"
+const LIVENESS_MD5 = "517f58256b5ba4642643b3e884d91d15"
+
 /** Run `fn` and return the error message it threw, or "" if it succeeded. */
 async function messageFrom(fn: () => Promise<unknown>): Promise<string> {
   try {
@@ -55,10 +78,12 @@ describe("DuckDB driver: opening a real store", () => {
     await c.connect()
     await c.execute("CREATE TABLE t AS SELECT 1 AS a, 'x' AS b")
     const probe = await c.execute("SELECT count(*) AS n FROM t")
+    const liveness = await c.execute(`SELECT md5('${LIVENESS_NONCE}') AS h`)
     await c.close()
     // Refuse to run against anything but the real thing. A fake driver would
-    // pass most assertions below while proving nothing.
-    if (Number(probe.rows?.[0]?.[0]) !== 1) {
+    // pass most assertions below while proving nothing. The digest is the half
+    // of this gate that a stub cannot satisfy by returning a plausible shape.
+    if (Number(probe.rows?.[0]?.[0]) !== 1 || String(liveness.rows?.[0]?.[0]) !== LIVENESS_MD5) {
       throw new Error(
         "ALTIMATE_DUCKDB_E2E=1 but the DuckDB driver is not the real one — " +
           "either the native binding is missing, or another test file has replaced " +
@@ -82,6 +107,20 @@ describe("DuckDB driver: opening a real store", () => {
       expect(Number(r.rows[0][0])).toBe(1)
       await c.close()
     }
+  })
+
+  ddbTest("the opened store is a live engine, not a connection that merely looks open", async () => {
+    // The assertion above this one passes on a dead connection: `(0 rows)` and
+    // "the driver never loaded" are the same observation. This one cannot.
+    const c = await connect({ type: "duckdb", path: storePath })
+    await c.connect()
+    const r = await c.execute(`SELECT md5('${LIVENESS_NONCE}') AS h`)
+    // Exactly one row: a swallowed failure surfaces as zero rows, and zero rows
+    // is the shape that reads as success everywhere downstream.
+    expect(r.rows.length).toBe(1)
+    // And the right answer, which requires actually computing it.
+    expect(String(r.rows[0][0])).toBe(LIVENESS_MD5)
+    await c.close()
   })
 
   ddbTest("opens the same store from many connectors at once", async () => {

--- a/packages/opencode/test/altimate/warehouse-test-duckdb-e2e.test.ts
+++ b/packages/opencode/test/altimate/warehouse-test-duckdb-e2e.test.ts
@@ -6,6 +6,7 @@ import path from "node:path"
 import { Dispatcher } from "../../src/altimate/native"
 import * as Registry from "../../src/altimate/native/connections/registry"
 import { WarehouseTestTool } from "../../src/altimate/tools/warehouse-test"
+import { holdWriteLock } from "./duckdb-lock-helper"
 import { initTool } from "./tool-fixture"
 
 // End-to-end coverage for the `warehouse_test` tool against a real DuckDB file
@@ -20,6 +21,9 @@ const ddbTest = RUN ? test : test.skip
 
 let dir = ""
 let storePath = ""
+// Captured so afterAll can put the environment back exactly as it found it.
+// Unconditionally deleting would clear a value the surrounding process had set.
+let prevTelemetryDisabled: string | undefined
 
 async function warehouseTest(name: string) {
   return Dispatcher.call("warehouse.test", { name })
@@ -27,6 +31,7 @@ async function warehouseTest(name: string) {
 
 describe("warehouse.test against a real DuckDB store", () => {
   beforeAll(async () => {
+    prevTelemetryDisabled = process.env["ALTIMATE_TELEMETRY_DISABLED"]
     process.env["ALTIMATE_TELEMETRY_DISABLED"] = "true"
     if (!RUN) return
     dir = fs.mkdtempSync(path.join(os.tmpdir(), "warehouse-test-"))
@@ -36,6 +41,7 @@ describe("warehouse.test against a real DuckDB store", () => {
     const c = await Registry.get("seed")
     await c.execute("CREATE TABLE t AS SELECT 1 AS a")
     const probe = await c.execute("SELECT count(*) AS n FROM t")
+    await Registry.closeAll()
     Registry.reset()
     // Refuse to run against anything but the real driver — see above.
     if (Number(probe.rows?.[0]?.[0]) !== 1) {
@@ -47,12 +53,20 @@ describe("warehouse.test against a real DuckDB store", () => {
     }
   })
 
-  afterEach(() => {
+  // Registry.reset() only clears the connector map — it is synchronous and
+  // close() is not — so on its own it leaks the native DuckDB handle behind
+  // every connector these tests create. closeAll() is what actually releases
+  // them; without it the handles accumulate and the rmSync below cannot delete
+  // the store on Windows.
+  afterEach(async () => {
+    await Registry.closeAll()
     Registry.reset()
   })
 
-  afterAll(() => {
-    delete process.env["ALTIMATE_TELEMETRY_DISABLED"]
+  afterAll(async () => {
+    if (prevTelemetryDisabled === undefined) delete process.env["ALTIMATE_TELEMETRY_DISABLED"]
+    else process.env["ALTIMATE_TELEMETRY_DISABLED"] = prevTelemetryDisabled
+    await Registry.closeAll()
     Registry.reset()
     if (dir) fs.rmSync(dir, { recursive: true, force: true })
   })
@@ -62,6 +76,7 @@ describe("warehouse.test against a real DuckDB store", () => {
     // merely usually right would recreate exactly that contamination. Each
     // iteration resets the registry so nothing is served from cache.
     for (let i = 0; i < 10; i++) {
+      await Registry.closeAll()
       Registry.reset()
       Registry.setConfigs({ local: { type: "duckdb", path: storePath } })
       const result = await warehouseTest("local")
@@ -96,6 +111,47 @@ describe("warehouse.test against a real DuckDB store", () => {
     Registry.setConfigs({ local: { type: "duckdb", path: storePath } })
     const result = await warehouseTest("local")
     expect(result.connected).toBe(true)
+  })
+
+  ddbTest("a store locked by another process is reported as a recoverable lock", async () => {
+    const lock = await holdWriteLock(storePath, dir)
+    try {
+      await Registry.closeAll()
+      Registry.reset()
+      Registry.setConfigs({ local: { type: "duckdb", path: storePath } })
+      const result = await warehouseTest("local")
+      expect(result.connected).toBe(false)
+      // Not "other": before this, an unwrapped lock error fell through every
+      // rule in categorizeConnectionError and was reported as an unclassified
+      // failure, which reads exactly like a bad password.
+      expect(result.error_category).toBe("store_locked")
+      // Still infrastructure — nothing about this connection's config is wrong
+      // — but recoverable, which is what separates it from a broken install.
+      expect(result.infrastructure).toBe(true)
+      expect(result.recoverable).toBe(true)
+    } finally {
+      await lock.release()
+    }
+  })
+
+  ddbTest("the tool tells a caller to clear a lock, not to stop and report it", async () => {
+    const tool = await initTool(WarehouseTestTool)
+    const ctx = { sessionID: "s", messageID: "m", agent: "build", abort: new AbortController().signal, messages: [] }
+    const lock = await holdWriteLock(storePath, dir)
+    try {
+      await Registry.closeAll()
+      Registry.reset()
+      Registry.setConfigs({ local: { type: "duckdb", path: storePath } })
+      const locked = await tool.execute({ name: "local" }, ctx)
+      expect(locked.title).toContain("STORE LOCKED")
+      expect(locked.metadata.recoverable).toBe(true)
+      // A lock clears itself once the other process lets go, so the
+      // stop-and-report copy meant for a broken install is wrong advice here.
+      expect(locked.output).not.toContain("Stop and report this")
+      expect(locked.output).toContain("Close that connection and try again")
+    } finally {
+      await lock.release()
+    }
   })
 
   ddbTest("the warehouse_test tool renders infrastructure faults unmistakably", async () => {

--- a/packages/opencode/test/altimate/warehouse-test-duckdb-e2e.test.ts
+++ b/packages/opencode/test/altimate/warehouse-test-duckdb-e2e.test.ts
@@ -93,14 +93,36 @@ describe("warehouse.test against a real DuckDB store", () => {
   ddbTest("reports a broken client as an infrastructure failure, not a failed connection", async () => {
     Registry.reset()
     // An unreachably small open budget stands in for any local fault that
-    // stops the store opening. The point of the assertion is the *shape* of
-    // the report: a caller must be able to tell this apart from a bad
-    // password without parsing prose.
+    // stops the store opening. It is set through the environment, NOT on the
+    // connection: a deadline the connection itself chose is that connection's
+    // own doing and is covered by the next test. The point of the assertion is
+    // the *shape* of the report — a caller must be able to tell this apart from
+    // a bad password without parsing prose.
+    const prev = process.env["ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS"]
+    process.env["ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS"] = "1"
+    try {
+      Registry.setConfigs({ local: { type: "duckdb", path: storePath } })
+      const result = await warehouseTest("local")
+      expect(result.connected).toBe(false)
+      expect(result.infrastructure).toBe(true)
+      expect(result.error_category).toBe("driver_open_timeout")
+    } finally {
+      if (prev === undefined) delete process.env["ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS"]
+      else process.env["ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS"] = prev
+    }
+  })
+
+  ddbTest("a deadline the connection itself set is a configuration fault, not infrastructure", async () => {
+    // The mirror of the bug this PR fixes. Telling a caller "your client is
+    // broken, stop and report it" when they set `open_timeout_ms: 1` themselves
+    // is the same category error as reporting a broken install as a bad
+    // password — it just points the wrong way.
+    Registry.reset()
     Registry.setConfigs({ local: { type: "duckdb", path: storePath, open_timeout_ms: 1 } })
     const result = await warehouseTest("local")
     expect(result.connected).toBe(false)
-    expect(result.infrastructure).toBe(true)
-    expect(result.error_category).toBe("driver_open_timeout")
+    expect(result.error_category).toBe("config_error")
+    expect(result.infrastructure).toBe(false)
   })
 
   ddbTest("does not mark a genuine configuration mistake as infrastructure", async () => {
@@ -169,8 +191,16 @@ describe("warehouse.test against a real DuckDB store", () => {
     expect(ok.title).toContain("OK")
 
     Registry.reset()
-    Registry.setConfigs({ local: { type: "duckdb", path: storePath, open_timeout_ms: 1 } })
-    const broken = await tool.execute({ name: "local" }, ctx)
+    const prev = process.env["ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS"]
+    process.env["ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS"] = "1"
+    let broken: Awaited<ReturnType<typeof tool.execute>>
+    try {
+      Registry.setConfigs({ local: { type: "duckdb", path: storePath } })
+      broken = await tool.execute({ name: "local" }, ctx)
+    } finally {
+      if (prev === undefined) delete process.env["ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS"]
+      else process.env["ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS"] = prev
+    }
     // The whole point: a reader of this transcript — human or model — must not
     // be able to mistake a broken client for the model getting something
     // wrong, or for a connection that needs its credentials fixed.

--- a/packages/opencode/test/altimate/warehouse-test-duckdb-e2e.test.ts
+++ b/packages/opencode/test/altimate/warehouse-test-duckdb-e2e.test.ts
@@ -1,0 +1,122 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+
+import { Dispatcher } from "../../src/altimate/native"
+import * as Registry from "../../src/altimate/native/connections/registry"
+import { WarehouseTestTool } from "../../src/altimate/tools/warehouse-test"
+import { initTool } from "./tool-fixture"
+
+// End-to-end coverage for the `warehouse_test` tool against a real DuckDB file
+// on disk, through the same `Dispatcher.call("warehouse.test", …)` the tool
+// itself makes. A mock connector would not have caught the bug this replaces —
+// it lived in the native open path — so nothing here is faked.
+//
+// Needs its own `bun test` process, and refuses to run against a fake. See the
+// long note in `duckdb-open-e2e.test.ts` for why.
+const RUN = process.env["ALTIMATE_DUCKDB_E2E"] === "1"
+const ddbTest = RUN ? test : test.skip
+
+let dir = ""
+let storePath = ""
+
+async function warehouseTest(name: string) {
+  return Dispatcher.call("warehouse.test", { name })
+}
+
+describe("warehouse.test against a real DuckDB store", () => {
+  beforeAll(async () => {
+    process.env["ALTIMATE_TELEMETRY_DISABLED"] = "true"
+    if (!RUN) return
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "warehouse-test-"))
+    storePath = path.join(dir, "warehouse.duckdb")
+    Registry.reset()
+    Registry.setConfigs({ seed: { type: "duckdb", path: storePath } })
+    const c = await Registry.get("seed")
+    await c.execute("CREATE TABLE t AS SELECT 1 AS a")
+    const probe = await c.execute("SELECT count(*) AS n FROM t")
+    Registry.reset()
+    // Refuse to run against anything but the real driver — see above.
+    if (Number(probe.rows?.[0]?.[0]) !== 1) {
+      throw new Error(
+        "ALTIMATE_DUCKDB_E2E=1 but the DuckDB driver is not the real one — " +
+          "either the native binding is missing, or another test file has replaced " +
+          "the module with a mock. Run this file in its own `bun test` process.",
+      )
+    }
+  })
+
+  afterEach(() => {
+    Registry.reset()
+  })
+
+  afterAll(() => {
+    delete process.env["ALTIMATE_TELEMETRY_DISABLED"]
+    Registry.reset()
+    if (dir) fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  ddbTest("connects on every one of 10 consecutive fresh registries", async () => {
+    // The failure this replaces was 7 of 7 calls failing, and a fix that is
+    // merely usually right would recreate exactly that contamination. Each
+    // iteration resets the registry so nothing is served from cache.
+    for (let i = 0; i < 10; i++) {
+      Registry.reset()
+      Registry.setConfigs({ local: { type: "duckdb", path: storePath } })
+      const result = await warehouseTest("local")
+      expect(result.connected).toBe(true)
+      expect(result.error).toBeUndefined()
+    }
+  })
+
+  ddbTest("reports a broken client as an infrastructure failure, not a failed connection", async () => {
+    Registry.reset()
+    // An unreachably small open budget stands in for any local fault that
+    // stops the store opening. The point of the assertion is the *shape* of
+    // the report: a caller must be able to tell this apart from a bad
+    // password without parsing prose.
+    Registry.setConfigs({ local: { type: "duckdb", path: storePath, open_timeout_ms: 1 } })
+    const result = await warehouseTest("local")
+    expect(result.connected).toBe(false)
+    expect(result.infrastructure).toBe(true)
+    expect(result.error_category).toBe("driver_open_timeout")
+  })
+
+  ddbTest("does not mark a genuine configuration mistake as infrastructure", async () => {
+    Registry.reset()
+    Registry.setConfigs({ local: { type: "duckdb", path: storePath } })
+    const result = await warehouseTest("nonexistent")
+    expect(result.connected).toBe(false)
+    expect(result.infrastructure).toBe(false)
+  })
+
+  ddbTest("a healthy store is unaffected by the deadline that failed the previous case", async () => {
+    Registry.reset()
+    Registry.setConfigs({ local: { type: "duckdb", path: storePath } })
+    const result = await warehouseTest("local")
+    expect(result.connected).toBe(true)
+  })
+
+  ddbTest("the warehouse_test tool renders infrastructure faults unmistakably", async () => {
+    const tool = await initTool(WarehouseTestTool)
+    const ctx = { sessionID: "s", messageID: "m", agent: "build", abort: new AbortController().signal, messages: [] }
+
+    Registry.reset()
+    Registry.setConfigs({ local: { type: "duckdb", path: storePath } })
+    const ok = await tool.execute({ name: "local" }, ctx)
+    expect(ok.title).toContain("OK")
+
+    Registry.reset()
+    Registry.setConfigs({ local: { type: "duckdb", path: storePath, open_timeout_ms: 1 } })
+    const broken = await tool.execute({ name: "local" }, ctx)
+    // The whole point: a reader of this transcript — human or model — must not
+    // be able to mistake a broken client for the model getting something
+    // wrong, or for a connection that needs its credentials fixed.
+    expect(broken.title).toContain("INFRASTRUCTURE FAILURE")
+    expect(broken.output).toContain("INFRASTRUCTURE FAILURE")
+    expect(broken.output).toContain("NOT a problem with the connection's configuration")
+    expect(broken.metadata.infrastructure).toBe(true)
+    expect(broken.metadata.error_category).toBe("driver_open_timeout")
+  })
+})

--- a/packages/opencode/test/altimate/warehouse-test-duckdb-e2e.test.ts
+++ b/packages/opencode/test/altimate/warehouse-test-duckdb-e2e.test.ts
@@ -21,6 +21,10 @@ const ddbTest = RUN ? test : test.skip
 
 let dir = ""
 let storePath = ""
+// A store this process never opens — see the note in duckdb-open-e2e.test.ts.
+// DuckDB's lock is per-process, so a store this process has open cannot be
+// locked against it by anyone else.
+let lockedPath = ""
 // Captured so afterAll can put the environment back exactly as it found it.
 // Unconditionally deleting would clear a value the surrounding process had set.
 let prevTelemetryDisabled: string | undefined
@@ -36,6 +40,7 @@ describe("warehouse.test against a real DuckDB store", () => {
     if (!RUN) return
     dir = fs.mkdtempSync(path.join(os.tmpdir(), "warehouse-test-"))
     storePath = path.join(dir, "warehouse.duckdb")
+    lockedPath = path.join(dir, "locked.duckdb")
     Registry.reset()
     Registry.setConfigs({ seed: { type: "duckdb", path: storePath } })
     const c = await Registry.get("seed")
@@ -114,11 +119,11 @@ describe("warehouse.test against a real DuckDB store", () => {
   })
 
   ddbTest("a store locked by another process is reported as a recoverable lock", async () => {
-    const lock = await holdWriteLock(storePath, dir)
+    const lock = await holdWriteLock(lockedPath, dir)
     try {
       await Registry.closeAll()
       Registry.reset()
-      Registry.setConfigs({ local: { type: "duckdb", path: storePath } })
+      Registry.setConfigs({ local: { type: "duckdb", path: lockedPath } })
       const result = await warehouseTest("local")
       expect(result.connected).toBe(false)
       // Not "other": before this, an unwrapped lock error fell through every
@@ -137,11 +142,11 @@ describe("warehouse.test against a real DuckDB store", () => {
   ddbTest("the tool tells a caller to clear a lock, not to stop and report it", async () => {
     const tool = await initTool(WarehouseTestTool)
     const ctx = { sessionID: "s", messageID: "m", agent: "build", abort: new AbortController().signal, messages: [] }
-    const lock = await holdWriteLock(storePath, dir)
+    const lock = await holdWriteLock(lockedPath, dir)
     try {
       await Registry.closeAll()
       Registry.reset()
-      Registry.setConfigs({ local: { type: "duckdb", path: storePath } })
+      Registry.setConfigs({ local: { type: "duckdb", path: lockedPath } })
       const locked = await tool.execute({ name: "local" }, ctx)
       expect(locked.title).toContain("STORE LOCKED")
       expect(locked.metadata.recoverable).toBe(true)


### PR DESCRIPTION
### Issue for this PR

Closes #1197

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**The bug.** `warehouse_test` failed on local DuckDB stores with `Timed out opening DuckDB database "<path>"`. Seven calls across six separate compiled-binary processes, durations 2061 / 2002 / 2005 / 2005 / 2004 / 2003 / 2004 ms — six of seven within 5ms of exactly 2000. A fixed deadline firing, not contention, which scatters. The stores were fine: in the same processes moments later, `python3 -c "import duckdb"` opened the same 1.3MB files and queried them.

`packages/drivers/src/duckdb.ts` rejected the open after a hard-coded 2000ms with no way to raise it. That is not a performance budget — DuckDB dispatches the open to the libuv threadpool, so the wait covers queueing behind every other threadpool user in the process (fs, dns, crypto), not just DuckDB's own work. On a loaded machine a healthy open crosses it, and the driver then rejects *and closes the handle that was about to succeed*, leaving the caller no way to recover. The budget now defaults to 30s and is settable per connection (`open_timeout_ms`) or by `ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS`.

**A second, live path to the identical symptom.** The "open callback fired synchronously" sentinel was `undefined` — which is exactly what a success callback invoked with no arguments passes. Such a callback was stored in `pendingOpen`, the replay guard `if (pendingOpen !== undefined)` then read it as "has not fired yet", the promise never settled, and the open failed on the deadline. That produces this exact string, deterministically, at exactly 2000ms. The sentinel is now a symbol the callback cannot supply, and a zero-argument success is normalised to `null`.

**The expensive half: the failure was silent.** `warehouse_test` reported `Connection 'x': FAILED` for a driver that will not load and for a wrong password alike, so an infrastructure fault read as a configuration fault — or, to a model or anyone reading a transcript, as the task simply not working. `Registry.test()` now returns `error_category` and `infrastructure`, and the tool renders local-client faults (`driver_missing`, `driver_open_timeout`, `store_locked`) as an unmistakable `INFRASTRUCTURE FAILURE` with `infrastructure: true` in metadata. `categorizeConnectionError` already existed for telemetry; this reuses it and adds the two categories the generic `timeout` / `not found` rules were swallowing.

**Read-only and lock detection (cherry-picked, not rewritten).** The first commit is `9d05c9f37a` verbatim, from a branch it had been sitting on alone. It fixes two things:

- `config.readonly` was read nowhere in `duckdb.ts` — across `packages/drivers/src/` the only reader is `sqlite.ts:15`. A caller declaring a read-only connection still got a read-write open and took the exclusive lock.
- The read-only retry was **unreachable**, not merely narrow. `onOpen` rejected with `Error("DUCKDB_LOCKED")` only when `msg.includes("locked") || includes("SQLITE_BUSY") || includes("DUCKDB_LOCKED")` matched, and the outer gate was `err.message === "DUCKDB_LOCKED"`. DuckDB's real message is `Could not set lock on file …: Conflicting lock is held`, which contains "lock" but never "locked", so the matcher returned false and the retry path could never execute on a genuine lock collision.

On top of that commit I dropped the `DUCKDB_LOCKED` normalisation inside `onOpen` and made `wrapDuckDBError` append rather than replace, because DuckDB's own text names the PID and executable holding the lock and that is the only way to find the other process. One assertion in `driver-security.test.ts` was updated to match the new wording.

**A separate defect found while reproducing.** `duckdb` was missing from `trustedDependencies`, so `bun install` never ran its `node-pre-gyp install` lifecycle script and `lib/binding/duckdb.node` was never fetched. On such a tree every DuckDB call fails with "driver not installed" even though the package is present. `drivers-e2e.test.ts` already carries a comment working around this exact symptom. I am calling it out separately because it is **not** the cause of the field failure above — the affected traces contain zero occurrences of `not installed`, `npm install`, `binding`, `MODULE_NOT_FOUND` or `Cannot find module`.

**Correction — this deadline was not the whole cause of the field failure.** The paragraph above says the affected traces contain no resolution-failure strings, and that is still true of those traces. But a later investigation found the field failure was **coupled**, not single-cause: driver resolution fell back to an on-demand install, eight of those ran concurrently and corrupted the shared dependency tree, and every load after that failed against the wreckage. The 2000ms deadline is a real defect and it did fire, but it was one link in that chain rather than the sole cause, and fixing it alone would not have made that run pass. I am leaving the timing evidence above as recorded, and correcting the conclusion drawn from it.

**Not this PR.** #1122 fixes driver *resolution* (a bare `await import("duckdb")` resolving against bunfs in a compiled binary). The code is disjoint — that PR touches the file's head, this touches `wrapDuckDBError` and the `connect()` body, and `9d05c9f37a` cherry-picks onto current `main` with no conflict — but per the correction above the two failures are links in one chain, not unrelated events.

### How did you verify your code works?

**Field evidence, added after review: this PR's absence causes measured data loss under concurrency.**

A benchmark rig launches concurrent trials that share a DuckDB store by construction. Two binaries, same store, same concurrency of 8, differing only in whether this PR is present:

| binary | canary returned | lock conflicts | driver load failures |
|---|---|---|---|
| without this PR | **1 / 8** | **7** | 0 |
| with this PR | **8 / 8** | **0** | 0 |

```
IO Error: Could not set lock on file … Conflicting lock is held … (PID 23384)
```

Seven of eight concurrent readers could not open a store they had every right to read, because `config.readonly` was dropped on the floor and the read-only retry was gated on a string that a real DuckDB lock error never contains. The affected surface is 8 of 12 datasets and 40 of 54 queries; a sweep run without this PR would have completed and produced a plausible, fully-traced number from trials that mostly read nothing.

Rig-side causes were eliminated before this comparison was drawn: no WAL on the store, an explicit `CHECKPOINT` changed nothing, and four concurrent `READ_ONLY` opens through the module itself all succeeded.

This is independent of the unit tests below — it is a controlled A/B in the environment the code actually runs in, and it is the strongest reason to merge.



Against a real DuckDB store through the real `Dispatcher.call("warehouse.test", …)` path — the same call the tool makes. A mock is what missed this bug in the first place.

**Reproduced first, from two directions, before changing anything:**

| Condition | Result on `main` |
|---|---|
| Write lock held by a second process | **0/7** — `IO Error: Could not set lock on file … Conflicting lock is held in … (PID 65001)` |
| `lib/binding/duckdb.node` absent | **0/7** — `DuckDB driver not installed. Run: npm install duckdb` |

Then the mechanism, in one process on one file: with `open_timeout_ms: 1` the driver fails; at the default it succeeds and returns the row. Same store, same process — the deadline was the failure, not the store, which is what the field evidence showed.

**Ruling out the resolution bug as the cause of the timeout.** I compiled a probe with the production compile options from `script/build.ts` (`external: ["duckdb"]`, `autoloadPackageJson: true`) and ran it from a cwd with no `node_modules`: resolution failure surfaces as `DuckDB driver not installed` in **0-2ms**, never as a timeout. From a cwd where `duckdb` resolves, the same compiled binary opened the store and queried it. So #1122's failure and this one are genuinely different events.

**Repeat runs, because a fix that is merely usually right would recreate the contamination this replaces:**

- `ALTIMATE_DUCKDB_E2E=1 bun test` on the two e2e files, **25 consecutive runs, 25/25 fully green** (325 test executions).
- Compiled binary, **30 fresh processes × 7 `warehouse.test` calls = 210/210 connected**, 0 failures.

**Concurrency**, measured across separate OS processes with the real package (independently reproduced by a colleague):

| Experiment | Result |
|---|---|
| Write lock held by another process; probe `default` / `READ_ONLY` / `read_only` | **all three fail** |
| 9 stores × 8 concurrent opens, **READ_ONLY up front** | **9/9 stores, 72/72 opens** |
| Same, opened read-write (`main`'s behaviour) | **0/9 stores** (per-store 4,5,4,3,4,4,4,4,4 of 8) |

The read-only *retry* cannot rescue a lock already held read-write by another process — DuckDB's lock is exclusive against read-only opens too. It is the up-front `config.readonly` open that does the work. Quote the 9/9 only with that precondition.

**`trustedDependencies`, both directions:** a scratch `bun install` with `trustedDependencies: ["duckdb"]` produces `lib/binding/duckdb.node`; without it the directory is empty, which is the state a fresh worktree of this repo was in.

**New tests fail on unmodified `main`** — I swapped `main`'s `duckdb.ts` in and reran: 4 of 8 fail there (the `config.readonly` test and the three deadline tests) and all 8 pass with this change.

**About the test placement**, because it is unusual and a reviewer will ask. Four files in `test/altimate` install a top-level `mock.module("@altimateai/drivers/duckdb", …)`, Bun evaluates every test file's top level before running any test, and `mock.restore()` does not undo a module mock. So in a whole-directory run the real driver is already replaced no matter how files sort or which specifier the test imports — I confirmed order makes no difference. These files are therefore gated on `ALTIMATE_DUCKDB_E2E=1` with a dedicated CI step, following the existing `drivers-e2e.test.ts` pattern. When the gate is on, a missing or mocked driver **fails** rather than skips: a green e2e file that quietly skipped everything is the same class of defect as the one this PR fixes.

| Gate | Result (after the review round) |
|---|---|
| `bun run typecheck` | 13/13 successful |
| `bun run script/upstream/analyze.ts --markers --base origin/main --strict` | ok — no upstream-shared files modified. Run against `origin/main`, not a bare `main`: a stale local `main` hides violations CI catches |
| `bun run lint` | 5863 warnings, 1 error. The error is the known pre-existing `consistent-return` in `packages/http-recorder/test/record-replay.test.ts`. The warning count is **+1 against this branch's previous commit**, from an un-awaited `mock.module` in a new test — which is how every other `mock.module` in that file is written |
| `packages/drivers` full suite | 141 pass, 0 fail |
| `packages/opencode` `test/altimate` (gate off) | 4222 pass, 0 fail, 151 files |
| `ALTIMATE_DUCKDB_E2E=1`, the two e2e files | 19 pass, 0 fail |

**Not verified by me:**

- `bun run typecheck` reporting 13/13 does **not** type-cover `packages/drivers/src/duckdb.ts` — that package declares no `typecheck` script, so it is not in the turbo task. Do not read 13/13 as coverage of the main change. It *does* cover `packages/opencode`, tests included: it caught a real type error in the new lock helper during the review round, which is the only direct evidence here of what the gate does and does not reach.
- A green `bun test --cwd packages/drivers` proves **nothing** about module resolution. That package's own `node_modules` is reachable for the whole run, so the resolution failure in #1122 cannot appear in it by construction. Two separate investigations drew the wrong conclusion from exactly that command. The only evidence about resolution in this PR is the compiled-binary probe described above.
- I could not reproduce the 2000ms timeout on an idle laptop, which is expected: the deadline fires under load. The mechanism is demonstrated by making the budget the variable rather than by recreating the field load, and by the field's own timing distribution.
- Windows, and the 30s default under a genuinely pathological store (very large, or a large WAL to replay). 30s is a judgement call, not a measured figure.
- The `trustedDependencies` addition makes `bun install` fetch a ~55MB prebuilt binary for everyone, including contributors who never touch DuckDB. I think that is the right trade because the alternative is a driver that silently does not work, but it is a cost and a reviewer may disagree.

**Review round (commit `e0d5decd10`).** Fifteen threads, four of them the same defect.

- **A lock on an explicitly read-only open was reported as an unclassified failure.** `connect()` only wrapped a lock error on the retry path, and an explicit `config.readonly` open never reaches that path — correctly, since DuckDB's lock is exclusive against read-only opens too, so retrying `READ_ONLY` when we already asked for `READ_ONLY` only repeats the failure. The `else` rethrew DuckDB's raw text, and `categorizeConnectionError` matches only the wrapper's `locked by another process` wording, so a plain lock collision came out as `other` — the same shape as a wrong password. Now wrapped, still not retried. `:memory:` is excluded for the same reason the retry excludes it.
- **The classifier now also matches DuckDB's raw text** (`conflicting lock`, `could not set lock`), so a lock reaching it unwrapped from any other path is still classified.
- **A locked store is no longer rendered as a broken client.** Two reviewers were right that `INFRASTRUCTURE FAILURE — stop and report` is wrong advice for a lock. It stays `infrastructure` (nothing about the config is wrong, and a harness must not score it as a task failure) but is now also `recoverable`, and the tool renders `STORE LOCKED` with the remedy the driver's own message already gives.
- `setTimeout` clamps a delay past 2^31-1 to about 1ms, so a deliberately huge `open_timeout_ms` became an immediate deadline. Clamped before it reaches the timer.
- The deadline message named only `ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS`, which `config.open_timeout_ms` overrides; it now names both and which wins.
- A deadline firing because the callback never arrives left the handle open. A late callback closes it via `onOpen`; when it never arrives the timeout closes it. Both idempotent.
- Dropped a dead `msg.includes("duckdb_locked")` clause — `msg` is lowercased, so `locked` already matches it.
- The `drivers` CI path filter did not list the two E2E files its own step runs, so a PR touching only those files got no execution anywhere.
- `Registry.reset()` is synchronous and `close()` is not, so it leaked a native handle per connector. Added `Registry.closeAll()`, used by `reload()` and the E2E suite.
- The E2E suite deleted `ALTIMATE_TELEMETRY_DISABLED` on teardown instead of restoring it.
- `bun.lock` did not record the `trustedDependencies` addition.

**Tests added.** `driver-security.test.ts` pins the read-only wrap and that the open is attempted exactly once with `READ_ONLY` — it fails without the fix. `connections.test.ts` adds eight ungated cases pinning the classification, including DuckDB's verbatim lock text (which contains `lock` but never `locked`). A new `duckdb-lock-helper.ts` holds a write lock **from a separate OS process**, because DuckDB's lock is per-process and an in-process second open proves nothing; the E2E suite uses it to cover read-only and read-write opens against a foreign lock, that the store is usable once released (which guards the helper itself), and the `STORE LOCKED` rendering.

**The review round's own tests hit this PR's bug, and CI caught it.** The first push of the round added a helper that holds a DuckDB write lock from a separate OS process. It resolved `duckdb` with `createRequire(import.meta.url)` from `packages/opencode/test/altimate/`. That passed on my machine and failed on CI with `Cannot find package 'duckdb'` — `duckdb` is a dependency of `packages/drivers` and lives only in `packages/drivers/node_modules`. Same class of fault as the one this PR exists to fix, reintroduced by the test written to prove the fix. The helper now takes the lock *through the driver*, imported by the absolute path both E2E suites already resolve.

Fixing that surfaced a second one worth recording: with resolution working, all three driver-level lock tests failed locally because **the test runner itself still held the write lock**. DuckDB's lock is per-process, and the driver's `close()` falls back to a 500ms timer because the native close callback does not always fire under Bun, so "closed" is not instantaneous. The lock tests now use their own store that this process never opens successfully. Six consecutive gated E2E runs, 19/19 each.

**Second review wave (commit `6ac0c640ae`).** Seventeen threads; two of them found gaps that mattered more than anything in the first wave.

- **`packages/drivers` had never run in CI.** The package declares no scripts, no job sets it as a working directory, and the TypeScript job runs `bun test` from `packages/opencode` only. All 142 driver unit tests — the lock, timeout and read-only regressions this PR turns on — could have failed with no job noticing. Added a `Run drivers unit suite` step to the `driver-e2e` job. Worth flagging: enabling it could surface pre-existing Linux failures a macOS run does not show.
- **The DuckDB E2E step ran with a 5s per-test deadline.** Invoking `bun test` directly does not use the package's `test` script, so it took the CLI default of 5000ms — shorter than the driver's own 30s default open budget and the lock helper's 30s readiness budget. A step meant to prove a too-short deadline was removed was imposing one of its own. Now `--timeout 90000`.
- **A deadline the caller set was reported as a broken client.** With `open_timeout_ms: 1` on the connection, `warehouse_test` said "the client on this machine is broken, nothing about your configuration is wrong, stop and report" for a failure that connection's own setting caused. Same category error this PR removes, pointing the other way. `resolveOpenTimeoutMs` now returns the source; a connection-scoped budget names itself and classifies as `config_error`, while the default or env var stays `driver_open_timeout` and infrastructure.
- The raw-lock fallback matched `could not set lock` alone, generic enough to appear in an unrelated remote error — it would have told the user to close a local process over a warehouse fault. Now requires DuckDB's full shape.
- The `drivers` filter ignored `package.json`, `bun.lock` and `packages/drivers/package.json`, which govern whether the native binding is fetched at all.
- The lock helper's 30s readiness timer was never cleared, and its child imported the driver outside its `try` so a load failure surfaced as a bare unhandled rejection.

**Declined, with reasons on the threads:** per-test `tmpdir()` scoping for the two E2E files (they run in a dedicated single-file Bun process, sequentially, and the lock tests specifically need a store this process never opens — DuckDB's lock is per-process); per-test `mock.module` teardown in `driver-security.test.ts` (every test in that block already installs its own mock, and isolating only the new ones would leave the file inconsistent); and generation-invalidating the connector cache in `reload()` (a real latent race, but unchanged by this PR and deserving its own change with its own concurrency tests).

**Final gate results:** typecheck 13/13; markers ok against `origin/main`; `packages/drivers` 142 pass / 0 fail; `test/altimate` 4224 pass / 0 fail; gated DuckDB E2E 21 pass / 0 fail on six consecutive runs. Lint 5864 warnings / 1 error — the error is the pre-existing `consistent-return` in `packages/http-recorder/test/record-replay.test.ts`; the warnings are +2 against this branch's pre-review-round commit, both un-awaited `mock.module` calls in new tests, matching how every other `mock.module` in that file is written.

**Liveness assertion (commit `c06a851e31`).** Every other assertion in `duckdb-open-e2e.test.ts` can be satisfied by a connection that is not really there: a row count can legitimately be zero, and an absent error string can mean the error was *swallowed* rather than that none occurred. That is live on `main` today — `register.ts`'s `sql.execute` catches everything and returns `{ row_count: 0, error }` instead of throwing, and `formatResult` renders `(0 rows)` without ever reading `error`, so `(0 rows)` and "the driver is dead" are indistinguishable downstream.

`md5()` is not: a dead connection cannot return one row, and a live one cannot return the right digest without hashing the input. The probe now gates the whole file (in the `beforeAll` that already refused to run against a fake, but did so on a row count a stub can trivially return) and is asserted explicitly in its own test. The expected digest is computed independently and cross-checked, never by asking DuckDB — deriving it from the system under test would make the check circular.

This is not a hypothetical safeguard. During the driver A/B for this PR, two binaries looked clean across transcripts, traces and 563 lines of debug output — zero ENOENT, zero fault lines — while failing to load the driver entirely; a probe of this shape is what caught it, after four earlier probe designs passed while proving nothing.

Verified load-bearing rather than decorative, since a liveness check that cannot fail is the very defect it exists to prevent: DuckDB independently returns the expected digest; a wrong digest aborts the whole file at the gate (0 pass, 1 fail); a wrong digest in the test alone, gate intact, fails that test (13 pass, 1 fail); and appending `WHERE false` to reproduce the `(0 rows)` shape fails it too — the swallowed-error case specifically.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes native DuckDB connection behavior, agent-facing warehouse test messaging, and CI coverage for local stores—high impact for DuckDB users but scoped to drivers/connections rather than auth or remote warehouse protocols.
> 
> **Overview**
> Replaces the DuckDB driver’s fixed **2s open deadline** with a **30s default** and tunable budgets (`open_timeout_ms`, `ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS`), fixes the **sync open callback** sentinel so zero-arg successes no longer hang until timeout, and improves **lock detection** (DuckDB’s real “conflicting lock” text), **`config.readonly`** opens, error wrapping, and cleanup when the callback never fires.
> 
> **`warehouse.test` / registry** now classify local-client failures (`driver_open_timeout`, `store_locked`, etc.), expose **`infrastructure`** / **`recoverable`**, and the **`warehouse_test`** tool distinguishes **INFRASTRUCTURE FAILURE** from **STORE LOCKED** (close-and-retry) vs ordinary config failures. Adds **`Registry.closeAll()`** for async connector teardown.
> 
> **Install & CI:** adds **`duckdb`** to **`trustedDependencies`** so the native binding installs; runs **`packages/drivers`** unit tests; runs gated real-DuckDB E2E in a **dedicated step** (`ALTIMATE_DUCKDB_E2E=1`, 90s timeout) and widens path filters so those tests and lock files still trigger the driver job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1fa3f1bb78a4f4b09ab8c00c4e48a1d32ed22cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the DuckDB driver failing healthy local stores with a 2s open deadline, and makes broken clients report as infrastructure faults instead of failed connections. Closes #1197.

**Bug fixes**

- Raises the open timeout from a hard-coded 2000ms to 30s, settable per connection (`open_timeout_ms`) or via `ALTIMATE_DUCKDB_OPEN_TIMEOUT_MS`; the old deadline fired under load because opens queue behind other libuv threadpool work.
- Fixes a second path to the same timeout: a synchronous success callback was recorded as `undefined` (the "not fired" sentinel), so the open never settled and hit the deadline.
- Honors `config.readonly` by opening `READ_ONLY` up front; lock detection now matches DuckDB's real message, which contains "lock" but never "locked", and requires both "could not set lock" and "conflicting lock" so non-contention failures keep their own message instead of being mislabeled as a lock.
- Wraps lock errors on explicit read-only opens too (still never retried, `:memory:` excluded), keeping DuckDB's original text that names the PID and executable holding the conflicting lock.
- Clamps over-large budgets so `setTimeout` can't turn them into an instant deadline, and the deadline now closes the native handle when the open callback never arrives.
- Adds `Registry.closeAll()`; synchronous `Registry.reset()` leaked a native handle per connector.

**Reporting and tests**

- `Registry.test()` now returns `error_category`, `infrastructure`, and `recoverable`; `warehouse_test` renders `driver_missing`/`driver_open_timeout` as `INFRASTRUCTURE FAILURE` and `store_locked` as `STORE LOCKED` with close-and-retry advice. A deadline the connection set itself classifies as `config_error`, and `categorizeConnectionError` matches DuckDB's raw lock text so an unwrapped lock no longer falls through to `other`.
- Adds `duckdb` to `trustedDependencies` so `bun install` fetches the native binding; without it every DuckDB call fails with "driver not installed".
- New e2e tests open a real store on disk, gated on `ALTIMATE_DUCKDB_E2E=1` (gate-off skips, gate-on hard-fails on a missing or mocked driver), and include an md5 liveness probe that a dead or fake driver cannot satisfy. CI now also runs the `packages/drivers` unit suite (previously never ran) and a dedicated gated step with an explicit 90s timeout.

<sup>Written for commit b1fa3f1bb78a4f4b09ab8c00c4e48a1d32ed22cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/1198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DuckDB connection handling for timeouts, read-only access, lock detection, and cleanup.
  * Warehouse connection checks now distinguish infrastructure failures, locked stores, recoverable errors, and ordinary failures.
  * Error messages now provide clearer failure categories and recovery guidance.
  * Resolved issues that could leave connections open after failed operations.

* **Tests**
  * Added end-to-end coverage for real DuckDB stores, concurrent access, timeouts, read-only behavior, and lock recovery.
  * Expanded validation of warehouse-test failure reporting and connection lifecycle management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



