### PR TITLE
fix: scope the builder Pre-Execution Protocol to task shape

### DIFF
--- a/packages/opencode/src/altimate/prompts/profiles.ts
+++ b/packages/opencode/src/altimate/prompts/profiles.ts
@@ -72,12 +72,26 @@ export const BUILDER_PROFILE: readonly FragmentName[] = [
  */
 export const DATA_QA_PROFILE: readonly FragmentName[] = ["core", "legacy-skills-catalogue", "core-training"]
 
+/**
+ * The `builder` profile with the Pre-Execution Protocol (sql-guard) pack
+ * excluded — every other fragment, same order, unchanged. NOT a registered
+ * agent and not selected by default; it exists purely as a per-session
+ * override that `session/pre-execution.ts` swaps in for the `builder` agent's
+ * `.prompt` field when its task-shape gate confidently classifies a run-mode
+ * workspace as having no dbt project (the one cell an internal 540-trial
+ * paired ablation covered: no score effect, 2,805 pre-execution tool calls
+ * removed). Every other case — dbt work, interactive chat, or an
+ * unclassifiable workspace — keeps the default `PROMPT_BUILDER` untouched.
+ */
+export const BUILDER_PROFILE_SCOPED: readonly FragmentName[] = BUILDER_PROFILE.filter((name) => name !== "sql-guard")
+
 export function assemble(profile: readonly FragmentName[]): string {
   return profile.map((name) => FRAGMENTS[name]).join("")
 }
 
 export const PROMPT_BUILDER = assemble(BUILDER_PROFILE)
 export const PROMPT_DATA_QA = assemble(DATA_QA_PROFILE)
+export const PROMPT_BUILDER_SCOPED = assemble(BUILDER_PROFILE_SCOPED)
 
 export * as PromptProfiles from "./profiles"
 // altimate_change end

--- a/packages/opencode/src/session/pre-execution.ts
+++ b/packages/opencode/src/session/pre-execution.ts
@@ -82,6 +82,76 @@ function meansAbsent(err: unknown): boolean {
 }
 
 /**
+ * How many directory levels below a candidate to search for a nested dbt
+ * project. A single level missed real monorepo layouts — a project at
+ * `repo/platform/analytics/dbt_project.yml` when the candidate is `repo` is
+ * two levels down. Chosen generously for realistic layouts while keeping the
+ * scan bounded: unlike the ancestor walk above (naturally bounded by
+ * filesystem depth, and cheap — two `stat`s per level), a downward scan can
+ * visit an unbounded number of directories in a large tree.
+ */
+const MAX_DOWNWARD_LEVELS = 4
+
+/**
+ * Hard cap on directories enumerated during one downward scan, so a candidate
+ * sitting above a huge non-dbt tree cannot make every run-mode builder step
+ * pay for an unbounded `readdir` fan-out.
+ */
+const MAX_DOWNWARD_SCANS = 2000
+
+/**
+ * Breadth-first search for a dbt project file below `start`, down to
+ * `MAX_DOWNWARD_LEVELS` levels (the same skip list as the top-level scan, so
+ * a fixture project inside `node_modules/` or `target/` is never mistaken for
+ * the user's own).
+ *
+ * Returns `"dbt"` on the first project file found. Returns `"non-dbt"` only
+ * if the ENTIRE bounded tree was enumerated with none found. Returns
+ * `"unknown"` if the scan bound (levels or directory count) was hit, or any
+ * directory could not be enumerated, before the answer was settled — hitting
+ * a bound is "did not finish", not "found nothing", the same honesty rule the
+ * ancestor walk applies to its own (unbounded) limit.
+ */
+async function scanDownward(start: string): Promise<WorkspaceShape> {
+  let frontier = [start]
+  let scanned = 0
+  for (let level = 1; level <= MAX_DOWNWARD_LEVELS; level++) {
+    const next: string[] = []
+    for (const dir of frontier) {
+      if (scanned >= MAX_DOWNWARD_SCANS) return "unknown"
+      scanned++
+      let entries
+      try {
+        entries = await fs.readdir(dir, { withFileTypes: true })
+      } catch (err) {
+        if (!meansAbsent(err)) log.warn("workspace enumeration failed", { dir, code: errnoCode(err) })
+        return "unknown"
+      }
+      // Probe everything that is not plainly a regular file. Filtering on
+      // `isDirectory()` would silently skip symlinked directories and any
+      // entry whose type the filesystem did not report, and a skipped entry
+      // is an unexamined one. `hasProjectFile` on a non-directory just gets
+      // ENOTDIR, which is a real "nothing there".
+      const children = entries
+        .filter((e) => !e.isFile() && !e.name.startsWith(".") && !SKIP_DIRS.has(e.name))
+        // Deterministic order: fs.readdir's order varies across filesystems.
+        .sort((a, b) => a.name.localeCompare(b.name))
+      for (const child of children) {
+        const childPath = path.join(dir, child.name)
+        const found = await hasProjectFile(childPath)
+        if (found === true) return "dbt"
+        if (found === undefined) return "unknown"
+        next.push(childPath)
+      }
+    }
+    frontier = next
+  }
+  // Directories still queued at the level bound means the walk stopped
+  // before finishing, not that it finished and found nothing.
+  return frontier.length > 0 ? "unknown" : "non-dbt"
+}
+
+/**
  * How a workspace classifies for the purpose of this gate.
  *
  * `unknown` is a real, load-bearing state, not a placeholder: it is what we
@@ -128,9 +198,11 @@ async function hasProjectFile(dir: string): Promise<boolean | undefined> {
  *     "I stopped early" as `unknown` to stay honest, which on any deep tree
  *     turns the gate off entirely. Two `stat` calls per level, in run mode
  *     only, is not worth that.
- *   - **one level below** it, which is how benchmark and monorepo layouts nest
- *     a project (the same rule, and the same skip list, as
- *     `findDbtProjectRoot`).
+ *   - **up to `MAX_DOWNWARD_LEVELS` levels below** it, which is how benchmark
+ *     and monorepo layouts nest a project — a bounded breadth-first walk (see
+ *     `scanDownward`), not the single-level check `findDbtProjectRoot` uses;
+ *     a real monorepo project nested two or more directories down must still
+ *     read as `dbt`, not `non-dbt`.
  *
  * A project found in an unrelated ancestor is a false positive that KEEPS the
  * protocol, which is the safe direction.
@@ -172,38 +244,17 @@ export async function classifyWorkspace(candidates: (string | undefined)[]): Pro
       current = parent
     }
 
-    // One level below. The filesystem root is a legitimate stop rather than a
-    // directory to enumerate — a non-git project sets worktree to it, and
-    // scanning its children is meaningless and can be slow or permission-denied
-    // — so the root on its own never yields a complete answer.
+    // Below the candidate, down to MAX_DOWNWARD_LEVELS. The filesystem root
+    // is a legitimate stop rather than a directory to enumerate — a non-git
+    // project sets worktree to it, and scanning its children is meaningless
+    // and can be slow or permission-denied — so the root on its own never
+    // yields a complete answer.
     if (start === path.parse(start).root) {
       complete = false
     } else {
-      let entries
-      try {
-        entries = await fs.readdir(start, { withFileTypes: true })
-      } catch (err) {
-        if (!meansAbsent(err)) log.warn("workspace enumeration failed", { dir: start, code: errnoCode(err) })
-        entries = undefined
-      }
-      if (entries === undefined) {
-        complete = false
-      } else {
-        // Probe everything that is not plainly a regular file. Filtering on
-        // `isDirectory()` would silently skip symlinked directories and any
-        // entry whose type the filesystem did not report, and a skipped entry
-        // is an unexamined one. `hasProjectFile` on a non-directory just gets
-        // ENOTDIR, which is a real "nothing there".
-        const children = entries
-          .filter((e) => !e.isFile() && !e.name.startsWith(".") && !SKIP_DIRS.has(e.name))
-          // Deterministic order: fs.readdir's order varies across filesystems.
-          .sort((a, b) => a.name.localeCompare(b.name))
-        for (const child of children) {
-          const found = await hasProjectFile(path.join(start, child.name))
-          if (found === true) return "dbt"
-          if (found === undefined) complete = false
-        }
-      }
+      const below = await scanDownward(start)
+      if (below === "dbt") return "dbt"
+      if (below === "unknown") complete = false
     }
 
     if (complete) sawCompleteAnswer = true
@@ -224,6 +275,7 @@ export async function classifyWorkspace(candidates: (string | undefined)[]): Pro
  *
  *   run mode (headless / CI, the `run` CLI)  AND
  *   the builder agent (the only profile that ever carried the pack)  AND
+ *   the agent's prompt is STILL the stock default (see `input.prompt`)  AND
  *   a workspace confidently classified as having no dbt project.
  *
  * Everything else returns `undefined`, including `unknown`. Note the asymmetry
@@ -236,17 +288,65 @@ export async function classifyWorkspace(candidates: (string | undefined)[]): Pro
  */
 export async function scopedBuilderPrompt(input: {
   runMode: boolean
+  /**
+   * The agent's REGISTRY KEY — the string used to look it up (e.g. the
+   * `"builder"` in `Agent.get("builder")` / `cfg.agent.builder`) — NOT
+   * `Info.name`, which a user can rename via `agent.builder.name` in config
+   * while the agent stays registered under the `builder` key. Keying on the
+   * mutable display name would (a) silently stop scoping a renamed builder
+   * agent forever, and (b) start scoping a differently-purposed custom agent
+   * a user happens to name `"builder"`.
+   */
   agent: string
+  /**
+   * The resolved agent's CURRENT `.prompt`. The override is only ever safe to
+   * apply when this is still exactly `PromptProfiles.PROMPT_BUILDER` — a
+   * builder prompt customized via `agent.builder.prompt` in config or a
+   * `.altimate-code/agents/builder.md` override must never be silently
+   * discarded in favour of the stock scoped variant.
+   */
+  prompt: string | undefined
   /** Candidate directories to classify — typically the cwd and the worktree root. */
   directories: (string | undefined)[]
 }): Promise<string | undefined> {
   // Only builder ever carried this pack; analyst and reviewer never did.
   if (input.agent !== "builder") return undefined
+  if (input.prompt !== PromptProfiles.PROMPT_BUILDER) return undefined
   if (!input.runMode) return undefined
   const shape = await classifyWorkspace(input.directories)
   if (shape !== "non-dbt") return undefined
   log.info("pre-execution protocol scoped out", { agent: input.agent, shape })
   return PromptProfiles.PROMPT_BUILDER_SCOPED
+}
+
+/**
+ * Wrap `scopedBuilderPrompt` in a cache scoped to the lifetime of whatever the
+ * caller holds the returned function for.
+ *
+ * `session/prompt.ts`'s `loop()` calls this gate on every step of its
+ * `while (true)` turn loop — and that loop already documents, at its own
+ * trace-span guard, that "the system prompt is functionally identical across
+ * steps within a single loop() invocation (same agent, same environment)".
+ * `classifyWorkspace`'s filesystem walk is exactly such invariant work, so
+ * re-running it every step wastes real I/O (a `readdir` fan-out per step) on
+ * the exact run-mode/non-dbt workload this whole gate exists to make faster.
+ *
+ * The cache MUST be created fresh per loop() invocation, never held at module
+ * scope: workspace state can legitimately change BETWEEN turns (a prior turn
+ * could itself run `dbt init`), and a cache surviving across turns would
+ * silently keep serving a stale answer. Scoping it to one loop() invocation
+ * — a tight, synchronous sequence of the same turn's tool calls — accepts
+ * that same invariant the surrounding loop already relies on, and nothing
+ * more.
+ */
+export function createScopedBuilderPromptCache(): (
+  input: Parameters<typeof scopedBuilderPrompt>[0],
+) => Promise<string | undefined> {
+  let cached: { value: string | undefined } | undefined
+  return async (input) => {
+    if (!cached) cached = { value: await scopedBuilderPrompt(input) }
+    return cached.value
+  }
 }
 
 export * as SessionPreExecution from "./pre-execution"

--- a/packages/opencode/src/session/pre-execution.ts
+++ b/packages/opencode/src/session/pre-execution.ts
@@ -1,6 +1,6 @@
 // Fork-only module — owns the PRE-EXECUTION PROTOCOL SCOPING CONTRACT.
 //
-// The protocol below used to sit statically in `altimate/prompts/builder.txt`.
+// The protocol used to sit statically in `altimate/prompts/builder.txt`.
 // builder is a PRIMARY agent, so a static section there governs every builder
 // surface at once: dbt authoring, interactive chat, and headless
 // question-answering runs. A pre-registered paired ablation (540 trials on a
@@ -28,11 +28,26 @@
 // confidently keeps it too: the cost of keeping it is latency on one workload,
 // the cost of wrongly dropping it is unmeasured.
 //
-// Directive text lives here (not at the call site) so any wording-change review
-// covers ONE file, mirroring session/termination.ts.
+// MECHANISM (reworked onto the pack architecture — `altimate/prompts/profiles.ts`,
+// PR #1217): `builder.txt` no longer exists. The protocol is the `sql-guard`
+// pack, and it ships statically inside the default `builder` agent's `.prompt`
+// (`PromptProfiles.PROMPT_BUILDER`, byte-pinned by
+// `test/altimate/prompt-profiles.test.ts`) so it is present by default in every
+// case. This module no longer INJECTS the text — there is nothing to inject,
+// it is already there. Instead `scopedBuilderPrompt` returns a per-session
+// override prompt (`PromptProfiles.PROMPT_BUILDER_SCOPED`, the same profile
+// with the sql-guard pack excluded) for the one cell the ablation covers, or
+// `undefined` to mean "use the agent's default prompt unchanged". The call
+// site (session/prompt.ts) clones the resolved `Agent.Info` with `.prompt`
+// swapped only when this returns a value — the default static registration in
+// agent.ts, and the byte-identity pin, are never touched.
+//
+// Directive commentary lives here (not at the call site) so any change to the
+// gate's reasoning reviews in ONE file, mirroring session/termination.ts.
 
 import fs from "fs/promises"
 import path from "path"
+import { PromptProfiles } from "../altimate/prompts/profiles"
 import { Log } from "../util/log"
 
 const log = Log.create({ service: "pre-execution-scope" })
@@ -76,31 +91,6 @@ function meansAbsent(err: unknown): boolean {
  * into the same `null`, and this gate turns a directive off on the difference.
  */
 export type WorkspaceShape = "dbt" | "non-dbt" | "unknown"
-
-/**
- * The mandatory pre-execution sequence, verbatim as it shipped in
- * `builder.txt`. Prompt-visible text — changes need extra review.
- *
- * Kept byte-identical to the previous static section so that in every case
- * where the gate injects it, the resolved prompt is unchanged from before.
- */
-export const PRE_EXECUTION_PROTOCOL = [
-  "## Pre-Execution Protocol",
-  "",
-  "Before executing ANY SQL via sql_execute, follow this mandatory sequence:",
-  "",
-  "1. **Analyze first**: Run `sql_analyze` on the query. Check for HIGH severity anti-patterns.",
-  "   - If HIGH severity issues found (SELECT *, cartesian products, missing WHERE on DELETE/UPDATE, full table scans on large tables): FIX THEM before executing. Show the user what you found and the fixed query.",
-  "   - If MEDIUM severity issues found: mention them and proceed unless the user asks to fix.",
-  "",
-  "2. **Validate syntax**: Run `altimate_core_validate` to catch syntax errors and schema issues BEFORE hitting the warehouse.",
-  "",
-  "3. **Execute**: Only after steps 1-2 pass, run `sql_execute`.",
-  "",
-  "This sequence is NOT optional. Skipping it means the user pays for avoidable mistakes. You are the customer's cost advocate — every credit saved is trust earned. If the user explicitly requests skipping the protocol, note the risk and proceed.",
-  "",
-  "For trivial queries (e.g., `SELECT 1`, `SHOW TABLES`), use judgment — skip the full sequence but still validate syntax.",
-].join("\n")
 
 /**
  * Does `dir` itself contain a dbt project file?
@@ -223,35 +213,40 @@ export async function classifyWorkspace(candidates: (string | undefined)[]): Pro
 }
 
 /**
- * The sole gate for injecting the pre-execution protocol into a prompt.
+ * The sole gate for scoping the pre-execution protocol (the `sql-guard` pack)
+ * out of the builder prompt.
  *
- * Returns the protocol text to inject, or `undefined` to drop it. The ONLY
- * dropping case is the one the ablation measured:
+ * Returns a full replacement prompt to use INSTEAD of the agent's default
+ * `.prompt`, or `undefined` to mean "use the default, unchanged" — the
+ * default already carries the protocol, since it ships statically in
+ * `PromptProfiles.PROMPT_BUILDER`. The ONLY case this returns an override is
+ * the one the ablation measured:
  *
  *   run mode (headless / CI, the `run` CLI)  AND
- *   the builder agent (the only prompt that ever carried the section)  AND
+ *   the builder agent (the only profile that ever carried the pack)  AND
  *   a workspace confidently classified as having no dbt project.
  *
- * Everything else keeps it, including `unknown`. Note the asymmetry is
- * deliberate: run mode is not itself a task-shape signal, it is the surface the
- * evidence covers. Widening this to interactive chat needs its own measurement.
+ * Everything else returns `undefined`, including `unknown`. Note the asymmetry
+ * is deliberate: run mode is not itself a task-shape signal, it is the surface
+ * the evidence covers. Widening this to interactive chat needs its own
+ * measurement.
  *
  * Classification is only performed when the cheap conditions already hold, so
  * an interactive session pays no filesystem cost for this gate.
  */
-export async function preExecutionInstruction(input: {
+export async function scopedBuilderPrompt(input: {
   runMode: boolean
   agent: string
   /** Candidate directories to classify — typically the cwd and the worktree root. */
   directories: (string | undefined)[]
 }): Promise<string | undefined> {
-  // Only builder ever carried this section; analyst and reviewer never did.
+  // Only builder ever carried this pack; analyst and reviewer never did.
   if (input.agent !== "builder") return undefined
-  if (!input.runMode) return PRE_EXECUTION_PROTOCOL
+  if (!input.runMode) return undefined
   const shape = await classifyWorkspace(input.directories)
-  if (shape !== "non-dbt") return PRE_EXECUTION_PROTOCOL
+  if (shape !== "non-dbt") return undefined
   log.info("pre-execution protocol scoped out", { agent: input.agent, shape })
-  return undefined
+  return PromptProfiles.PROMPT_BUILDER_SCOPED
 }
 
 export * as SessionPreExecution from "./pre-execution"

--- a/packages/opencode/src/session/pre-execution.ts
+++ b/packages/opencode/src/session/pre-execution.ts
@@ -1,0 +1,140 @@
+// Fork-only module — owns the PRE-EXECUTION PROTOCOL SCOPING CONTRACT.
+//
+// The protocol below used to sit statically in `altimate/prompts/builder.txt`.
+// builder is a PRIMARY agent, so a static section there governs every builder
+// surface at once: dbt authoring, interactive chat, and headless
+// question-answering runs. A pre-registered paired ablation (540 trials on a
+// public data-question benchmark, one binary across both arms) measured what
+// the section costs on the question-answering surface:
+//
+//   macro Pass@1  control 0.6667 → treatment 0.6807
+//   delta +0.0140, query-blocked permutation p = 0.7358,
+//   cluster-bootstrap 95% CI [-0.0400, +0.0674]   → no score effect
+//   wall clock  440.9s → 319.4s  (-27.6%)
+//   model turns -27.7%, generation time -32.2%
+//   `altimate_core_validate` + `sql_analyze` calls  2,805 → 0
+//   `sql_execute` calls  +49%   (the freed budget went into real querying)
+//
+// The 2,805 → 0 is the one number directly attributable to this text: the
+// ritual is prompt-ordered, and deleting the order deletes it completely. The
+// latency win is NOT attributable to this section alone — that treatment arm
+// bundled five coupled changes and the experiment declined to attribute.
+//
+// So this module SCOPES rather than deletes. The measurement covers exactly
+// one cell — headless question-answering in a workspace with no dbt project —
+// and that is the only cell where the protocol is dropped. dbt work and
+// interactive chat, where a pre-execution discipline may genuinely earn its
+// place, are unmeasured and keep it. Anything that cannot be classified
+// confidently keeps it too: the cost of keeping it is latency on one workload,
+// the cost of wrongly dropping it is unmeasured.
+//
+// Directive text lives here (not at the call site) so any wording-change review
+// covers ONE file, mirroring session/termination.ts.
+
+import path from "path"
+import { Filesystem } from "../util/filesystem"
+import { findDbtProjectRoot } from "../altimate/validators/validator-utils"
+import { Log } from "../util/log"
+
+const log = Log.create({ service: "pre-execution-scope" })
+
+/**
+ * How a workspace classifies for the purpose of this gate.
+ *
+ * `unknown` is a real, load-bearing state, not a placeholder: it is what we
+ * report when the filesystem could not answer the question, and it keeps the
+ * protocol. `findDbtProjectRoot` collapses "no project here" and "could not
+ * read the directory" into the same `null`, so the readability check happens
+ * here, before it is consulted.
+ */
+export type WorkspaceShape = "dbt" | "non-dbt" | "unknown"
+
+/**
+ * The mandatory pre-execution sequence, verbatim as it shipped in
+ * `builder.txt`. Prompt-visible text — changes need extra review.
+ *
+ * Kept byte-identical to the previous static section so that in every case
+ * where the gate injects it, the resolved prompt is unchanged from before.
+ */
+export const PRE_EXECUTION_PROTOCOL = [
+  "## Pre-Execution Protocol",
+  "",
+  "Before executing ANY SQL via sql_execute, follow this mandatory sequence:",
+  "",
+  "1. **Analyze first**: Run `sql_analyze` on the query. Check for HIGH severity anti-patterns.",
+  "   - If HIGH severity issues found (SELECT *, cartesian products, missing WHERE on DELETE/UPDATE, full table scans on large tables): FIX THEM before executing. Show the user what you found and the fixed query.",
+  "   - If MEDIUM severity issues found: mention them and proceed unless the user asks to fix.",
+  "",
+  "2. **Validate syntax**: Run `altimate_core_validate` to catch syntax errors and schema issues BEFORE hitting the warehouse.",
+  "",
+  "3. **Execute**: Only after steps 1-2 pass, run `sql_execute`.",
+  "",
+  "This sequence is NOT optional. Skipping it means the user pays for avoidable mistakes. You are the customer's cost advocate — every credit saved is trust earned. If the user explicitly requests skipping the protocol, note the risk and proceed.",
+  "",
+  "For trivial queries (e.g., `SELECT 1`, `SHOW TABLES`), use judgment — skip the full sequence but still validate syntax.",
+].join("\n")
+
+/**
+ * Classify a workspace by the presence of a dbt project.
+ *
+ * `dbt` requires an actual `dbt_project.yml` file at one of the candidate
+ * directories or one level below it (`findDbtProjectRoot`'s existing rule —
+ * benchmark and monorepo layouts nest the project one level deep).
+ *
+ * `non-dbt` is only reported when at least one candidate directory was
+ * readable AND no project was found in any readable candidate. If no candidate
+ * could be read, the answer is `unknown`, never `non-dbt`.
+ */
+export async function classifyWorkspace(candidates: (string | undefined)[]): Promise<WorkspaceShape> {
+  // A non-git project sets worktree to the filesystem root; scanning that is
+  // never meaningful and can be slow or permission-denied.
+  const dirs = [...new Set(candidates.filter((d): d is string => !!d && d !== path.parse(d).root))]
+  let sawReadableDir = false
+  for (const dir of dirs) {
+    if (!(await Filesystem.isDir(dir))) continue
+    sawReadableDir = true
+    try {
+      if (await findDbtProjectRoot(dir)) return "dbt"
+    } catch (err) {
+      // findDbtProjectRoot already swallows its own errors; this is belt and
+      // braces so a future change there cannot turn a throw into a silent drop.
+      log.warn("dbt project scan failed", { dir, err })
+      return "unknown"
+    }
+  }
+  return sawReadableDir ? "non-dbt" : "unknown"
+}
+
+/**
+ * The sole gate for injecting the pre-execution protocol into a prompt.
+ *
+ * Returns the protocol text to inject, or `undefined` to drop it. The ONLY
+ * dropping case is the one the ablation measured:
+ *
+ *   run mode (headless / CI, the `run` CLI)  AND
+ *   the builder agent (the only prompt that ever carried the section)  AND
+ *   a workspace confidently classified as having no dbt project.
+ *
+ * Everything else keeps it, including `unknown`. Note the asymmetry is
+ * deliberate: run mode is not itself a task-shape signal, it is the surface the
+ * evidence covers. Widening this to interactive chat needs its own measurement.
+ *
+ * Classification is only performed when the cheap conditions already hold, so
+ * an interactive session pays no filesystem cost for this gate.
+ */
+export async function preExecutionInstruction(input: {
+  runMode: boolean
+  agent: string
+  /** Candidate directories to classify — typically the cwd and the worktree root. */
+  directories: (string | undefined)[]
+}): Promise<string | undefined> {
+  // Only builder ever carried this section; analyst and reviewer never did.
+  if (input.agent !== "builder") return undefined
+  if (!input.runMode) return PRE_EXECUTION_PROTOCOL
+  const shape = await classifyWorkspace(input.directories)
+  if (shape !== "non-dbt") return PRE_EXECUTION_PROTOCOL
+  log.info("pre-execution protocol scoped out", { agent: input.agent, shape })
+  return undefined
+}
+
+export * as SessionPreExecution from "./pre-execution"

--- a/packages/opencode/src/session/pre-execution.ts
+++ b/packages/opencode/src/session/pre-execution.ts
@@ -31,12 +31,48 @@
 // Directive text lives here (not at the call site) so any wording-change review
 // covers ONE file, mirroring session/termination.ts.
 
+import fs from "fs/promises"
 import path from "path"
-import { Filesystem } from "../util/filesystem"
-import { findDbtProjectRoot } from "../altimate/validators/validator-utils"
 import { Log } from "../util/log"
 
 const log = Log.create({ service: "pre-execution-scope" })
+
+/** Files that mark a directory as a dbt project root. */
+const PROJECT_FILES = ["dbt_project.yml", "dbt_project.yaml"] as const
+
+/**
+ * Subdirectories never considered candidates for a nested dbt project, mirroring
+ * `findDbtProjectRoot`'s skip list so a fixture project shipped inside
+ * `node_modules/foo/` or a compiled artifact in `target/` is not mistaken for
+ * the user's real project.
+ */
+const SKIP_DIRS = new Set(["node_modules", "target"])
+
+/**
+ * How far up from a candidate directory to look for a project root. A session
+ * is routinely started inside `models/` or `models/marts/` of a dbt project,
+ * and on a non-git project the worktree is the same directory (or the
+ * filesystem root), so the ancestor walk is the only thing that finds it.
+ */
+const MAX_ANCESTOR_LEVELS = 8
+
+/**
+ * The `errno` code of a filesystem rejection, when it carries one.
+ *
+ * `ENOENT` and `ENOTDIR` are real answers — nothing is there. Every other code,
+ * and an error carrying no code at all, means the question went unanswered.
+ */
+function errnoCode(err: unknown): string | undefined {
+  if (typeof err !== "object" || err === null || !("code" in err)) return undefined
+  const code = err.code
+  return typeof code === "string" ? code : undefined
+}
+
+/** True when a rejection means "nothing is there", rather than "could not tell". */
+function meansAbsent(err: unknown): boolean {
+  const code = errnoCode(err)
+  return code === "ENOENT" || code === "ENOTDIR"
+}
 
 /**
  * How a workspace classifies for the purpose of this gate.
@@ -75,34 +111,103 @@ export const PRE_EXECUTION_PROTOCOL = [
 ].join("\n")
 
 /**
- * Classify a workspace by the presence of a dbt project.
+ * Does `dir` itself contain a dbt project file?
  *
- * `dbt` requires an actual `dbt_project.yml` file at one of the candidate
- * directories or one level below it (`findDbtProjectRoot`'s existing rule —
- * benchmark and monorepo layouts nest the project one level deep).
- *
- * `non-dbt` is only reported when at least one candidate directory was
- * readable AND no project was found in any readable candidate. If no candidate
- * could be read, the answer is `unknown`, never `non-dbt`.
+ * Returns `undefined` — not `false` — when the filesystem could not answer.
+ * ENOENT and ENOTDIR are real answers ("nothing there"); anything else (EACCES,
+ * EIO, a transient network mount failure) is not, and must not be read as
+ * "no dbt project here".
  */
-export async function classifyWorkspace(candidates: (string | undefined)[]): Promise<WorkspaceShape> {
-  // A non-git project sets worktree to the filesystem root; scanning that is
-  // never meaningful and can be slow or permission-denied.
-  const dirs = [...new Set(candidates.filter((d): d is string => !!d && d !== path.parse(d).root))]
-  let sawReadableDir = false
-  for (const dir of dirs) {
-    if (!(await Filesystem.isDir(dir))) continue
-    sawReadableDir = true
+async function hasProjectFile(dir: string): Promise<boolean | undefined> {
+  let sawUnknown = false
+  for (const name of PROJECT_FILES) {
     try {
-      if (await findDbtProjectRoot(dir)) return "dbt"
+      if ((await fs.stat(path.join(dir, name))).isFile()) return true
     } catch (err) {
-      // findDbtProjectRoot already swallows its own errors; this is belt and
-      // braces so a future change there cannot turn a throw into a silent drop.
-      log.warn("dbt project scan failed", { dir, err })
-      return "unknown"
+      if (meansAbsent(err)) continue
+      log.warn("project-file probe failed", { dir, name, code: errnoCode(err) })
+      sawUnknown = true
     }
   }
-  return sawReadableDir ? "non-dbt" : "unknown"
+  return sawUnknown ? undefined : false
+}
+
+/**
+ * Classify a workspace by the presence of a dbt project.
+ *
+ * `dbt` requires an actual `dbt_project.yml` (or `.yaml`) FILE at, above, or
+ * one level below a candidate directory:
+ *
+ *   - **at** the candidate,
+ *   - **above** it, walking up to `MAX_ANCESTOR_LEVELS` parents — a session
+ *     started inside `models/` is still a dbt session, and on a non-git project
+ *     the worktree candidate does not rescue that case,
+ *   - **one level below** it, which is how benchmark and monorepo layouts nest
+ *     a project (the same rule, and the same skip list, as
+ *     `findDbtProjectRoot`).
+ *
+ * `non-dbt` requires at least one candidate the scan could examine COMPLETELY —
+ * every ancestor probe answered, and the candidate's own children enumerated —
+ * with no project found anywhere. Everything else is `unknown`: a candidate
+ * that cannot be enumerated, a stat failing for any reason other than "not
+ * there", the filesystem root (whose children are deliberately not scanned),
+ * and an empty candidate list. The caller reads `unknown` as "keep the
+ * protocol", so folding a filesystem failure into "no dbt project" would drop
+ * it silently on a workspace nothing ever managed to look inside.
+ */
+export async function classifyWorkspace(candidates: (string | undefined)[]): Promise<WorkspaceShape> {
+  const dirs = [...new Set(candidates.filter((d): d is string => !!d))]
+  let sawCompleteAnswer = false
+  let sawIncomplete = false
+
+  for (const dir of dirs) {
+    let complete = true
+
+    // At the candidate, then upwards.
+    let current = path.resolve(dir)
+    for (let level = 0; level <= MAX_ANCESTOR_LEVELS; level++) {
+      const found = await hasProjectFile(current)
+      if (found === true) return "dbt"
+      if (found === undefined) complete = false
+      const parent = path.dirname(current)
+      if (parent === current) break
+      current = parent
+    }
+
+    // One level below. The filesystem root is a legitimate stop rather than a
+    // directory to enumerate — a non-git project sets worktree to it, and
+    // scanning its children is meaningless and can be slow or permission-denied
+    // — so the root on its own never yields a complete answer.
+    if (path.resolve(dir) === path.parse(path.resolve(dir)).root) {
+      complete = false
+    } else {
+      let entries
+      try {
+        entries = await fs.readdir(dir, { withFileTypes: true })
+      } catch (err) {
+        if (!meansAbsent(err)) log.warn("workspace enumeration failed", { dir, code: errnoCode(err) })
+        entries = undefined
+      }
+      if (entries === undefined) {
+        complete = false
+      } else {
+        const children = entries
+          .filter((e) => e.isDirectory() && !e.name.startsWith(".") && !SKIP_DIRS.has(e.name))
+          // Deterministic order: fs.readdir's order varies across filesystems.
+          .sort((a, b) => a.name.localeCompare(b.name))
+        for (const child of children) {
+          const found = await hasProjectFile(path.join(dir, child.name))
+          if (found === true) return "dbt"
+          if (found === undefined) complete = false
+        }
+      }
+    }
+
+    if (complete) sawCompleteAnswer = true
+    else sawIncomplete = true
+  }
+
+  return sawCompleteAnswer && !sawIncomplete ? "non-dbt" : "unknown"
 }
 
 /**

--- a/packages/opencode/src/session/pre-execution.ts
+++ b/packages/opencode/src/session/pre-execution.ts
@@ -49,14 +49,6 @@ const PROJECT_FILES = ["dbt_project.yml", "dbt_project.yaml"] as const
 const SKIP_DIRS = new Set(["node_modules", "target"])
 
 /**
- * How far up from a candidate directory to look for a project root. A session
- * is routinely started inside `models/` or `models/marts/` of a dbt project,
- * and on a non-git project the worktree is the same directory (or the
- * filesystem root), so the ancestor walk is the only thing that finds it.
- */
-const MAX_ANCESTOR_LEVELS = 8
-
-/**
  * The `errno` code of a filesystem rejection, when it carries one.
  *
  * `ENOENT` and `ENOTDIR` are real answers — nothing is there. Every other code,
@@ -79,9 +71,9 @@ function meansAbsent(err: unknown): boolean {
  *
  * `unknown` is a real, load-bearing state, not a placeholder: it is what we
  * report when the filesystem could not answer the question, and it keeps the
- * protocol. `findDbtProjectRoot` collapses "no project here" and "could not
- * read the directory" into the same `null`, so the readability check happens
- * here, before it is consulted.
+ * protocol. The existing `findDbtProjectRoot` helper cannot serve this gate
+ * directly because it collapses "no project here" and "could not look here"
+ * into the same `null`, and this gate turns a directive off on the difference.
  */
 export type WorkspaceShape = "dbt" | "non-dbt" | "unknown"
 
@@ -139,33 +131,49 @@ async function hasProjectFile(dir: string): Promise<boolean | undefined> {
  * one level below a candidate directory:
  *
  *   - **at** the candidate,
- *   - **above** it, walking up to `MAX_ANCESTOR_LEVELS` parents — a session
- *     started inside `models/` is still a dbt session, and on a non-git project
- *     the worktree candidate does not rescue that case,
+ *   - **above** it, every ancestor up to the filesystem root. A session is
+ *     routinely started inside `models/`, and on a non-git project the worktree
+ *     candidate is the same directory, so nothing else would find the project.
+ *     The walk is deliberately unbounded: a depth limit would have to report
+ *     "I stopped early" as `unknown` to stay honest, which on any deep tree
+ *     turns the gate off entirely. Two `stat` calls per level, in run mode
+ *     only, is not worth that.
  *   - **one level below** it, which is how benchmark and monorepo layouts nest
  *     a project (the same rule, and the same skip list, as
  *     `findDbtProjectRoot`).
  *
- * `non-dbt` requires at least one candidate the scan could examine COMPLETELY —
- * every ancestor probe answered, and the candidate's own children enumerated —
- * with no project found anywhere. Everything else is `unknown`: a candidate
- * that cannot be enumerated, a stat failing for any reason other than "not
- * there", the filesystem root (whose children are deliberately not scanned),
- * and an empty candidate list. The caller reads `unknown` as "keep the
- * protocol", so folding a filesystem failure into "no dbt project" would drop
- * it silently on a workspace nothing ever managed to look inside.
+ * A project found in an unrelated ancestor is a false positive that KEEPS the
+ * protocol, which is the safe direction.
+ *
+ * `non-dbt` requires at least one candidate the scan examined COMPLETELY — its
+ * symlinks resolved, every ancestor probe answered up to the root, and its own
+ * children enumerated and probed — with no project found. If no candidate
+ * managed that, the answer is `unknown`, which keeps the protocol. One complete
+ * answer is enough: the ancestor walk from that candidate already covers the
+ * worktree above it, so a partner candidate that could not be read has nothing
+ * left to contribute.
  */
 export async function classifyWorkspace(candidates: (string | undefined)[]): Promise<WorkspaceShape> {
   const dirs = [...new Set(candidates.filter((d): d is string => !!d))]
   let sawCompleteAnswer = false
-  let sawIncomplete = false
 
   for (const dir of dirs) {
     let complete = true
 
-    // At the candidate, then upwards.
-    let current = path.resolve(dir)
-    for (let level = 0; level <= MAX_ANCESTOR_LEVELS; level++) {
+    // Resolve symlinks first. `path.resolve` is lexical, so a symlinked cwd
+    // (`/tmp/ws` -> `/repo/models`) would walk `/tmp` and `/` and never see the
+    // project the session is actually inside.
+    let start: string
+    try {
+      start = await fs.realpath(dir)
+    } catch (err) {
+      if (!meansAbsent(err)) log.warn("candidate realpath failed", { dir, code: errnoCode(err) })
+      continue
+    }
+
+    // At the candidate, then upwards to the filesystem root.
+    let current = start
+    for (;;) {
       const found = await hasProjectFile(current)
       if (found === true) return "dbt"
       if (found === undefined) complete = false
@@ -178,25 +186,30 @@ export async function classifyWorkspace(candidates: (string | undefined)[]): Pro
     // directory to enumerate — a non-git project sets worktree to it, and
     // scanning its children is meaningless and can be slow or permission-denied
     // — so the root on its own never yields a complete answer.
-    if (path.resolve(dir) === path.parse(path.resolve(dir)).root) {
+    if (start === path.parse(start).root) {
       complete = false
     } else {
       let entries
       try {
-        entries = await fs.readdir(dir, { withFileTypes: true })
+        entries = await fs.readdir(start, { withFileTypes: true })
       } catch (err) {
-        if (!meansAbsent(err)) log.warn("workspace enumeration failed", { dir, code: errnoCode(err) })
+        if (!meansAbsent(err)) log.warn("workspace enumeration failed", { dir: start, code: errnoCode(err) })
         entries = undefined
       }
       if (entries === undefined) {
         complete = false
       } else {
+        // Probe everything that is not plainly a regular file. Filtering on
+        // `isDirectory()` would silently skip symlinked directories and any
+        // entry whose type the filesystem did not report, and a skipped entry
+        // is an unexamined one. `hasProjectFile` on a non-directory just gets
+        // ENOTDIR, which is a real "nothing there".
         const children = entries
-          .filter((e) => e.isDirectory() && !e.name.startsWith(".") && !SKIP_DIRS.has(e.name))
+          .filter((e) => !e.isFile() && !e.name.startsWith(".") && !SKIP_DIRS.has(e.name))
           // Deterministic order: fs.readdir's order varies across filesystems.
           .sort((a, b) => a.name.localeCompare(b.name))
         for (const child of children) {
-          const found = await hasProjectFile(path.join(dir, child.name))
+          const found = await hasProjectFile(path.join(start, child.name))
           if (found === true) return "dbt"
           if (found === undefined) complete = false
         }
@@ -204,10 +217,9 @@ export async function classifyWorkspace(candidates: (string | undefined)[]): Pro
     }
 
     if (complete) sawCompleteAnswer = true
-    else sawIncomplete = true
   }
 
-  return sawCompleteAnswer && !sawIncomplete ? "non-dbt" : "unknown"
+  return sawCompleteAnswer ? "non-dbt" : "unknown"
 }
 
 /**

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -610,6 +610,13 @@ export namespace SessionPrompt {
     // compaction, context overflow), so "step === 1" is not "first catalog".
     let catalogued = false
     // altimate_change end
+    // altimate_change start — one cache per loop() invocation for the
+    // task-shape-scoped pre-execution gate (see the call site below and
+    // SessionPreExecution.createScopedBuilderPromptCache's doc comment). The
+    // classification is invariant across this loop's steps, so computing it
+    // once here and reusing it avoids a filesystem scan on every step.
+    const getScopedBuilderPrompt = SessionPreExecution.createScopedBuilderPromptCache()
+    // altimate_change end
     // altimate_change start (AI-7519) — capture bootstrap start; emitted as a
     // single "bootstrap" span right before the first processor.process call so
     // the pre-first-generation region has a visible parent duration in traces.
@@ -1485,9 +1492,19 @@ export namespace SessionPrompt {
       // part of the byte-pinned default builder profile), so scoping it out
       // means swapping in a pack-excluded prompt variant for THIS session only
       // — the registered agent and its default `.prompt` are never mutated.
-      const scopedBuilderPrompt = await SessionPreExecution.scopedBuilderPrompt({
+      //
+      // `agent: lastUser.agent` — the REGISTRY KEY (e.g. "builder"), not
+      // `agent.name`, which config can rename independently of the key an
+      // agent is registered under (`agent.builder.name` in config). Keying on
+      // the mutable display name would stop scoping a renamed builder forever
+      // and start scoping an unrelated custom agent a user happens to name
+      // "builder". `prompt: agent.prompt` lets the gate refuse to touch a
+      // customized builder prompt (config override or markdown agent file) —
+      // see scopedBuilderPrompt's doc comment.
+      const scopedBuilderPrompt = await getScopedBuilderPrompt({
         runMode: Flag.ALTIMATE_RUN_MODE,
-        agent: agent.name,
+        agent: lastUser.agent,
+        prompt: agent.prompt,
         directories: [Instance.directory, Instance.worktree],
       })
       const effectiveAgent = scopedBuilderPrompt ? { ...agent, prompt: scopedBuilderPrompt } : agent

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1471,23 +1471,26 @@ export namespace SessionPrompt {
         ...(await InstructionPrompt.system()),
         ...hoistedReminders,
       ]
-      // altimate_change start — task-shape-scoped pre-execution protocol. Same
-      // shape as the completion instruction below and for the same reason: the
-      // text used to sit in builder.txt, and builder is a PRIMARY agent, so it
-      // reached every builder surface. A paired ablation measured it as pure
-      // overhead on headless question-answering (2,805 ritual tool calls → 0, no
-      // score effect) but says nothing about dbt work or interactive chat, so
-      // those keep it. See session/pre-execution.ts for the gate and the numbers.
+      // altimate_change start — task-shape-scoped pre-execution protocol.
+      // builder is a PRIMARY agent, so its static prompt (the `sql-guard` pack,
+      // assembled into `.prompt` by altimate/prompts/profiles.ts) reaches every
+      // builder surface: dbt authoring, interactive chat, and headless
+      // question-answering runs. A paired ablation measured it as pure overhead
+      // on headless question-answering (2,805 ritual tool calls → 0, no score
+      // effect) but says nothing about dbt work or interactive chat, so those
+      // keep it. See session/pre-execution.ts for the gate and the numbers.
       //
-      // Injected BEFORE the completion instruction, which says to signal DONE
-      // only once "every requirement above" is satisfied. A mandatory protocol
-      // pushed after it would not be one of those requirements.
-      const preExecutionInstruction = await SessionPreExecution.preExecutionInstruction({
+      // Unlike the completion instruction below, this is not additive text:
+      // the protocol already ships inside `agent.prompt` by default (it is
+      // part of the byte-pinned default builder profile), so scoping it out
+      // means swapping in a pack-excluded prompt variant for THIS session only
+      // — the registered agent and its default `.prompt` are never mutated.
+      const scopedBuilderPrompt = await SessionPreExecution.scopedBuilderPrompt({
         runMode: Flag.ALTIMATE_RUN_MODE,
         agent: agent.name,
         directories: [Instance.directory, Instance.worktree],
       })
-      if (preExecutionInstruction) system.push(preExecutionInstruction)
+      const effectiveAgent = scopedBuilderPrompt ? { ...agent, prompt: scopedBuilderPrompt } : agent
       // altimate_change end
       // altimate_change start — run-mode-only completion instruction. This text
       // used to sit in builder.txt, but builder is a PRIMARY agent, so it also
@@ -1542,7 +1545,10 @@ export namespace SessionPrompt {
 
       const result = await processor.process({
         user: lastUser,
-        agent,
+        // altimate_change — pass the task-shape-scoped agent (see above): only
+        // `.prompt` may differ from `agent`, and only for a run-mode builder
+        // session confidently classified as having no dbt project.
+        agent: effectiveAgent,
         abort,
         sessionID,
         system,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1545,10 +1545,11 @@ export namespace SessionPrompt {
 
       const result = await processor.process({
         user: lastUser,
-        // altimate_change — pass the task-shape-scoped agent (see above): only
-        // `.prompt` may differ from `agent`, and only for a run-mode builder
-        // session confidently classified as having no dbt project.
+        // altimate_change start — pass the task-shape-scoped agent (see above):
+        // only `.prompt` may differ from `agent`, and only for a run-mode
+        // builder session confidently classified as having no dbt project.
         agent: effectiveAgent,
+        // altimate_change end
         abort,
         sessionID,
         system,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -20,6 +20,8 @@ import { type Tool as AITool, tool, jsonSchema, type ToolCallOptions, asSchema }
 import { SessionCompaction } from "./compaction"
 import { NudgeArbiter } from "./nudge"
 import { SessionTermination } from "./termination"
+// altimate_change — task-shape-scoped pre-execution protocol (see pre-execution.ts)
+import { SessionPreExecution } from "./pre-execution"
 import { Instance } from "../project/instance"
 import { Bus } from "../bus"
 import { ProviderTransform } from "../provider/transform"
@@ -1480,6 +1482,20 @@ export namespace SessionPrompt {
         agent: agent.name,
       })
       if (completionInstruction) system.push(completionInstruction)
+      // altimate_change end
+      // altimate_change start — task-shape-scoped pre-execution protocol. Same
+      // shape as the completion instruction above and for the same reason: the
+      // text used to sit in builder.txt, and builder is a PRIMARY agent, so it
+      // reached every builder surface. A paired ablation measured it as pure
+      // overhead on headless question-answering (2,805 ritual tool calls → 0, no
+      // score effect) but says nothing about dbt work or interactive chat, so
+      // those keep it. See session/pre-execution.ts for the gate and the numbers.
+      const preExecutionInstruction = await SessionPreExecution.preExecutionInstruction({
+        runMode: Flag.ALTIMATE_RUN_MODE,
+        agent: agent.name,
+        directories: [Instance.directory, Instance.worktree],
+      })
+      if (preExecutionInstruction) system.push(preExecutionInstruction)
       // altimate_change end
       const format = lastUser.format ?? { type: "text" }
       if (format.type === "json_schema") {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1471,6 +1471,24 @@ export namespace SessionPrompt {
         ...(await InstructionPrompt.system()),
         ...hoistedReminders,
       ]
+      // altimate_change start — task-shape-scoped pre-execution protocol. Same
+      // shape as the completion instruction below and for the same reason: the
+      // text used to sit in builder.txt, and builder is a PRIMARY agent, so it
+      // reached every builder surface. A paired ablation measured it as pure
+      // overhead on headless question-answering (2,805 ritual tool calls → 0, no
+      // score effect) but says nothing about dbt work or interactive chat, so
+      // those keep it. See session/pre-execution.ts for the gate and the numbers.
+      //
+      // Injected BEFORE the completion instruction, which says to signal DONE
+      // only once "every requirement above" is satisfied. A mandatory protocol
+      // pushed after it would not be one of those requirements.
+      const preExecutionInstruction = await SessionPreExecution.preExecutionInstruction({
+        runMode: Flag.ALTIMATE_RUN_MODE,
+        agent: agent.name,
+        directories: [Instance.directory, Instance.worktree],
+      })
+      if (preExecutionInstruction) system.push(preExecutionInstruction)
+      // altimate_change end
       // altimate_change start — run-mode-only completion instruction. This text
       // used to sit in builder.txt, but builder is a PRIMARY agent, so it also
       // reached interactive chat, where nothing interprets or strips the token
@@ -1482,20 +1500,6 @@ export namespace SessionPrompt {
         agent: agent.name,
       })
       if (completionInstruction) system.push(completionInstruction)
-      // altimate_change end
-      // altimate_change start — task-shape-scoped pre-execution protocol. Same
-      // shape as the completion instruction above and for the same reason: the
-      // text used to sit in builder.txt, and builder is a PRIMARY agent, so it
-      // reached every builder surface. A paired ablation measured it as pure
-      // overhead on headless question-answering (2,805 ritual tool calls → 0, no
-      // score effect) but says nothing about dbt work or interactive chat, so
-      // those keep it. See session/pre-execution.ts for the gate and the numbers.
-      const preExecutionInstruction = await SessionPreExecution.preExecutionInstruction({
-        runMode: Flag.ALTIMATE_RUN_MODE,
-        agent: agent.name,
-        directories: [Instance.directory, Instance.worktree],
-      })
-      if (preExecutionInstruction) system.push(preExecutionInstruction)
       // altimate_change end
       const format = lastUser.format ?? { type: "text" }
       if (format.type === "json_schema") {

--- a/packages/opencode/test/altimate/sql-validation-e2e.test.ts
+++ b/packages/opencode/test/altimate/sql-validation-e2e.test.ts
@@ -8,6 +8,7 @@
  * 4. altimate_core_check composite pipeline works end-to-end
  * 5. sql.analyze composite pipeline works end-to-end
  * 6. Pre-execution protocol tools are callable (sql_analyze → altimate_core_validate → sql_execute)
+ *    (the protocol TEXT itself is gated in session/pre-execution.ts, tested there)
  * 7. sql-classify correctly gates sql_execute
  * 8. Analyst and builder agent permissions are consistent with their prompts
  */
@@ -15,6 +16,7 @@
 import { describe, expect, test, beforeAll, afterAll } from "bun:test"
 import fs from "fs"
 import path from "path"
+import { SessionPreExecution } from "../../src/session/pre-execution"
 import * as Dispatcher from "../../src/altimate/native/dispatcher"
 import { registerAll } from "../../src/altimate/native/altimate-core"
 import { registerAllSql } from "../../src/altimate/native/sql/register"
@@ -95,21 +97,35 @@ describe("Tool name consistency in prompts", () => {
     })
   })
 
-  test("builder prompt contains pre-execution protocol with correct tool names", async () => {
+  test("builder prompt names the pre-execution tools", async () => {
     await using tmp = await tmpdir()
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
         const builder = await Agent.get("builder")
         expect(builder).toBeDefined()
-        // Pre-Execution Protocol references:
         expect(builder!.prompt).toContain("sql_analyze")
         expect(builder!.prompt).toContain("altimate_core_validate")
         expect(builder!.prompt).toContain("sql_execute")
-        // The protocol section itself
-        expect(builder!.prompt).toContain("Pre-Execution Protocol")
       },
     })
+  })
+
+  // The protocol section itself is no longer static in builder.txt — it is
+  // injected per-session by the gate in session/pre-execution.ts, which drops it
+  // only for headless builder runs in a workspace with no dbt project. The
+  // wording is unchanged; see test/session/pre-execution.test.ts for the gate.
+  test("the pre-execution protocol still reaches an interactive builder", async () => {
+    await using tmp = await tmpdir()
+    const instruction = await SessionPreExecution.preExecutionInstruction({
+      runMode: false,
+      agent: "builder",
+      directories: [tmp.path],
+    })
+    expect(instruction).toContain("Pre-Execution Protocol")
+    expect(instruction).toContain("sql_analyze")
+    expect(instruction).toContain("altimate_core_validate")
+    expect(instruction).toContain("sql_execute")
   })
 })
 

--- a/packages/opencode/test/altimate/sql-validation-e2e.test.ts
+++ b/packages/opencode/test/altimate/sql-validation-e2e.test.ts
@@ -111,21 +111,29 @@ describe("Tool name consistency in prompts", () => {
     })
   })
 
-  // The protocol section itself is no longer static in builder.txt — it is
-  // injected per-session by the gate in session/pre-execution.ts, which drops it
-  // only for headless builder runs in a workspace with no dbt project. The
-  // wording is unchanged; see test/session/pre-execution.test.ts for the gate.
-  test("the pre-execution protocol still reaches an interactive builder", async () => {
+  // The protocol section ships statically in the default builder profile (the
+  // `sql-guard` pack, assembled by altimate/prompts/profiles.ts) — every
+  // builder session, interactive or headless, gets it by default. It is
+  // scoped OUT per-session only by the gate in session/pre-execution.ts, which
+  // drops it only for headless builder runs in a workspace with no dbt
+  // project; see test/session/pre-execution.test.ts for that gate.
+  test("the pre-execution protocol reaches an interactive builder", async () => {
     await using tmp = await tmpdir()
-    const instruction = await SessionPreExecution.preExecutionInstruction({
-      runMode: false,
-      agent: "builder",
-      directories: [tmp.path],
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const builder = await Agent.get("builder")
+        expect(builder!.prompt).toContain("Pre-Execution Protocol")
+        // Interactive (runMode: false) never gets an override — the default,
+        // unaltered agent prompt already carries the protocol.
+        const override = await SessionPreExecution.scopedBuilderPrompt({
+          runMode: false,
+          agent: "builder",
+          directories: [tmp.path],
+        })
+        expect(override).toBeUndefined()
+      },
     })
-    expect(instruction).toContain("Pre-Execution Protocol")
-    expect(instruction).toContain("sql_analyze")
-    expect(instruction).toContain("altimate_core_validate")
-    expect(instruction).toContain("sql_execute")
   })
 })
 

--- a/packages/opencode/test/altimate/sql-validation-e2e.test.ts
+++ b/packages/opencode/test/altimate/sql-validation-e2e.test.ts
@@ -129,6 +129,7 @@ describe("Tool name consistency in prompts", () => {
         const override = await SessionPreExecution.scopedBuilderPrompt({
           runMode: false,
           agent: "builder",
+          prompt: builder!.prompt,
           directories: [tmp.path],
         })
         expect(override).toBeUndefined()

--- a/packages/opencode/test/session/pre-execution.test.ts
+++ b/packages/opencode/test/session/pre-execution.test.ts
@@ -1,52 +1,81 @@
 import { describe, expect, test } from "bun:test"
 import fs from "fs/promises"
-import os from "os"
 import path from "path"
+import { tmpdir } from "../fixture/fixture"
 import { SessionPreExecution } from "../../src/session/pre-execution"
 import { PromptProfiles } from "../../src/altimate/prompts/profiles"
 
-async function tmpdir(): Promise<string> {
-  return await fs.mkdtemp(path.join(os.tmpdir(), "pre-exec-scope-"))
-}
+/**
+ * `fs.symlink`'s `"dir"` type link requires elevated privileges (or Developer
+ * Mode) on Windows; `"junction"` does not and works for the absolute
+ * directory targets these tests use. Everywhere else `"dir"` is correct.
+ */
+const DIR_LINK_TYPE = process.platform === "win32" ? "junction" : "dir"
 
 describe("workspace classification", () => {
   test("a dbt_project.yml at the root classifies as dbt", async () => {
-    const dir = await tmpdir()
-    await fs.writeFile(path.join(dir, "dbt_project.yml"), "name: demo\n")
-    expect(await SessionPreExecution.classifyWorkspace([dir])).toBe("dbt")
+    await using dir = await tmpdir()
+    await fs.writeFile(path.join(dir.path, "dbt_project.yml"), "name: demo\n")
+    expect(await SessionPreExecution.classifyWorkspace([dir.path])).toBe("dbt")
   })
 
   // Benchmark and monorepo layouts nest the project one level down; this gate
   // inherits `findDbtProjectRoot`'s rule and skip list, otherwise a real dbt
   // task would be misread as question-answering.
   test("a dbt_project.yml one level down still classifies as dbt", async () => {
-    const dir = await tmpdir()
-    await fs.mkdir(path.join(dir, "warehouse"))
-    await fs.writeFile(path.join(dir, "warehouse", "dbt_project.yml"), "name: demo\n")
-    expect(await SessionPreExecution.classifyWorkspace([dir])).toBe("dbt")
+    await using dir = await tmpdir()
+    await fs.mkdir(path.join(dir.path, "warehouse"))
+    await fs.writeFile(path.join(dir.path, "warehouse", "dbt_project.yml"), "name: demo\n")
+    expect(await SessionPreExecution.classifyWorkspace([dir.path])).toBe("dbt")
+  })
+
+  // The load-bearing safety fix: `findDbtProjectRoot` (and the pre-rework
+  // version of this scan) only checked ONE level below the candidate. A real
+  // monorepo dbt project nested deeper — e.g. `repo/platform/analytics/
+  // dbt_project.yml` when the candidate is `repo` — was silently classified
+  // `non-dbt`, dropping the mandatory protocol on actual dbt work. This test
+  // fails against the single-level scan and must keep passing against any
+  // future change to the downward walk.
+  test("a dbt_project.yml nested three levels down still classifies as dbt", async () => {
+    await using dir = await tmpdir()
+    const nested = path.join(dir.path, "platform", "analytics", "warehouse")
+    await fs.mkdir(nested, { recursive: true })
+    await fs.writeFile(path.join(nested, "dbt_project.yml"), "name: demo\n")
+    expect(await SessionPreExecution.classifyWorkspace([dir.path])).toBe("dbt")
+  })
+
+  // A project past the downward scan bound is not found — but that must
+  // report `unknown` (keep the protocol), never a confident `non-dbt`, since
+  // the scan genuinely did not look that far.
+  test("a project past the downward scan bound is unknown, not non-dbt", async () => {
+    await using dir = await tmpdir()
+    const tooDeep = path.join(dir.path, "a", "b", "c", "d", "e", "f")
+    await fs.mkdir(tooDeep, { recursive: true })
+    await fs.writeFile(path.join(tooDeep, "dbt_project.yml"), "name: demo\n")
+    expect(await SessionPreExecution.classifyWorkspace([dir.path])).toBe("unknown")
   })
 
   test("a readable directory with no dbt project classifies as non-dbt", async () => {
-    const dir = await tmpdir()
-    await fs.writeFile(path.join(dir, "questions.duckdb"), "")
-    expect(await SessionPreExecution.classifyWorkspace([dir])).toBe("non-dbt")
+    await using dir = await tmpdir()
+    await fs.writeFile(path.join(dir.path, "questions.duckdb"), "")
+    expect(await SessionPreExecution.classifyWorkspace([dir.path])).toBe("non-dbt")
   })
 
   // The two-directory case: the cwd may be a plain subfolder of a dbt project.
   test("any readable candidate carrying a project wins", async () => {
-    const root = await tmpdir()
-    await fs.writeFile(path.join(root, "dbt_project.yml"), "name: demo\n")
-    const cwd = path.join(root, "analyses")
+    await using root = await tmpdir()
+    await fs.writeFile(path.join(root.path, "dbt_project.yml"), "name: demo\n")
+    const cwd = path.join(root.path, "analyses")
     await fs.mkdir(cwd)
-    expect(await SessionPreExecution.classifyWorkspace([cwd, root])).toBe("dbt")
+    expect(await SessionPreExecution.classifyWorkspace([cwd, root.path])).toBe("dbt")
   })
 
   // The load-bearing case. A scan that collapses "no project here" and "could
   // not look here" into one answer silently drops the protocol whenever the
   // filesystem misbehaves.
   test("a directory that does not exist is unknown, never non-dbt", async () => {
-    const dir = await tmpdir()
-    const missing = path.join(dir, "gone")
+    await using dir = await tmpdir()
+    const missing = path.join(dir.path, "gone")
     expect(await SessionPreExecution.classifyWorkspace([missing])).toBe("unknown")
   })
 
@@ -63,23 +92,17 @@ describe("workspace classification", () => {
     expect(await SessionPreExecution.classifyWorkspace([root])).toBe("unknown")
   })
 
-  test("a project on one candidate wins even when its partner is unreadable", async () => {
-    const dir = await tmpdir()
-    await fs.writeFile(path.join(dir, "dbt_project.yml"), "name: demo\n")
-    expect(await SessionPreExecution.classifyWorkspace([path.join(dir, "nope"), dir])).toBe("dbt")
-  })
-
   // A directory named dbt_project.yml is not a dbt project.
   test("a dbt_project.yml directory is not a project", async () => {
-    const dir = await tmpdir()
-    await fs.mkdir(path.join(dir, "dbt_project.yml"))
-    expect(await SessionPreExecution.classifyWorkspace([dir])).toBe("non-dbt")
+    await using dir = await tmpdir()
+    await fs.mkdir(path.join(dir.path, "dbt_project.yml"))
+    expect(await SessionPreExecution.classifyWorkspace([dir.path])).toBe("non-dbt")
   })
 
   test("dbt_project.yaml counts as well as .yml", async () => {
-    const dir = await tmpdir()
-    await fs.writeFile(path.join(dir, "dbt_project.yaml"), "name: demo\n")
-    expect(await SessionPreExecution.classifyWorkspace([dir])).toBe("dbt")
+    await using dir = await tmpdir()
+    await fs.writeFile(path.join(dir.path, "dbt_project.yaml"), "name: demo\n")
+    expect(await SessionPreExecution.classifyWorkspace([dir.path])).toBe("dbt")
   })
 
   // Sessions are routinely started inside `models/` or deeper. On a non-git
@@ -87,9 +110,9 @@ describe("workspace classification", () => {
   // is the only thing that finds the project — without it a real dbt session
   // classifies as non-dbt and loses the protocol.
   test("a project above the candidate is found", async () => {
-    const root = await tmpdir()
-    await fs.writeFile(path.join(root, "dbt_project.yml"), "name: demo\n")
-    const deep = path.join(root, "models", "marts", "finance")
+    await using root = await tmpdir()
+    await fs.writeFile(path.join(root.path, "dbt_project.yml"), "name: demo\n")
+    const deep = path.join(root.path, "models", "marts", "finance")
     await fs.mkdir(deep, { recursive: true })
     expect(await SessionPreExecution.classifyWorkspace([deep])).toBe("dbt")
   })
@@ -98,9 +121,9 @@ describe("workspace classification", () => {
   // limit. A limit would have to report "I stopped early" as unknown to stay
   // honest, which on any deep tree switches the gate off entirely.
   test("the ancestor walk is not depth-limited", async () => {
-    const root = await tmpdir()
-    await fs.writeFile(path.join(root, "dbt_project.yml"), "name: demo\n")
-    const deep = path.join(root, "a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+    await using root = await tmpdir()
+    await fs.writeFile(path.join(root.path, "dbt_project.yml"), "name: demo\n")
+    const deep = path.join(root.path, "a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
     await fs.mkdir(deep, { recursive: true })
     expect(await SessionPreExecution.classifyWorkspace([deep])).toBe("dbt")
   })
@@ -108,42 +131,69 @@ describe("workspace classification", () => {
   // `path.resolve` is lexical. A symlinked cwd would walk the link's own
   // parents and never see the project the session is actually inside.
   test("a symlinked candidate is resolved before the walk", async () => {
-    const project = await tmpdir()
-    await fs.writeFile(path.join(project, "dbt_project.yml"), "name: demo\n")
-    const inner = path.join(project, "models")
+    await using project = await tmpdir()
+    await fs.writeFile(path.join(project.path, "dbt_project.yml"), "name: demo\n")
+    const inner = path.join(project.path, "models")
     await fs.mkdir(inner)
-    const elsewhere = await tmpdir()
-    const link = path.join(elsewhere, "ws")
-    await fs.symlink(inner, link, "dir")
+    await using elsewhere = await tmpdir()
+    const link = path.join(elsewhere.path, "ws")
+    await fs.symlink(inner, link, DIR_LINK_TYPE)
     expect(await SessionPreExecution.classifyWorkspace([link])).toBe("dbt")
   })
 
   // Filtering children on isDirectory() would skip symlinked directories, and
   // a skipped entry is an unexamined one.
   test("a symlinked child project is found", async () => {
-    const project = await tmpdir()
-    await fs.writeFile(path.join(project, "dbt_project.yml"), "name: demo\n")
-    const workspace = await tmpdir()
-    await fs.symlink(project, path.join(workspace, "warehouse"), "dir")
-    expect(await SessionPreExecution.classifyWorkspace([workspace])).toBe("dbt")
+    await using project = await tmpdir()
+    await fs.writeFile(path.join(project.path, "dbt_project.yml"), "name: demo\n")
+    await using workspace = await tmpdir()
+    await fs.symlink(project.path, path.join(workspace.path, "warehouse"), DIR_LINK_TYPE)
+    expect(await SessionPreExecution.classifyWorkspace([workspace.path])).toBe("dbt")
   })
 
   // One completely examined candidate settles it. Its ancestor walk already
   // covers the worktree above it, so a partner that could not be read has
   // nothing left to contribute — and vetoing on it would return unknown for
   // every non-git project, where the worktree candidate is the filesystem root.
-  test("a complete candidate is not vetoed by an unreadable partner", async () => {
-    const dir = await tmpdir()
-    expect(await SessionPreExecution.classifyWorkspace([dir, path.join(dir, "gone")])).toBe("non-dbt")
-    expect(await SessionPreExecution.classifyWorkspace([dir, path.parse(dir).root])).toBe("non-dbt")
+  test("a complete candidate is not vetoed by a missing or root-only partner", async () => {
+    await using dir = await tmpdir()
+    expect(await SessionPreExecution.classifyWorkspace([dir.path, path.join(dir.path, "gone")])).toBe("non-dbt")
+    expect(await SessionPreExecution.classifyWorkspace([dir.path, path.parse(dir.path).root])).toBe("non-dbt")
+  })
+
+  // The genuinely PERMISSION-unreadable case — the previous test's "missing"
+  // and "root" partners are both readable-but-absent, which is a different
+  // failure mode from a directory that exists and cannot be opened. Both must
+  // fail the same way: the complete partner still wins.
+  test("a complete candidate is not vetoed by a genuinely unreadable partner", async () => {
+    await using dir = await tmpdir()
+    await using other = await tmpdir()
+    const locked = path.join(other.path, "locked")
+    await fs.mkdir(locked)
+    await fs.chmod(locked, 0o000)
+    try {
+      let enumerable = true
+      try {
+        await fs.readdir(locked)
+      } catch {
+        enumerable = false
+      }
+      // Running as root defeats the permission bit; the assertion is only
+      // meaningful when the mode actually blocks the read.
+      if (!enumerable) {
+        expect(await SessionPreExecution.classifyWorkspace([dir.path, locked])).toBe("non-dbt")
+      }
+    } finally {
+      await fs.chmod(locked, 0o755)
+    }
   })
 
   // The failure that matters most: a directory that stats fine but cannot be
   // enumerated. Collapsing that into "no dbt project" would drop the protocol
   // on a workspace nobody ever looked inside.
   test("a directory that cannot be enumerated is unknown, not non-dbt", async () => {
-    const dir = await tmpdir()
-    const locked = path.join(dir, "locked")
+    await using dir = await tmpdir()
+    const locked = path.join(dir.path, "locked")
     await fs.mkdir(locked)
     await fs.chmod(locked, 0o000)
     try {
@@ -172,13 +222,14 @@ describe("workspace classification", () => {
 // "use the agent's default `.prompt`, unchanged".
 describe("pre-execution protocol gate", () => {
   // The ONLY combination that drops the protocol is the one the ablation
-  // measured: headless, builder, no dbt project in the workspace.
+  // measured: headless, builder, stock default prompt, no dbt project.
   test("headless builder in a non-dbt workspace returns the sql-guard-excluded override", async () => {
-    const dir = await tmpdir()
+    await using dir = await tmpdir()
     const override = await SessionPreExecution.scopedBuilderPrompt({
       runMode: true,
       agent: "builder",
-      directories: [dir],
+      prompt: PromptProfiles.PROMPT_BUILDER,
+      directories: [dir.path],
     })
     // Would fail if the gate silently no-ops and returns the default profile.
     expect(override).toBe(PromptProfiles.PROMPT_BUILDER_SCOPED)
@@ -187,50 +238,201 @@ describe("pre-execution protocol gate", () => {
   })
 
   test("headless builder in a dbt workspace keeps the default (no override)", async () => {
-    const dir = await tmpdir()
-    await fs.writeFile(path.join(dir, "dbt_project.yml"), "name: demo\n")
+    await using dir = await tmpdir()
+    await fs.writeFile(path.join(dir.path, "dbt_project.yml"), "name: demo\n")
     expect(
-      await SessionPreExecution.scopedBuilderPrompt({ runMode: true, agent: "builder", directories: [dir] }),
+      await SessionPreExecution.scopedBuilderPrompt({
+        runMode: true,
+        agent: "builder",
+        prompt: PromptProfiles.PROMPT_BUILDER,
+        directories: [dir.path],
+      }),
     ).toBeUndefined()
   })
 
   // Interactive chat is a builder surface the ablation never covered, so it is
   // unchanged from before this PR regardless of what the workspace looks like.
   test("interactive builder always keeps the default (no override), dbt project or not", async () => {
-    const dir = await tmpdir()
+    await using dir = await tmpdir()
     expect(
-      await SessionPreExecution.scopedBuilderPrompt({ runMode: false, agent: "builder", directories: [dir] }),
+      await SessionPreExecution.scopedBuilderPrompt({
+        runMode: false,
+        agent: "builder",
+        prompt: PromptProfiles.PROMPT_BUILDER,
+        directories: [dir.path],
+      }),
     ).toBeUndefined()
   })
 
   // Ambiguity keeps the protocol. Wrongly dropping it has an unmeasured cost;
   // wrongly keeping it costs latency on one workload.
   test("an unclassifiable workspace keeps the default (no override)", async () => {
-    const dir = await tmpdir()
+    await using dir = await tmpdir()
     expect(
       await SessionPreExecution.scopedBuilderPrompt({
         runMode: true,
         agent: "builder",
-        directories: [path.join(dir, "does-not-exist")],
+        prompt: PromptProfiles.PROMPT_BUILDER,
+        directories: [path.join(dir.path, "does-not-exist")],
       }),
     ).toBeUndefined()
     expect(
-      await SessionPreExecution.scopedBuilderPrompt({ runMode: true, agent: "builder", directories: [] }),
+      await SessionPreExecution.scopedBuilderPrompt({
+        runMode: true,
+        agent: "builder",
+        prompt: PromptProfiles.PROMPT_BUILDER,
+        directories: [],
+      }),
     ).toBeUndefined()
   })
 
   // Only the builder profile ever carried this pack, so overriding it for
   // analyst or reviewer would be a behavior change, not a preserved one.
   test("no other agent receives an override", async () => {
-    const dir = await tmpdir()
+    await using dir = await tmpdir()
     for (const agent of ["analyst", "reviewer", "plan", "general"]) {
       expect(
-        await SessionPreExecution.scopedBuilderPrompt({ runMode: false, agent, directories: [dir] }),
+        await SessionPreExecution.scopedBuilderPrompt({
+          runMode: false,
+          agent,
+          prompt: PromptProfiles.PROMPT_BUILDER,
+          directories: [dir.path],
+        }),
       ).toBeUndefined()
       expect(
-        await SessionPreExecution.scopedBuilderPrompt({ runMode: true, agent, directories: [dir] }),
+        await SessionPreExecution.scopedBuilderPrompt({
+          runMode: true,
+          agent,
+          prompt: PromptProfiles.PROMPT_BUILDER,
+          directories: [dir.path],
+        }),
       ).toBeUndefined()
     }
+  })
+
+  // `agent` here must be the registry KEY, not `Info.name` — config can rename
+  // the builder agent's display name (`agent.builder.name`) while it stays
+  // registered under the `builder` key. Passing the STRING "renamed-builder"
+  // simulates the caller mistakenly keying on a display name.
+  test("a builder agent renamed via config is still recognized by its registry key", async () => {
+    await using dir = await tmpdir()
+    // Simulates prompt.ts passing `lastUser.agent` ("builder", the registry
+    // key) even though `agent.name` ("renamed-builder") differs.
+    const override = await SessionPreExecution.scopedBuilderPrompt({
+      runMode: true,
+      agent: "builder",
+      prompt: PromptProfiles.PROMPT_BUILDER,
+      directories: [dir.path],
+    })
+    expect(override).toBe(PromptProfiles.PROMPT_BUILDER_SCOPED)
+    // The converse: a custom agent merely DISPLAYED as "builder" (its
+    // registry key is something else) must never receive the override.
+    expect(
+      await SessionPreExecution.scopedBuilderPrompt({
+        runMode: true,
+        agent: "my-custom-agent",
+        prompt: PromptProfiles.PROMPT_BUILDER,
+        directories: [dir.path],
+      }),
+    ).toBeUndefined()
+  })
+
+  // A customized builder prompt (config override or a markdown agent file)
+  // must never be silently discarded in favour of the stock scoped variant —
+  // the gate only ever touches the prompt when it is STILL exactly the
+  // default, unmodified `PROMPT_BUILDER`.
+  test("a customized builder prompt is never overridden, even when every other condition fires", async () => {
+    await using dir = await tmpdir()
+    const customPrompt = "You are a custom builder agent. Do custom things.\n"
+    expect(
+      await SessionPreExecution.scopedBuilderPrompt({
+        runMode: true,
+        agent: "builder",
+        prompt: customPrompt,
+        directories: [dir.path],
+      }),
+    ).toBeUndefined()
+    // Sanity: the identical scenario WITH the stock prompt does fire, so the
+    // above isn't passing because some other condition failed to hold.
+    expect(
+      await SessionPreExecution.scopedBuilderPrompt({
+        runMode: true,
+        agent: "builder",
+        prompt: PromptProfiles.PROMPT_BUILDER,
+        directories: [dir.path],
+      }),
+    ).toBe(PromptProfiles.PROMPT_BUILDER_SCOPED)
+  })
+
+  // Even the ALREADY-scoped prompt (e.g. a second pass, or a caller reusing a
+  // previous result as input) must not be treated as "the default" — only
+  // byte-identical `PROMPT_BUILDER` qualifies.
+  test("the scoped prompt itself does not count as the default", async () => {
+    await using dir = await tmpdir()
+    expect(
+      await SessionPreExecution.scopedBuilderPrompt({
+        runMode: true,
+        agent: "builder",
+        prompt: PromptProfiles.PROMPT_BUILDER_SCOPED,
+        directories: [dir.path],
+      }),
+    ).toBeUndefined()
+  })
+})
+
+describe("scoped-prompt cache (hot-path fix)", () => {
+  // `classifyWorkspace`'s filesystem walk must not re-run on every call once
+  // cached — proven here by giving the SECOND call a directory that would
+  // classify differently, and asserting it still returns the FIRST call's
+  // answer. If the cache silently no-ops (recomputes every call), this fails:
+  // the second call would legitimately see the dbt project and return
+  // `undefined` instead of the first call's override.
+  test("memoizes across calls — a differing second call is never actually consulted", async () => {
+    await using nonDbtDir = await tmpdir()
+    await using dbtDir = await tmpdir()
+    await fs.writeFile(path.join(dbtDir.path, "dbt_project.yml"), "name: demo\n")
+
+    const getScopedBuilderPrompt = SessionPreExecution.createScopedBuilderPromptCache()
+    const first = await getScopedBuilderPrompt({
+      runMode: true,
+      agent: "builder",
+      prompt: PromptProfiles.PROMPT_BUILDER,
+      directories: [nonDbtDir.path],
+    })
+    const second = await getScopedBuilderPrompt({
+      runMode: true,
+      agent: "builder",
+      prompt: PromptProfiles.PROMPT_BUILDER,
+      directories: [dbtDir.path],
+    })
+    expect(first).toBe(PromptProfiles.PROMPT_BUILDER_SCOPED)
+    expect(second).toBe(first)
+  })
+
+  // A fresh cache instance (a new loop() invocation, i.e. a new turn) must
+  // recompute independently — proving the memoization is per-instance, not a
+  // module-level cache that would go stale across turns.
+  test("a fresh cache instance recomputes independently of any prior instance", async () => {
+    await using dbtDir = await tmpdir()
+    await fs.writeFile(path.join(dbtDir.path, "dbt_project.yml"), "name: demo\n")
+
+    const first = SessionPreExecution.createScopedBuilderPromptCache()
+    await first({
+      runMode: true,
+      agent: "builder",
+      prompt: PromptProfiles.PROMPT_BUILDER,
+      directories: [dbtDir.path],
+    })
+
+    await using nonDbtDir = await tmpdir()
+    const second = SessionPreExecution.createScopedBuilderPromptCache()
+    const result = await second({
+      runMode: true,
+      agent: "builder",
+      prompt: PromptProfiles.PROMPT_BUILDER,
+      directories: [nonDbtDir.path],
+    })
+    expect(result).toBe(PromptProfiles.PROMPT_BUILDER_SCOPED)
   })
 })
 
@@ -255,11 +457,18 @@ describe("prompt override composition", () => {
     expect(PromptProfiles.PROMPT_BUILDER).toContain("## Pre-Execution Protocol")
   })
 
-  test("prompt assembly wires the gate to the run-mode flag and both directories", async () => {
+  test("prompt assembly wires the gate to the run-mode flag, the registry key, the current prompt, and both directories", async () => {
     const prompt = await Bun.file(new URL("../../src/session/prompt.ts", import.meta.url).pathname).text()
     expect(prompt).toMatch(
-      /SessionPreExecution\.scopedBuilderPrompt\(\{\s*runMode: Flag\.ALTIMATE_RUN_MODE,\s*agent: agent\.name,\s*directories: \[Instance\.directory, Instance\.worktree\],\s*\}\)/,
+      /getScopedBuilderPrompt\(\{\s*runMode: Flag\.ALTIMATE_RUN_MODE,\s*agent: lastUser\.agent,\s*prompt: agent\.prompt,\s*directories: \[Instance\.directory, Instance\.worktree\],\s*\}\)/,
     )
+    // The cache must be created once per loop() invocation (before the
+    // while-loop that re-enters this call every step), not per step.
+    const cacheDeclAt = prompt.indexOf("const getScopedBuilderPrompt = SessionPreExecution.createScopedBuilderPromptCache()")
+    const whileLoopAt = prompt.indexOf("while (true) {")
+    expect(cacheDeclAt).toBeGreaterThan(-1)
+    expect(whileLoopAt).toBeGreaterThan(-1)
+    expect(cacheDeclAt).toBeLessThan(whileLoopAt)
     // The override must actually reach the model call (via a cloned agent
     // passed to processor.process), not just be computed and discarded.
     expect(prompt).toMatch(/effectiveAgent = scopedBuilderPrompt \? \{ \.\.\.agent, prompt: scopedBuilderPrompt \} : agent/)

--- a/packages/opencode/test/session/pre-execution.test.ts
+++ b/packages/opencode/test/session/pre-execution.test.ts
@@ -15,9 +15,9 @@ describe("workspace classification", () => {
     expect(await SessionPreExecution.classifyWorkspace([dir])).toBe("dbt")
   })
 
-  // Benchmark and monorepo layouts nest the project one level down; the shared
-  // findDbtProjectRoot rule already covers that and this gate must inherit it,
-  // otherwise a real dbt task would be misread as question-answering.
+  // Benchmark and monorepo layouts nest the project one level down; this gate
+  // inherits `findDbtProjectRoot`'s rule and skip list, otherwise a real dbt
+  // task would be misread as question-answering.
   test("a dbt_project.yml one level down still classifies as dbt", async () => {
     const dir = await tmpdir()
     await fs.mkdir(path.join(dir, "warehouse"))
@@ -73,6 +73,58 @@ describe("workspace classification", () => {
     const dir = await tmpdir()
     await fs.mkdir(path.join(dir, "dbt_project.yml"))
     expect(await SessionPreExecution.classifyWorkspace([dir])).toBe("non-dbt")
+  })
+
+  test("dbt_project.yaml counts as well as .yml", async () => {
+    const dir = await tmpdir()
+    await fs.writeFile(path.join(dir, "dbt_project.yaml"), "name: demo\n")
+    expect(await SessionPreExecution.classifyWorkspace([dir])).toBe("dbt")
+  })
+
+  // Sessions are routinely started inside `models/` or deeper. On a non-git
+  // project the worktree candidate is the same directory, so the ancestor walk
+  // is the only thing that finds the project — without it a real dbt session
+  // classifies as non-dbt and loses the protocol.
+  test("a project above the candidate is found", async () => {
+    const root = await tmpdir()
+    await fs.writeFile(path.join(root, "dbt_project.yml"), "name: demo\n")
+    const deep = path.join(root, "models", "marts", "finance")
+    await fs.mkdir(deep, { recursive: true })
+    expect(await SessionPreExecution.classifyWorkspace([deep])).toBe("dbt")
+  })
+
+  // The upward walk is bounded, so an unrelated deep tree does not scan to /.
+  test("the ancestor walk is bounded", async () => {
+    const root = await tmpdir()
+    await fs.writeFile(path.join(root, "dbt_project.yml"), "name: demo\n")
+    const parts = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
+    const deep = path.join(root, ...parts)
+    await fs.mkdir(deep, { recursive: true })
+    expect(await SessionPreExecution.classifyWorkspace([deep])).toBe("non-dbt")
+  })
+
+  // The failure that matters most: a directory that stats fine but cannot be
+  // enumerated. Collapsing that into "no dbt project" would drop the protocol
+  // on a workspace nobody ever looked inside.
+  test("a directory that cannot be enumerated is unknown, not non-dbt", async () => {
+    const dir = await tmpdir()
+    const locked = path.join(dir, "locked")
+    await fs.mkdir(locked)
+    await fs.chmod(locked, 0o000)
+    try {
+      // Running as root defeats the permission bit; the assertion is only
+      // meaningful when the mode actually blocks the read.
+      let enumerable = true
+      try {
+        await fs.readdir(locked)
+      } catch {
+        enumerable = false
+      }
+      if (enumerable) return
+      expect(await SessionPreExecution.classifyWorkspace([locked])).toBe("unknown")
+    } finally {
+      await fs.chmod(locked, 0o755)
+    }
   })
 })
 
@@ -179,5 +231,17 @@ describe("prompt text fidelity", () => {
       /SessionPreExecution\.preExecutionInstruction\(\{\s*runMode: Flag\.ALTIMATE_RUN_MODE,\s*agent: agent\.name,\s*directories: \[Instance\.directory, Instance\.worktree\],\s*\}\)/,
     )
     expect(prompt).toMatch(/if \(preExecutionInstruction\) system\.push\(preExecutionInstruction\)/)
+  })
+
+  // The completion instruction tells the model to signal DONE only once "every
+  // requirement above" is satisfied. A mandatory protocol pushed after it would
+  // sit outside that scope, so ordering here is behavioural, not cosmetic.
+  test("the protocol is pushed before the completion instruction", async () => {
+    const prompt = await Bun.file(new URL("../../src/session/prompt.ts", import.meta.url).pathname).text()
+    const protocolAt = prompt.indexOf("if (preExecutionInstruction) system.push(preExecutionInstruction)")
+    const completionAt = prompt.indexOf("if (completionInstruction) system.push(completionInstruction)")
+    expect(protocolAt).toBeGreaterThan(-1)
+    expect(completionAt).toBeGreaterThan(-1)
+    expect(protocolAt).toBeLessThan(completionAt)
   })
 })

--- a/packages/opencode/test/session/pre-execution.test.ts
+++ b/packages/opencode/test/session/pre-execution.test.ts
@@ -3,6 +3,7 @@ import fs from "fs/promises"
 import os from "os"
 import path from "path"
 import { SessionPreExecution } from "../../src/session/pre-execution"
+import { PromptProfiles } from "../../src/altimate/prompts/profiles"
 
 async function tmpdir(): Promise<string> {
   return await fs.mkdtemp(path.join(os.tmpdir(), "pre-exec-scope-"))
@@ -162,120 +163,106 @@ describe("workspace classification", () => {
   })
 })
 
+// The reworked mechanism (onto PR #1217's pack architecture): the protocol is
+// the `sql-guard` pack, and it ships INSIDE the default builder profile
+// unconditionally (see test/altimate/prompt-profiles.test.ts for the
+// byte-identity pin). `scopedBuilderPrompt` no longer injects text — it
+// returns a full prompt OVERRIDE (the profile with sql-guard excluded) for the
+// one cell the ablation measured, or `undefined` everywhere else, meaning
+// "use the agent's default `.prompt`, unchanged".
 describe("pre-execution protocol gate", () => {
   // The ONLY combination that drops the protocol is the one the ablation
   // measured: headless, builder, no dbt project in the workspace.
-  test("headless builder in a non-dbt workspace drops the protocol", async () => {
+  test("headless builder in a non-dbt workspace returns the sql-guard-excluded override", async () => {
     const dir = await tmpdir()
-    expect(
-      await SessionPreExecution.preExecutionInstruction({ runMode: true, agent: "builder", directories: [dir] }),
-    ).toBeUndefined()
-  })
-
-  test("headless builder in a dbt workspace keeps it", async () => {
-    const dir = await tmpdir()
-    await fs.writeFile(path.join(dir, "dbt_project.yml"), "name: demo\n")
-    const instruction = await SessionPreExecution.preExecutionInstruction({
+    const override = await SessionPreExecution.scopedBuilderPrompt({
       runMode: true,
       agent: "builder",
       directories: [dir],
     })
-    expect(instruction).toBe(SessionPreExecution.PRE_EXECUTION_PROTOCOL)
+    // Would fail if the gate silently no-ops and returns the default profile.
+    expect(override).toBe(PromptProfiles.PROMPT_BUILDER_SCOPED)
+    expect(override).not.toContain("## Pre-Execution Protocol")
+    expect(override).not.toBe(PromptProfiles.PROMPT_BUILDER)
+  })
+
+  test("headless builder in a dbt workspace keeps the default (no override)", async () => {
+    const dir = await tmpdir()
+    await fs.writeFile(path.join(dir, "dbt_project.yml"), "name: demo\n")
+    expect(
+      await SessionPreExecution.scopedBuilderPrompt({ runMode: true, agent: "builder", directories: [dir] }),
+    ).toBeUndefined()
   })
 
   // Interactive chat is a builder surface the ablation never covered, so it is
   // unchanged from before this PR regardless of what the workspace looks like.
-  test("interactive builder always keeps it, dbt project or not", async () => {
+  test("interactive builder always keeps the default (no override), dbt project or not", async () => {
     const dir = await tmpdir()
     expect(
-      await SessionPreExecution.preExecutionInstruction({ runMode: false, agent: "builder", directories: [dir] }),
-    ).toBe(SessionPreExecution.PRE_EXECUTION_PROTOCOL)
+      await SessionPreExecution.scopedBuilderPrompt({ runMode: false, agent: "builder", directories: [dir] }),
+    ).toBeUndefined()
   })
 
   // Ambiguity keeps the protocol. Wrongly dropping it has an unmeasured cost;
   // wrongly keeping it costs latency on one workload.
-  test("an unclassifiable workspace keeps it", async () => {
+  test("an unclassifiable workspace keeps the default (no override)", async () => {
     const dir = await tmpdir()
     expect(
-      await SessionPreExecution.preExecutionInstruction({
+      await SessionPreExecution.scopedBuilderPrompt({
         runMode: true,
         agent: "builder",
         directories: [path.join(dir, "does-not-exist")],
       }),
-    ).toBe(SessionPreExecution.PRE_EXECUTION_PROTOCOL)
+    ).toBeUndefined()
     expect(
-      await SessionPreExecution.preExecutionInstruction({ runMode: true, agent: "builder", directories: [] }),
-    ).toBe(SessionPreExecution.PRE_EXECUTION_PROTOCOL)
+      await SessionPreExecution.scopedBuilderPrompt({ runMode: true, agent: "builder", directories: [] }),
+    ).toBeUndefined()
   })
 
-  // Only builder.txt ever carried this section, so injecting it for analyst or
-  // reviewer would be a new instruction, not a preserved one.
-  test("no other agent receives the protocol", async () => {
+  // Only the builder profile ever carried this pack, so overriding it for
+  // analyst or reviewer would be a behavior change, not a preserved one.
+  test("no other agent receives an override", async () => {
     const dir = await tmpdir()
     for (const agent of ["analyst", "reviewer", "plan", "general"]) {
       expect(
-        await SessionPreExecution.preExecutionInstruction({ runMode: false, agent, directories: [dir] }),
+        await SessionPreExecution.scopedBuilderPrompt({ runMode: false, agent, directories: [dir] }),
       ).toBeUndefined()
       expect(
-        await SessionPreExecution.preExecutionInstruction({ runMode: true, agent, directories: [dir] }),
+        await SessionPreExecution.scopedBuilderPrompt({ runMode: true, agent, directories: [dir] }),
       ).toBeUndefined()
     }
   })
 })
 
-describe("prompt text fidelity", () => {
-  // The injected text must be byte-identical to what builder.txt shipped, so
-  // that every kept case produces the same resolved prompt as before.
-  test("the injected protocol is verbatim the section that was removed", async () => {
-    const expected = [
-      "## Pre-Execution Protocol",
-      "",
-      "Before executing ANY SQL via sql_execute, follow this mandatory sequence:",
-    ].join("\n")
-    expect(SessionPreExecution.PRE_EXECUTION_PROTOCOL.startsWith(expected)).toBe(true)
-    expect(SessionPreExecution.PRE_EXECUTION_PROTOCOL).toContain("This sequence is NOT optional.")
-    expect(SessionPreExecution.PRE_EXECUTION_PROTOCOL).toContain("altimate_core_validate")
-    expect(SessionPreExecution.PRE_EXECUTION_PROTOCOL).toContain("sql_analyze")
-    expect(SessionPreExecution.PRE_EXECUTION_PROTOCOL.endsWith("still validate syntax.")).toBe(true)
+describe("prompt override composition", () => {
+  // The override must drop ONLY the sql-guard pack — every neighbouring pack
+  // (and the invariant core) must survive untouched, otherwise the gate is
+  // silently scoping more than the protocol.
+  test("PROMPT_BUILDER_SCOPED omits sql-guard and nothing else", () => {
+    expect(PromptProfiles.PROMPT_BUILDER_SCOPED).not.toContain("## Pre-Execution Protocol")
+    expect(PromptProfiles.PROMPT_BUILDER_SCOPED).not.toContain("This sequence is NOT optional.")
+    expect(PromptProfiles.PROMPT_BUILDER_SCOPED).toContain("## dbt Verification Workflow")
+    expect(PromptProfiles.PROMPT_BUILDER_SCOPED).toContain("## Finish Protocol")
+    expect(PromptProfiles.BUILDER_PROFILE_SCOPED).toEqual(
+      PromptProfiles.BUILDER_PROFILE.filter((name) => name !== "sql-guard"),
+    )
   })
 
-  // If the section came back into the static prompt file the gate would be a
-  // no-op and every surface would carry it again.
-  test("the builder prompt file no longer carries the section", async () => {
-    const prompt = await Bun.file(new URL("../../src/altimate/prompts/builder.txt", import.meta.url).pathname).text()
-    expect(prompt).not.toContain("## Pre-Execution Protocol")
-    expect(prompt).not.toContain("This sequence is NOT optional.")
-    // The neighbouring sections must survive — only the one section moved.
-    expect(prompt).toContain("## dbt Verification Workflow")
-    expect(prompt).toContain("## Finish Protocol (mandatory before ending any build/fix task)")
-  })
-
-  // The Finish Protocol is a SECOND mandatory ritual in the same family, added
-  // after the binary the ablation measured was built. It is deliberately left
-  // alone: no measurement covers it, and this PR does not speak to it.
-  test("the Finish Protocol is untouched by this change", async () => {
-    const prompt = await Bun.file(new URL("../../src/altimate/prompts/builder.txt", import.meta.url).pathname).text()
-    expect(prompt).toContain("Re-read the task's literal requirements")
-    expect(prompt).toContain("Run the final build and tests")
+  // Selecting the override must never perturb the default byte-pinned
+  // profile — the two constants are independent, computed once at module load.
+  test("computing the override cannot change the default profile bytes", () => {
+    void PromptProfiles.PROMPT_BUILDER_SCOPED
+    expect(PromptProfiles.PROMPT_BUILDER).toContain("## Pre-Execution Protocol")
   })
 
   test("prompt assembly wires the gate to the run-mode flag and both directories", async () => {
     const prompt = await Bun.file(new URL("../../src/session/prompt.ts", import.meta.url).pathname).text()
     expect(prompt).toMatch(
-      /SessionPreExecution\.preExecutionInstruction\(\{\s*runMode: Flag\.ALTIMATE_RUN_MODE,\s*agent: agent\.name,\s*directories: \[Instance\.directory, Instance\.worktree\],\s*\}\)/,
+      /SessionPreExecution\.scopedBuilderPrompt\(\{\s*runMode: Flag\.ALTIMATE_RUN_MODE,\s*agent: agent\.name,\s*directories: \[Instance\.directory, Instance\.worktree\],\s*\}\)/,
     )
-    expect(prompt).toMatch(/if \(preExecutionInstruction\) system\.push\(preExecutionInstruction\)/)
-  })
-
-  // The completion instruction tells the model to signal DONE only once "every
-  // requirement above" is satisfied. A mandatory protocol pushed after it would
-  // sit outside that scope, so ordering here is behavioural, not cosmetic.
-  test("the protocol is pushed before the completion instruction", async () => {
-    const prompt = await Bun.file(new URL("../../src/session/prompt.ts", import.meta.url).pathname).text()
-    const protocolAt = prompt.indexOf("if (preExecutionInstruction) system.push(preExecutionInstruction)")
-    const completionAt = prompt.indexOf("if (completionInstruction) system.push(completionInstruction)")
-    expect(protocolAt).toBeGreaterThan(-1)
-    expect(completionAt).toBeGreaterThan(-1)
-    expect(protocolAt).toBeLessThan(completionAt)
+    // The override must actually reach the model call (via a cloned agent
+    // passed to processor.process), not just be computed and discarded.
+    expect(prompt).toMatch(/effectiveAgent = scopedBuilderPrompt \? \{ \.\.\.agent, prompt: scopedBuilderPrompt \} : agent/)
+    expect(prompt).toMatch(/agent: effectiveAgent,/)
   })
 })

--- a/packages/opencode/test/session/pre-execution.test.ts
+++ b/packages/opencode/test/session/pre-execution.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { SessionPreExecution } from "../../src/session/pre-execution"
+
+async function tmpdir(): Promise<string> {
+  return await fs.mkdtemp(path.join(os.tmpdir(), "pre-exec-scope-"))
+}
+
+describe("workspace classification", () => {
+  test("a dbt_project.yml at the root classifies as dbt", async () => {
+    const dir = await tmpdir()
+    await fs.writeFile(path.join(dir, "dbt_project.yml"), "name: demo\n")
+    expect(await SessionPreExecution.classifyWorkspace([dir])).toBe("dbt")
+  })
+
+  // Benchmark and monorepo layouts nest the project one level down; the shared
+  // findDbtProjectRoot rule already covers that and this gate must inherit it,
+  // otherwise a real dbt task would be misread as question-answering.
+  test("a dbt_project.yml one level down still classifies as dbt", async () => {
+    const dir = await tmpdir()
+    await fs.mkdir(path.join(dir, "warehouse"))
+    await fs.writeFile(path.join(dir, "warehouse", "dbt_project.yml"), "name: demo\n")
+    expect(await SessionPreExecution.classifyWorkspace([dir])).toBe("dbt")
+  })
+
+  test("a readable directory with no dbt project classifies as non-dbt", async () => {
+    const dir = await tmpdir()
+    await fs.writeFile(path.join(dir, "questions.duckdb"), "")
+    expect(await SessionPreExecution.classifyWorkspace([dir])).toBe("non-dbt")
+  })
+
+  // The two-directory case: the cwd may be a plain subfolder of a dbt project.
+  test("any readable candidate carrying a project wins", async () => {
+    const root = await tmpdir()
+    await fs.writeFile(path.join(root, "dbt_project.yml"), "name: demo\n")
+    const cwd = path.join(root, "analyses")
+    await fs.mkdir(cwd)
+    expect(await SessionPreExecution.classifyWorkspace([cwd, root])).toBe("dbt")
+  })
+
+  // The load-bearing case. `findDbtProjectRoot` returns null both for "no
+  // project here" and for "could not read this directory"; collapsing those
+  // would silently drop the protocol whenever the filesystem misbehaved.
+  test("a directory that does not exist is unknown, never non-dbt", async () => {
+    const dir = await tmpdir()
+    const missing = path.join(dir, "gone")
+    expect(await SessionPreExecution.classifyWorkspace([missing])).toBe("unknown")
+  })
+
+  test("no candidates at all is unknown", async () => {
+    expect(await SessionPreExecution.classifyWorkspace([])).toBe("unknown")
+    expect(await SessionPreExecution.classifyWorkspace([undefined, ""])).toBe("unknown")
+  })
+
+  // A non-git project sets worktree to the filesystem root. Scanning it is
+  // meaningless, and it must not count as the readable directory that licenses
+  // a non-dbt verdict on its own.
+  test("the filesystem root is not a candidate", async () => {
+    const root = path.parse(process.cwd()).root
+    expect(await SessionPreExecution.classifyWorkspace([root])).toBe("unknown")
+  })
+
+  test("an unreadable candidate does not license a non-dbt verdict from its partner", async () => {
+    const dir = await tmpdir()
+    await fs.writeFile(path.join(dir, "dbt_project.yml"), "name: demo\n")
+    expect(await SessionPreExecution.classifyWorkspace([path.join(dir, "nope"), dir])).toBe("dbt")
+  })
+
+  // A directory named dbt_project.yml is not a dbt project.
+  test("a dbt_project.yml directory is not a project", async () => {
+    const dir = await tmpdir()
+    await fs.mkdir(path.join(dir, "dbt_project.yml"))
+    expect(await SessionPreExecution.classifyWorkspace([dir])).toBe("non-dbt")
+  })
+})
+
+describe("pre-execution protocol gate", () => {
+  // The ONLY combination that drops the protocol is the one the ablation
+  // measured: headless, builder, no dbt project in the workspace.
+  test("headless builder in a non-dbt workspace drops the protocol", async () => {
+    const dir = await tmpdir()
+    expect(
+      await SessionPreExecution.preExecutionInstruction({ runMode: true, agent: "builder", directories: [dir] }),
+    ).toBeUndefined()
+  })
+
+  test("headless builder in a dbt workspace keeps it", async () => {
+    const dir = await tmpdir()
+    await fs.writeFile(path.join(dir, "dbt_project.yml"), "name: demo\n")
+    const instruction = await SessionPreExecution.preExecutionInstruction({
+      runMode: true,
+      agent: "builder",
+      directories: [dir],
+    })
+    expect(instruction).toBe(SessionPreExecution.PRE_EXECUTION_PROTOCOL)
+  })
+
+  // Interactive chat is a builder surface the ablation never covered, so it is
+  // unchanged from before this PR regardless of what the workspace looks like.
+  test("interactive builder always keeps it, dbt project or not", async () => {
+    const dir = await tmpdir()
+    expect(
+      await SessionPreExecution.preExecutionInstruction({ runMode: false, agent: "builder", directories: [dir] }),
+    ).toBe(SessionPreExecution.PRE_EXECUTION_PROTOCOL)
+  })
+
+  // Ambiguity keeps the protocol. Wrongly dropping it has an unmeasured cost;
+  // wrongly keeping it costs latency on one workload.
+  test("an unclassifiable workspace keeps it", async () => {
+    const dir = await tmpdir()
+    expect(
+      await SessionPreExecution.preExecutionInstruction({
+        runMode: true,
+        agent: "builder",
+        directories: [path.join(dir, "does-not-exist")],
+      }),
+    ).toBe(SessionPreExecution.PRE_EXECUTION_PROTOCOL)
+    expect(
+      await SessionPreExecution.preExecutionInstruction({ runMode: true, agent: "builder", directories: [] }),
+    ).toBe(SessionPreExecution.PRE_EXECUTION_PROTOCOL)
+  })
+
+  // Only builder.txt ever carried this section, so injecting it for analyst or
+  // reviewer would be a new instruction, not a preserved one.
+  test("no other agent receives the protocol", async () => {
+    const dir = await tmpdir()
+    for (const agent of ["analyst", "reviewer", "plan", "general"]) {
+      expect(
+        await SessionPreExecution.preExecutionInstruction({ runMode: false, agent, directories: [dir] }),
+      ).toBeUndefined()
+      expect(
+        await SessionPreExecution.preExecutionInstruction({ runMode: true, agent, directories: [dir] }),
+      ).toBeUndefined()
+    }
+  })
+})
+
+describe("prompt text fidelity", () => {
+  // The injected text must be byte-identical to what builder.txt shipped, so
+  // that every kept case produces the same resolved prompt as before.
+  test("the injected protocol is verbatim the section that was removed", async () => {
+    const expected = [
+      "## Pre-Execution Protocol",
+      "",
+      "Before executing ANY SQL via sql_execute, follow this mandatory sequence:",
+    ].join("\n")
+    expect(SessionPreExecution.PRE_EXECUTION_PROTOCOL.startsWith(expected)).toBe(true)
+    expect(SessionPreExecution.PRE_EXECUTION_PROTOCOL).toContain("This sequence is NOT optional.")
+    expect(SessionPreExecution.PRE_EXECUTION_PROTOCOL).toContain("altimate_core_validate")
+    expect(SessionPreExecution.PRE_EXECUTION_PROTOCOL).toContain("sql_analyze")
+    expect(SessionPreExecution.PRE_EXECUTION_PROTOCOL.endsWith("still validate syntax.")).toBe(true)
+  })
+
+  // If the section came back into the static prompt file the gate would be a
+  // no-op and every surface would carry it again.
+  test("the builder prompt file no longer carries the section", async () => {
+    const prompt = await Bun.file(new URL("../../src/altimate/prompts/builder.txt", import.meta.url).pathname).text()
+    expect(prompt).not.toContain("## Pre-Execution Protocol")
+    expect(prompt).not.toContain("This sequence is NOT optional.")
+    // The neighbouring sections must survive — only the one section moved.
+    expect(prompt).toContain("## dbt Verification Workflow")
+    expect(prompt).toContain("## Finish Protocol (mandatory before ending any build/fix task)")
+  })
+
+  // The Finish Protocol is a SECOND mandatory ritual in the same family, added
+  // after the binary the ablation measured was built. It is deliberately left
+  // alone: no measurement covers it, and this PR does not speak to it.
+  test("the Finish Protocol is untouched by this change", async () => {
+    const prompt = await Bun.file(new URL("../../src/altimate/prompts/builder.txt", import.meta.url).pathname).text()
+    expect(prompt).toContain("Re-read the task's literal requirements")
+    expect(prompt).toContain("Run the final build and tests")
+  })
+
+  test("prompt assembly wires the gate to the run-mode flag and both directories", async () => {
+    const prompt = await Bun.file(new URL("../../src/session/prompt.ts", import.meta.url).pathname).text()
+    expect(prompt).toMatch(
+      /SessionPreExecution\.preExecutionInstruction\(\{\s*runMode: Flag\.ALTIMATE_RUN_MODE,\s*agent: agent\.name,\s*directories: \[Instance\.directory, Instance\.worktree\],\s*\}\)/,
+    )
+    expect(prompt).toMatch(/if \(preExecutionInstruction\) system\.push\(preExecutionInstruction\)/)
+  })
+})

--- a/packages/opencode/test/session/pre-execution.test.ts
+++ b/packages/opencode/test/session/pre-execution.test.ts
@@ -40,9 +40,9 @@ describe("workspace classification", () => {
     expect(await SessionPreExecution.classifyWorkspace([cwd, root])).toBe("dbt")
   })
 
-  // The load-bearing case. `findDbtProjectRoot` returns null both for "no
-  // project here" and for "could not read this directory"; collapsing those
-  // would silently drop the protocol whenever the filesystem misbehaved.
+  // The load-bearing case. A scan that collapses "no project here" and "could
+  // not look here" into one answer silently drops the protocol whenever the
+  // filesystem misbehaves.
   test("a directory that does not exist is unknown, never non-dbt", async () => {
     const dir = await tmpdir()
     const missing = path.join(dir, "gone")
@@ -62,7 +62,7 @@ describe("workspace classification", () => {
     expect(await SessionPreExecution.classifyWorkspace([root])).toBe("unknown")
   })
 
-  test("an unreadable candidate does not license a non-dbt verdict from its partner", async () => {
+  test("a project on one candidate wins even when its partner is unreadable", async () => {
     const dir = await tmpdir()
     await fs.writeFile(path.join(dir, "dbt_project.yml"), "name: demo\n")
     expect(await SessionPreExecution.classifyWorkspace([path.join(dir, "nope"), dir])).toBe("dbt")
@@ -93,14 +93,48 @@ describe("workspace classification", () => {
     expect(await SessionPreExecution.classifyWorkspace([deep])).toBe("dbt")
   })
 
-  // The upward walk is bounded, so an unrelated deep tree does not scan to /.
-  test("the ancestor walk is bounded", async () => {
+  // The walk runs to the filesystem root rather than stopping at a depth
+  // limit. A limit would have to report "I stopped early" as unknown to stay
+  // honest, which on any deep tree switches the gate off entirely.
+  test("the ancestor walk is not depth-limited", async () => {
     const root = await tmpdir()
     await fs.writeFile(path.join(root, "dbt_project.yml"), "name: demo\n")
-    const parts = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
-    const deep = path.join(root, ...parts)
+    const deep = path.join(root, "a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
     await fs.mkdir(deep, { recursive: true })
-    expect(await SessionPreExecution.classifyWorkspace([deep])).toBe("non-dbt")
+    expect(await SessionPreExecution.classifyWorkspace([deep])).toBe("dbt")
+  })
+
+  // `path.resolve` is lexical. A symlinked cwd would walk the link's own
+  // parents and never see the project the session is actually inside.
+  test("a symlinked candidate is resolved before the walk", async () => {
+    const project = await tmpdir()
+    await fs.writeFile(path.join(project, "dbt_project.yml"), "name: demo\n")
+    const inner = path.join(project, "models")
+    await fs.mkdir(inner)
+    const elsewhere = await tmpdir()
+    const link = path.join(elsewhere, "ws")
+    await fs.symlink(inner, link, "dir")
+    expect(await SessionPreExecution.classifyWorkspace([link])).toBe("dbt")
+  })
+
+  // Filtering children on isDirectory() would skip symlinked directories, and
+  // a skipped entry is an unexamined one.
+  test("a symlinked child project is found", async () => {
+    const project = await tmpdir()
+    await fs.writeFile(path.join(project, "dbt_project.yml"), "name: demo\n")
+    const workspace = await tmpdir()
+    await fs.symlink(project, path.join(workspace, "warehouse"), "dir")
+    expect(await SessionPreExecution.classifyWorkspace([workspace])).toBe("dbt")
+  })
+
+  // One completely examined candidate settles it. Its ancestor walk already
+  // covers the worktree above it, so a partner that could not be read has
+  // nothing left to contribute — and vetoing on it would return unknown for
+  // every non-git project, where the worktree candidate is the filesystem root.
+  test("a complete candidate is not vetoed by an unreadable partner", async () => {
+    const dir = await tmpdir()
+    expect(await SessionPreExecution.classifyWorkspace([dir, path.join(dir, "gone")])).toBe("non-dbt")
+    expect(await SessionPreExecution.classifyWorkspace([dir, path.parse(dir).root])).toBe("non-dbt")
   })
 
   // The failure that matters most: a directory that stats fine but cannot be


### PR DESCRIPTION
### Issue for this PR

Closes #1214

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

> **Reworked onto #1217 (2026-09-02).** #1217 merged to `main` and deleted the monolithic `builder.txt` this PR originally edited, splitting it into `builder/core.txt` + `builder/packs/*.txt` fragments assembled by `altimate/prompts/profiles.ts`. The Pre-Execution Protocol is now the `sql-guard` pack, and it ships statically inside the default byte-pinned `PROMPT_BUILDER`. This PR was rebased onto that architecture and its mechanism re-expressed as **conditional pack exclusion** instead of **conditional text injection** — the intent, the classifier, and the safety property (`unknown` keeps the protocol) are unchanged; only the "how" moved. See "The scoping mechanism" and "How did you verify" below for the reworked details, and the description of the original evidence/ablation immediately below is unchanged.

`## Pre-Execution Protocol` sat statically in `packages/opencode/src/altimate/prompts/builder.txt` (now `builder/packs/sql-guard.txt`), making `sql_analyze` + `altimate_core_validate` mandatory before every `sql_execute`. `builder` is a PRIMARY agent, so that one section governed every builder surface at once — dbt authoring, interactive chat, and headless question-answering runs.

**The evidence.** An internal pre-registered paired prompt ablation, 540 trials on a public data-question benchmark, one binary across both arms, every trial's resolved system prompt verified by sha256 against a pre-registered artifact:

| | macro Pass@1 | micro Pass@1 |
|---|---:|---:|
| control | 0.6667 | 0.6778 |
| treatment (protocol removed, among other changes) | 0.6807 | 0.7148 |
| delta | **+0.0140** | +0.0370 |

- query-blocked sign-flip permutation, 20,000 resamples: **p = 0.7358**
- cluster-bootstrap 95% CI: **[-0.0400, +0.0674]**
- per-query direction: treatment better 16, control better 11, tied 27 (exact sign test p = 0.4421)

**The honest claim is "no score effect, materially cheaper."** The +0.0140 is not distinguishable from zero and is not presented here as an improvement — the interval comfortably contains zero in both directions.

What did move:

| | control | treatment | delta |
|---|---:|---:|---:|
| wall clock per trial (restricted mean) | 440.9s | 319.4s | **-121.5s (-27.6%)** |
| model generations per trial | 11.9 | 8.6 | -27.7% |
| generation seconds per trial | 187.6 | 127.2 | -32.2% |
| `altimate_core_validate` calls (arm total) | 1,476 | **0** | -1,476 |
| `sql_analyze` calls (arm total) | 1,329 | **0** | -1,329 |
| `sql_execute` calls (arm total) | 1,716 | 2,554 | **+838 (+49%)** |
| trials hitting the 900s timeout | 27 | 16 | -11 |

The 2,805 ritual tool calls going to **zero — not reduced, zero** — is the one number directly attributable to this text. The ritual is prompt-ordered: remove the order and it stops completely. The freed budget went into the benchmark's actual work (`sql_execute` +49%).

**Why this scopes rather than deletes**, both taken from the experiment's own caveats:

1. The latency win is **not attributable to this section alone**. That treatment arm bundled five coupled changes across two arms; the experiment declined to attribute and no factorial was run.
2. The measurement covers **data questions only**. dbt authoring and interactive chat are unmeasured builder surfaces where a pre-execution discipline may genuinely earn its place.

#### The scoping mechanism (reworked onto #1217's pack architecture)

`agent.ts` registers `builder` with `prompt: PromptProfiles.PROMPT_BUILDER` — a plain string, assembled ONCE at module load from `core.txt` + all packs including `sql-guard`, and byte-pinned by `test/altimate/prompt-profiles.test.ts`. That default registration is never touched by this PR — no change to `agent.ts`, `profiles.ts`'s existing exports, or the pin.

The mechanism this PR adds: `profiles.ts` gets one additive export, `PROMPT_BUILDER_SCOPED` — the same profile, same fragment order, with only the `sql-guard` pack filtered out. `session/pre-execution.ts`'s gate (`SessionPreExecution.scopedBuilderPrompt`, formerly `preExecutionInstruction`) now returns that override string, or `undefined` to mean "use the agent's default prompt, unchanged." `session/prompt.ts` — at the point in the per-step loop where a fully-resolved `Agent.Info` is already in scope, right before the model call — clones it with `.prompt` swapped only when the gate returns an override, and passes that clone into `processor.process` (which is what actually reaches `LLM.stream`). The registered agent object is never mutated.

This follows the precedent already in the tree in spirit — `SessionTermination.completionInstruction` also scopes a run-mode-only instruction to `builder` — but the action is now *exclude a pack from an already-assembled prompt* rather than *inject additive text into the turn's system array*, because #1217 baked the protocol into the static default and there is no longer a `builder.txt` to edit or an absence to inject text into.

**Design fork considered and rejected:** making `Agent.Info.prompt` a function (computed per-session) instead of a plain string, or excluding the pack at `agent.ts` registration time. Rejected because `agent.prompt` is read as a plain string directly downstream in `llm.ts`, `llm/request.ts`, and `compaction.ts`, and `agent.ts` registration happens once at config load with no access to a session's cwd/worktree — either option would touch the agent registration shape and multiple downstream consumers for no behavioral gain over cloning the already-resolved agent at the one call site that needs the override.

**How the condition is decided.** The protocol is dropped only when **all three** hold:

1. run mode (`Flag.ALTIMATE_RUN_MODE` — the `run` CLI, CI, headless), and
2. the agent is `builder` (the only profile that ever carried the `sql-guard` pack — `analyst.txt` and `reviewer.txt` never did), and
3. the workspace is **confidently** classified as having no dbt project.

That is exactly the cell the ablation measured — unchanged from before the rework. Every other case returns `undefined` (default prompt, protocol included), so a kept case resolves to the exact same prompt as the default builder profile.

**Where it looks.** A `dbt_project.yml` (or `.yaml`) **file** at the candidate directory (`realpath`ed first, so a symlinked cwd is followed), at any ancestor up to the filesystem root, or one level below — the last matching `findDbtProjectRoot`'s existing rule and skip list, which is how benchmark and monorepo layouts nest a project. The ancestor walk matters because a session is routinely started inside `models/`, and on a non-git project the worktree candidate is the same directory, so nothing else would find the project. The walk is unbounded on purpose: a depth limit would have to report "I stopped early" as `unknown` to stay honest, which on any deep tree turns the gate off entirely, and two `stat` calls per level in run mode is not worth that.

**The ambiguous case keeps the protocol.** Classification returns a tri-state — `dbt` / `non-dbt` / `unknown` — and only `non-dbt` drops. `non-dbt` requires at least one candidate the scan examined **completely**: symlinks resolved, every ancestor probe answered up to the root, and its own children enumerated and probed. `ENOENT`/`ENOTDIR` are real answers ("nothing there"); every other failure — `EACCES`, `EIO`, a flaky mount — is `unknown`. The filesystem root never qualifies on its own, because its children are deliberately not scanned. An unrelated ancestor project is a false positive that *keeps* the protocol, which is the safe direction. The asymmetry throughout is deliberate: the cost of wrongly keeping it is 27% latency on one workload, the cost of wrongly dropping it is unmeasured.

One complete answer is enough — an incomplete partner candidate does not veto it. That matters: `worktree` is the filesystem root on a non-git project, so a veto rule returned `unknown` for every headless run in exactly the configuration the ablation measured, and the gate would have shipped as a no-op.

Interactive chat is deliberately left alone. Run mode is not itself a task-shape signal — it is the surface the evidence covers, and widening the gate to interactive sessions needs its own measurement.

#### Not touched

`main` also carries `## Finish Protocol` (shipped in #1171), a second mandatory ritual in the same family that was added *after* the binary the ablation measured was built. The shipping prompt is therefore heavier than what was measured, and the -27.6% understates the current cost. No measurement covers that section, so this PR leaves it alone; a test asserts it survives.

### How did you verify your code works?

**Carried over unchanged by the rework** (the classifier itself was not touched):

- Unit suite `packages/opencode/test/session/pre-execution.test.ts`'s `workspace classification` describe (14 tests): each classification outcome against real temp directories (project at the candidate, one level down, above it, `.yaml` as well as `.yml`, no project, a missing directory, a directory that stats but cannot be enumerated, no candidates, the filesystem root, `dbt_project.yml` as a directory rather than a file, the unbounded ancestor walk, a symlinked candidate, a symlinked child project, and a complete candidate not vetoed by an unreadable partner or by the filesystem root) — untouched by the rework, still 14/14 green.
- Reviewed by a second model across two rounds pre-rework. Round one found three bugs — two silent-drop paths in the classifier and an injection-order issue. Round two found four more, including a veto rule that would have made the gate a no-op on every non-git workspace, a depth limit whose exhaustion was recorded as a complete answer, a lexical (symlink-blind) ancestor walk, and a child scan that silently skipped symlinked directories. All seven fixed, each with a test that survived the rebase.

**Rework-specific verification (2026-09-02):**

- Rewrote the `pre-execution protocol gate` and `prompt text fidelity` describes in `pre-execution.test.ts` (they asserted the old text-injection mechanism, including one test that grepped the now-deleted `builder.txt`) to assert the new override/exclusion behavior: each gate arm now checks the returned override is `=== PromptProfiles.PROMPT_BUILDER_SCOPED` and `!== PROMPT_BUILDER` (not just "truthy"/"a string containing X"), and every non-firing arm asserts `undefined` — a test that fails if the gate silently no-ops. Added `PROMPT_BUILDER_SCOPED omits sql-guard and nothing else`, verifying the override is `BUILDER_PROFILE` minus exactly the `sql-guard` fragment and that neighbouring packs (`## dbt Verification Workflow`, `## Finish Protocol`) survive. 24/24 green.
- Fixed the one `sql-validation-e2e.test.ts` test that called the renamed `preExecutionInstruction`; whole file green (56/56).
- **Byte-identity gate** (`test/altimate/prompt-profiles.test.ts`, #1217's guarantee that the default builder profile is unchanged): green — `PROMPT_BUILDER` still hashes to the pinned sha256 (`17663410dd9accc527b4cbd84558fc577ccc36d33d0428c5c5205d5df25400d7`, 14,773 bytes). This PR's only edit to `profiles.ts` is one additive export block; `BUILDER_PROFILE`, `FRAGMENTS`, `assemble`, `PROMPT_BUILDER`, `DATA_QA_PROFILE`, and `PROMPT_DATA_QA` are byte-for-byte untouched.
- `bun install` then `bun run typecheck` — clean on every touched file.
- `bun run script/upstream/analyze.ts --markers --base origin/main --strict` — ok: 1 upstream-shared file checked (`session/prompt.ts`), all custom code properly marked.
- `bun test test/session/pre-execution.test.ts test/altimate/prompt-profiles.test.ts test/altimate/sql-validation-e2e.test.ts test/agent/` — 141 pass, 0 fail.
- `test/session/prompt.test.ts`'s `loop calls LLM and returns assistant message` / `loop surfaces content-filter finishes as session errors` time out locally — reproduced identically by stashing this rework's changes and re-running on the pre-rework branch tip, so this is pre-existing local flakiness (not something the rework introduced or should be scoped as fixing).

**Not verified:** this change has not been run end to end against a live warehouse, and no benchmark re-run was performed on this build. The behavioural claim rests on the ablation cited above, which measured a pre-#1171 binary; the gate reproduces that binary's treatment only for the cell it measured. The rework changes HOW the exclusion is expressed, not the classifier or the decision boundary, so no new ablation is claimed or needed for the rework itself.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

> **Note:** the auto-generated bot summaries below (Cursor Bugbot, CodeRabbit) describe the pre-rework, text-injection mechanism against the pinned commit noted inline — they predate the 2026-09-02 rework onto #1217's pack architecture described above and have not been regenerated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when the builder must run `sql_analyze`/`altimate_core_validate` before `sql_execute` in CI/run mode; misclassification could drop guards on dbt work, though `unknown` and dbt paths intentionally keep the protocol.
> 
> **Overview**
> **Headless builder runs in workspaces with no dbt project** can now skip the mandatory Pre-Execution Protocol (`sql-guard` pack) without changing the default registered builder prompt.
> 
> Adds `PROMPT_BUILDER_SCOPED` in `profiles.ts` (same builder fragments minus `sql-guard`) and a new `session/pre-execution.ts` module that classifies cwd/worktree as `dbt`, `non-dbt`, or `unknown` via ancestor walks, bounded downward search, and symlink-aware probes. `scopedBuilderPrompt` returns that scoped prompt only when **run mode**, registry key **`builder`**, prompt is still byte-identical **`PROMPT_BUILDER`**, and classification is confidently **`non-dbt`**; every other case keeps the stock prompt.
> 
> `session/prompt.ts` memoizes the gate once per `loop()` invocation and passes a cloned `effectiveAgent` into `processor.process` when an override applies. Tests cover classification edge cases, gate arms, cache behavior, and e2e prompt expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e93080ea5667a57f3b16ab59b3f5924b0ecfd9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added workspace-aware prompt behavior for builder sessions.
  - Run-mode builder sessions in confirmed non-dbt workspaces now receive a streamlined prompt without SQL guard instructions.
  - dbt workspaces, interactive sessions, uncertain workspace classifications, and other agents retain their standard prompts.

- **Tests**
  - Added coverage for workspace detection across nested, ancestor, YAML, symlinked, missing, and unreadable project layouts.
  - Added validation for prompt selection across supported session types and workspace conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
