### PR TITLE
fix(release): never let a prerelease version fall back to the `latest` dist-tag

### DIFF
--- a/packages/opencode/test/release/channel.test.ts
+++ b/packages/opencode/test/release/channel.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Which npm dist-tag a publish lands on.
+ *
+ * Getting this wrong in the `latest` direction moves every existing user onto
+ * whatever was published, and the documented recovery
+ * (`npm dist-tag add …@<good> latest`) needs publish credentials most of the
+ * team does not hold — so the decision is pinned here rather than left to an
+ * inline expression whose only protection is an env var reaching one workflow
+ * step. See #1233.
+ */
+
+import { describe, test, expect } from "bun:test"
+import { resolveChannel } from "../../../script/src/channel"
+
+describe("resolveChannel: a prerelease must never reach `latest`", () => {
+  test("an explicit channel always wins", () => {
+    // This is the path the release workflow actually takes.
+    expect(resolveChannel({ OPENCODE_CHANNEL: "beta", OPENCODE_VERSION: "v0.10.0-beta.1" })).toBe("beta")
+    expect(resolveChannel({ OPENCODE_CHANNEL: "latest", OPENCODE_VERSION: "v0.10.0" })).toBe("latest")
+  })
+
+  test("a prerelease tag falls back to `beta`, not `latest`", () => {
+    // The regression this guards. With OPENCODE_CHANNEL unset, the version is
+    // the tag name — and before the fix, `0.10.0-beta.1` failed the `0.0.0-`
+    // test and returned "latest", moving the stable dist-tag onto a beta.
+    for (const v of ["v0.10.0-beta.1", "0.10.0-beta.1", "v1.0.0-rc.2", "v0.9.6-beta.10"]) {
+      expect(resolveChannel({ OPENCODE_VERSION: v })).toBe("beta")
+    }
+  })
+
+  test("a plain release version still resolves to `latest`", () => {
+    // The fix must not push ordinary stable releases off `latest`.
+    for (const v of ["v0.10.0", "0.10.0", "v1.2.3"]) {
+      expect(resolveChannel({ OPENCODE_VERSION: v })).toBe("latest")
+    }
+  })
+
+  test("`0.0.0-` preview builds still defer to the branch channel", () => {
+    // These carry a `-` too, but they must keep falling through to the
+    // branch-name channel rather than being captured as `beta`.
+    expect(resolveChannel({ OPENCODE_VERSION: "0.0.0-release/v0.10.0-202609012234" })).toBeNull()
+    expect(resolveChannel({ OPENCODE_VERSION: "v0.0.0-somebranch-123" })).toBeNull()
+  })
+
+  test("an explicit bump means a stable release", () => {
+    expect(resolveChannel({ OPENCODE_BUMP: "minor" })).toBe("latest")
+  })
+
+  test("no signal at all defers to the caller", () => {
+    expect(resolveChannel({})).toBeNull()
+  })
+})

--- a/packages/script/src/channel.ts
+++ b/packages/script/src/channel.ts
@@ -1,0 +1,32 @@
+// altimate_change start — extracted from the CHANNEL IIFE in ./index.ts so the
+// dist-tag decision can be tested without importing that module, which checks
+// the bun version, shells out to git and fetches the npm registry at import.
+//
+// This decides which npm dist-tag a publish lands on. Getting it wrong in the
+// `latest` direction moves every existing user onto whatever was published, and
+// recovery needs npm credentials most of the team does not hold — so it is
+// worth having as a pure, tested function rather than an inline expression.
+// (#1233)
+
+export type ChannelEnv = {
+  OPENCODE_CHANNEL?: string | undefined
+  OPENCODE_BUMP?: string | undefined
+  OPENCODE_VERSION?: string | undefined
+}
+
+/** Resolve the npm dist-tag, or null when the caller should fall back to the
+ * current git branch name (the local/preview path). */
+export function resolveChannel(env: ChannelEnv): string | null {
+  if (env.OPENCODE_CHANNEL) return env.OPENCODE_CHANNEL
+  if (env.OPENCODE_BUMP) return "latest"
+  if (env.OPENCODE_VERSION) {
+    const version = env.OPENCODE_VERSION.replace(/^v/, "")
+    // `0.0.0-` preview builds keep falling through to the branch-name channel.
+    if (version.startsWith("0.0.0-")) return null
+    // A semver prerelease belongs on `beta`, never `latest`. Before this, a
+    // `v0.10.0-beta.1` tag reaching this branch returned "latest" and would
+    // have auto-upgraded the entire stable user base onto a beta.
+    return version.includes("-") ? "beta" : "latest"
+  }
+  return null
+}

--- a/packages/script/src/index.ts
+++ b/packages/script/src/index.ts
@@ -1,6 +1,7 @@
 import { $ } from "bun"
 import semver from "semver"
 import path from "path"
+import { resolveChannel } from "./channel"
 
 const rootPkgPath = path.resolve(import.meta.dir, "../../../package.json")
 const rootPkg = await Bun.file(rootPkgPath).json()
@@ -24,9 +25,9 @@ const env = {
   OPENCODE_RELEASE: process.env["OPENCODE_RELEASE"],
 }
 const CHANNEL = await (async () => {
-  if (env.OPENCODE_CHANNEL) return env.OPENCODE_CHANNEL
-  if (env.OPENCODE_BUMP) return "latest"
-  if (env.OPENCODE_VERSION && !env.OPENCODE_VERSION.replace(/^v/, "").startsWith("0.0.0-")) return "latest"
+  // altimate_change — see ./channel.ts for why this is a separate pure function. (#1233)
+  const resolved = resolveChannel(env)
+  if (resolved) return resolved
   return await $`git branch --show-current`.text().then((x) => x.trim())
 })()
 const IS_PREVIEW = CHANNEL !== "latest"


### PR DESCRIPTION
Closes #1233

Audited while preparing the `v0.10.0` beta. Split out of #1232 because it is unrelated to that release's content — this is release *infrastructure*, and it should be reviewable on its own.

## The failure case

`.github/workflows/release.yml:338` publishes with `OPENCODE_VERSION: ${{ github.ref_name }}`, which for a beta tag is `v0.10.0-beta.1`. If `OPENCODE_CHANNEL` ever failed to reach that step, the fallback chain in `packages/script/src/index.ts` ran:

1. `OPENCODE_CHANNEL` empty → skipped
2. `OPENCODE_BUMP` unset → skipped
3. `OPENCODE_VERSION` → `0.10.0-beta.1` → does **not** start with `0.0.0-` → **returns `latest`**

All three `npm publish` calls then run `--tag latest`, moving the stable dist-tag onto a prerelease. Every existing user auto-upgrades to the beta on next launch — the exact outcome the beta channel exists to prevent.

## This has never fired

Worth stating plainly, since the fix is precautionary:

- `release.yml:98` and `:344` set `OPENCODE_CHANNEL` to `${{ contains(github.ref_name, '-') && 'beta' || 'latest' }}`, which always yields one of those two strings and never empty.
- There is exactly one publish step, and it carries the variable in its own `env:` block.
- All three `npm publish` calls in `publish.ts` pass `--tag ${Script.channel}`; none publishes bare.

So the hazard is masked entirely by one workflow expression. Nothing in the fallback itself prevents it.

## Why fix it anyway

The blast radius is the whole user base, and the documented recovery — `npm dist-tag add @altimateai/altimate-code@<good> latest` — needs npm publish credentials that most of the team does not hold. Detection you cannot act on is not a safety net. The release process makes "confirm `latest` did not move" a mandatory post-publish assertion precisely because this class of mistake is unrecoverable for most people who would hit it.

## The change

Extracted the decision into `packages/script/src/channel.ts` as a pure `resolveChannel`. It could not be tested in place: importing `script/src/index.ts` checks the bun version, shells out to `git branch`, and fetches the npm registry at module load.

Behaviour:

| `OPENCODE_VERSION` | Before | After |
|---|---|---|
| `v0.10.0-beta.1` | `latest` | **`beta`** |
| `v0.10.0` | `latest` | `latest` |
| `0.0.0-<branch>-<ts>` | falls through to branch channel | unchanged |

An explicit `OPENCODE_CHANNEL` still wins outright, so the normal workflow path is untouched.

## Tests

Six cases in `packages/opencode/test/release/channel.test.ts` covering both directions plus the preview path. Mutation-verified: restoring the old `return "latest"` fails exactly the prerelease regression test and nothing else.

Typecheck clean across 13 packages; marker guard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents prerelease versions from ever landing on the `latest` npm dist-tag. Previously, if `OPENCODE_CHANNEL` failed to reach the publish step, a beta tag like `v0.10.0-beta.1` would fall through to `latest`, auto-upgrading every existing user on next launch.

This hasn't fired yet — the workflow always sets `OPENCODE_CHANNEL` — but recovery (`npm dist-tag add ...`) requires publish credentials most of the team doesn't hold, so the fallback alone isn't a safety net.

**Changes**
- Extracts the dist-tag decision into `resolveChannel` in `packages/script/src/channel.ts` as a pure function so it can be tested without importing the module.
- Prerelease versions now resolve to `beta`; `0.0.0-` preview builds still fall through to the branch channel; stable versions still resolve to `latest`.
- An explicit `OPENCODE_CHANNEL` still wins, so the normal workflow path is unchanged.
- Adds tests in `packages/opencode/test/release/channel.test.ts` covering both directions plus the preview path.
- Closes #1233.

<sup>Written for commit 8dd9800951d0a43d5a840971052e387ca6a99697. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/1234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Release publishing now selects the appropriate distribution channel more reliably:
    - Explicit channel settings take priority.
    - Prerelease versions are published to the beta channel.
    - Stable versions use the latest channel.
    - Preview builds defer to the branch-based channel.
    - Explicit bump commands continue to use the latest channel.

- **Tests**
  - Added coverage for release-channel selection across supported version, preview, and configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->