### PR TITLE
fix: ledger redaction — preserve write paths and close a curl -u credential leak introduced by #1117

### DIFF
--- a/packages/opencode/src/altimate/telemetry/index.ts
+++ b/packages/opencode/src/altimate/telemetry/index.ts
@@ -1558,14 +1558,20 @@ export namespace Telemetry {
   // Each match replaces with a fixed redaction so length-based fingerprinting
   // can't reconstruct the original token.
 
-  export function maskString(s: string): string {
+  // altimate_change start — maskPaths opt-out for callers that redact on their
+  // own terms (see compaction.ts::redactLedgerDetail). Default true keeps
+  // every existing caller's behavior byte-for-byte unchanged; only a caller
+  // that explicitly passes maskPaths:false skips the #1117 path-masking pass,
+  // and every other rule (api keys, bearer tokens, emails, internal hosts,
+  // quote collapsing) still applies.
+  export function maskString(s: string, opts?: { maskPaths?: boolean }): string {
     // Consumers truncate masked output to <= 2000 chars; masking beyond 8 KB
     // buys nothing, and unbounded input is what turns any super-linear rule
     // into a stall. Input is cut FIRST so every rule — the linear credential/
     // quote passes included — does bounded work, and the cut must never fail
     // a rule open across the boundary. No floor gates any of this: a floor is
     // a leak past the floor.
-    if (s.length <= PM_CAP) return pmMask(s)
+    if (s.length <= PM_CAP) return pmMask(s, opts)
     // the head ends at whitespace of any kind, so no token straddles it (a
     // head with no whitespace at all is one token: nothing is emitted)
     const ws = s.slice(0, PM_CAP).search(/\s\S*$/)
@@ -1583,17 +1589,18 @@ export namespace Telemetry {
     // masked the same way with and without the continuation, cut back to
     // whitespace. Whatever the continuation changes is dropped, never
     // emitted half-proven.
-    const alone = pmMask(head)
-    const seen = pmMask(s.slice(0, at + PM_LOOKAHEAD))
+    const alone = pmMask(head, opts)
+    const seen = pmMask(s.slice(0, at + PM_LOOKAHEAD), opts)
     let n = 0
     while (n < alone.length && alone[n] === seen[n]) n++
     if (n === alone.length) return alone
     const back = alone.slice(0, n).search(/\s\S*$/)
     return back >= 0 ? alone.slice(0, back).trimEnd() : ""
   }
+  // altimate_change end
 
   // the masking chain proper, on bounded input (see maskString)
-  function pmMask(s: string): string {
+  function pmMask(s: string, opts?: { maskPaths?: boolean }): string {
     let out = s
       // ANSI CSI sequences (colored subprocess stderr) would otherwise split
       // tokens so neither credential nor path rules can see them
@@ -1604,7 +1611,13 @@ export namespace Telemetry {
       .replace(/"(?:[^"\\]|\\.)*"/g, "?")
     // Fast path: a string with no separator cannot contain a path — skip the
     // whole path stack (most telemetry strings carry no path at all).
-    if (out.includes("/") || out.includes("\\") || /(?<![A-Za-z0-9])[A-Z]:[^\s:\\\/]{1,255}\.[A-Za-z]/.test(out)) {
+    // altimate_change — maskPaths:false (see maskString) skips this whole
+    // pass; every other rule in pmMask still runs.
+    const maskPaths = opts?.maskPaths ?? true
+    if (
+      maskPaths &&
+      (out.includes("/") || out.includes("\\") || /(?<![A-Za-z0-9])[A-Z]:[^\s:\\\/]{1,255}\.[A-Za-z]/.test(out))
+    ) {
       out = out
       // altimate_change start — mask filesystem paths in error text
       // Six masking rules (cloud URIs, Windows home, Windows/UNC incl. .\ and

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -667,9 +667,49 @@ export namespace SessionCompaction {
     return SENSITIVE_NAME.test(name)
   }
 
+  // altimate_change — the flag+value regex used both to redact `-u`/`--user`
+  // below and (via redactLedgerDetail's raw-value precomputation) to locate
+  // the same occurrences in the pre-mask text. Shared so the two passes stay
+  // in lockstep by construction instead of by copy-pasted duplication.
+  const USER_FLAG_RE =
+    /(^|\s)(--user|-u)(?:(=|\s+)("[^"]*"|'[^']*'|[^\s,;]+)|([^\s,;]+))(?:(\s+)("[^"]*"|'[^']*'|[^\s,;]+))?/gi
+
+  function isCurlContext(segment: string): boolean {
+    // Windows invokes curl as `curl.exe`, and either platform may reach it
+    // through a path such as /usr/bin/curl or a Windows System32 path.
+    // Missing those spellings left the `-u` VALUE unredacted.
+    return /(?:^|[\s/\\])curl(?:\.exe)?(?=\s|$)/i.test(segment)
+  }
+
   export function redactLedgerDetail(value: string): string {
     const sensitiveName = SENSITIVE_NAME
-    let masked = Telemetry.maskString(value)
+    // altimate_change — keep the filesystem-path masking pass OFF here. Left
+    // on, it collapses a path-qualified command like `/usr/bin/curl` down to
+    // `<path>` before the curlContext lookback below ever runs, which both
+    // destroys the write paths this ledger exists to report AND — the actual
+    // security bug — erases the `curl` token the lookback needs, so a
+    // path-qualified `curl -u user password` credential slips through
+    // unredacted. Every other telemetry mask (api keys, bearer tokens,
+    // emails, internal hosts, quote collapsing) still applies.
+    let masked = Telemetry.maskString(value, { maskPaths: false })
+
+    // altimate_change start — belt-and-suspenders curl detection. Derive
+    // curlContext for each `-u`/`--user` occurrence from the RAW, pre-mask
+    // `value` as well as from `masked`. maskPaths:false above is what keeps
+    // the `curl` token intact today; this makes detection structurally
+    // independent of that single flag, so a future masking rule that happens
+    // to eat the command-name token can't quietly reopen this leak. The two
+    // occurrence lists are correlated by ordinal position (same regex, same
+    // match order); if a prior mask ever changes how many times the pattern
+    // matches, this safely falls back to the masked-only signal — no worse
+    // than before this change.
+    const rawCurlByOrdinal = [...value.matchAll(USER_FLAG_RE)].map((m) =>
+      isCurlContext(shellSegmentBefore(value, m.index + m[1].length)),
+    )
+    const maskedOccurrenceCount = [...masked.matchAll(USER_FLAG_RE)].length
+    const ordinalsAligned = maskedOccurrenceCount === rawCurlByOrdinal.length
+    let ordinal = 0
+    // altimate_change end
 
     // `-u` is also a benign flag for commands such as `git push -u` and
     // `python -u`. Redact it as authentication only in the current curl shell
@@ -677,7 +717,7 @@ export namespace SessionCompaction {
     // `--user` follows the same rule so task literals are not discarded merely
     // because an unrelated CLI chose that option name.
     masked = masked.replace(
-      /(^|\s)(--user|-u)(?:(=|\s+)("[^"]*"|'[^']*'|[^\s,;]+)|([^\s,;]+))(?:(\s+)("[^"]*"|'[^']*'|[^\s,;]+))?/gi,
+      USER_FLAG_RE,
       (
         match,
         lead: string,
@@ -690,13 +730,17 @@ export namespace SessionCompaction {
         offset: number,
         whole: string,
       ) => {
+        // altimate_change — capture and advance the ordinal before any early
+        // return so it always tracks this callback's position in `masked`'s
+        // match sequence, matching how rawCurlByOrdinal was built.
+        const currentOrdinal = ordinal++
         // Attached values are valid only for short `-u` (`-ualice:pass`).
         if (flag.toLowerCase() === "--user" && separator === undefined) return match
         const rawValue = (separatedValue ?? attachedValue ?? "").replace(/^["']|["']$/g, "")
-        // Windows invokes curl as `curl.exe`, and either platform may reach it
-        // through a path such as /usr/bin/curl or a Windows System32 path.
-        // Missing those spellings left the `-u` VALUE unredacted.
-        const curlContext = /(?:^|[\s/\\])curl(?:\.exe)?(?=\s|$)/i.test(shellSegmentBefore(whole, offset + lead.length))
+        const maskedCurlContext = isCurlContext(shellSegmentBefore(whole, offset + lead.length))
+        // altimate_change — OR in the raw-value signal (see block above).
+        const curlContext =
+          maskedCurlContext || (ordinalsAligned && (rawCurlByOrdinal[currentOrdinal] ?? false))
         // Outside a curl context a colon-shaped value is treated as
         // user:password. The ONE exemption is an explicitly recognized
         // all-numeric UID:GID pair (`docker run --user 1000:1000`), which is a

--- a/packages/opencode/test/session/compaction-ledger.test.ts
+++ b/packages/opencode/test/session/compaction-ledger.test.ts
@@ -439,6 +439,25 @@ describe("SessionCompaction.renderLedger", () => {
     expect(SessionCompaction.redactLedgerDetail("curlywurly -u alice script.py")).toBe("curlywurly -u alice script.py")
   })
 
+  test("does not leak credentials via a path-qualified curl and the space-separated -u idiom (regression, #1117)", () => {
+    // #1117 added a filesystem-path masking rule to Telemetry.maskString.
+    // redactLedgerDetail used to call maskString BEFORE its own curl-context
+    // lookback, so `/usr/bin/curl` collapsed to `<path>` first. The `curl`
+    // token was gone by the time the lookback ran: curlContext came back
+    // false, `-u alice hunter2` (space-separated, non-colon-shaped) isn't
+    // credentialShaped either, and the credential passed through untouched
+    // into ledger text that later gets persisted into a model prompt across
+    // compaction. This is the exact adversarial shape of that leak.
+    for (const command of [
+      "/usr/bin/curl -u alice hunter2 https://example.com",
+      "/usr/local/bin/curl.exe -u alice hunter2 https://example.com",
+    ]) {
+      const detail = SessionCompaction.redactLedgerDetail(command)
+      expect(detail).not.toContain("alice")
+      expect(detail).not.toContain("hunter2")
+    }
+  })
+
   test("keeps non-credential colon-shaped values outside a curl context", () => {
     // `1000:1000` has no alphabetic character before the colon, so it is a
     // UID:GID pair rather than user:password and must survive in the ledger.


### PR DESCRIPTION
### Issue for this PR

Closes #1245

### Type of change

- [x] Bug fix

### What does this PR do?

**Security-relevant / expedited — please review promptly.** `origin/main`'s `TypeScript` CI job has been red since ~2026-09-04 07:28Z, blocking all PRs. This fixes both the broken-main failure and a live credential-leak regression it's coupled to.

**Root cause:** #1117 (`14ba9bb9e7`) added a filesystem-path masking rule to `Telemetry.maskString` (`packages/opencode/src/altimate/telemetry/index.ts`). `SessionCompaction.redactLedgerDetail` (`packages/opencode/src/session/compaction.ts`) calls `Telemetry.maskString(value)` **before** running its own `-u`/`--user` curl-credential redaction. That ordering has two consequences:

1. **Over-masking (4 of the 5 failing tests):** every write path (2+ path segments) collapses to the literal `<path>`, so the session ledger — whose whole purpose is to tell the model which files it already wrote — can no longer report file paths at all.
2. **Credential leak (the 5th test, and the important one):** when curl is invoked path-qualified (`/usr/bin/curl -u alice password ...`), `maskString`'s path rule replaces the `curl`/`curl.exe` token with `<path>` **before** `redactLedgerDetail`'s curl-context lookback ever runs. With the `curl` token gone, the lookback can't find it, `curlContext` comes back false, and the space-separated (non-colon-shaped) `-u alice password` idiom isn't otherwise recognized as credential-shaped — so it passes through `redactLedgerDetail` completely unredacted. This ledger text is persisted into a later model prompt across compaction (see the comment at `compaction.ts:~657`): a real credential leaking across a session/provider boundary.

The leak is **main-only** — not present in v0.10.0 or any released version.

**Fix:**

1. `Telemetry.maskString` gains an opt-out for its path-masking pass: `maskString(value, opts?: { maskPaths?: boolean })`, default `maskPaths: true` — byte-for-byte unchanged for every existing caller. When `maskPaths: false`, only the #1117 path rule is skipped; every other mask (api keys, bearer tokens, emails, internal hosts, quote collapsing) still applies.
2. `redactLedgerDetail` now calls `maskString(value, { maskPaths: false })`. This restores write-path fidelity (fixes the 4 over-mask tests), and — because the `curl` token survives — the curl-context lookback works again, closing the leak (fixes the 5th test).
3. **Belt-and-suspenders:** `redactLedgerDetail`'s curl-context detection is also derived independently from the pre-mask raw value (correlated ordinally against the masked-string matches, with a safe fallback to the prior masked-only check if the two ever disagree). This makes curl detection structurally immune to any *future* masking rule that happens to eat the command-name token — it no longer depends solely on `maskPaths: false`.
4. No other `maskString` call site was touched — they all keep `maskPaths: true` (`mcp/index.ts`, `sql-execute.ts`, `tool.ts`, `prompt.ts`, `register.ts`, `dispatcher.ts`, `registry.ts`, `warehouse-add.ts`, `project-scan.ts`). #1117's telemetry path-masking protection is fully intact for its intended consumers — verified by `test/telemetry/mask-file-paths.test.ts` staying green.

Both `telemetry/index.ts` and `compaction.ts` are upstream-shared files; edits are wrapped in `altimate_change` markers. The marker guard (`bun run script/upstream/analyze.ts --markers --base origin/main --strict`) reports clean.

Related: this touches the same session-state-ledger security work referenced in `compaction.ts` (`redactLedgerDetail`'s existing credential-redaction suite).

### How did you verify your code works?

- `bun test packages/opencode/test/session/compaction-ledger.test.ts packages/opencode/test/session/compaction-ledger-history.test.ts` — 54 pass, 0 fail (was 5 failing on main).
- Added an explicit adversarial test reproducing the exact leak shape: `redactLedgerDetail("/usr/bin/curl -u alice hunter2 https://example.com")` and a `/usr/local/bin/curl.exe` variant, asserting the output contains neither `alice` nor `hunter2`. **Confirmed it fails against pre-fix code** via `git stash` on the two source files (leaving the new test in place) — reproduced the leak verbatim (`<path> -u alice hunter2 https://example.com/`) — then confirmed it passes after `git stash pop`.
- `bun test test/telemetry/mask-file-paths.test.ts test/altimate/telemetry-signals.test.ts test/mcp/mcp-bearer-auth.test.ts` — 211 pass, 0 fail (confirms #1117's default-`maskPaths` path masking is untouched for its other callers).
- Broader regression sweep: `bun test` across all `test/session/compaction-*.test.ts`, `observation-mask`, `task-pin`, `uncounted-tail` — 241 pass, 0 fail, 0 regressions.
- `bun run typecheck` — clean across all 15 workspace packages.
- `bun run script/upstream/analyze.ts --markers --base origin/main --strict` — clean.
- Pushed and confirmed the `TypeScript` CI job goes green on the pushed commit.

Not independently re-verified: the pre-existing flaky timeouts in `test/session/prompt.test.ts` (`loop calls LLM and returns assistant message`, `loop surfaces content-filter finishes as session errors`) — confirmed these fail identically against unmodified `origin/main` (network/mock-provider timeout issue, unrelated to this change) and are not part of this PR's scope.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

**This PR should NOT be merged by an automated agent — human review requested given the security sensitivity.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes credential redaction on compaction ledger text that is persisted into later model prompts; the fix is targeted but security-critical.
> 
> **Overview**
> Fixes a **credential leak** and **ledger over-masking** caused by running filesystem path masking on session-ledger text before compaction-specific redaction.
> 
> `Telemetry.maskString` now accepts optional `{ maskPaths?: boolean }` (default **true**), so only the #1117 path pass can be skipped; API keys, bearer tokens, emails, and other rules are unchanged for existing callers. **`redactLedgerDetail`** calls `maskString(value, { maskPaths: false })` so write paths stay visible in the state ledger and path-qualified commands like `/usr/bin/curl` are not collapsed to `<path>` before curl-context detection.
> 
> **Hardening:** `-u`/`--user` handling uses a shared `USER_FLAG_RE`, and curl context is inferred from both the masked string and the **raw** pre-mask value (ordinal-aligned), so a future mask rule that strips `curl` is less likely to reopen the leak.
> 
> Adds a regression test for path-qualified `curl` with space-separated `-u user password`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3463f0985af64e003a0aab18d5eb03ef961e26ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved protection for credentials included in path-qualified `curl` commands, including space-separated username and password formats.
  - Preserved command paths in session activity details while continuing to redact sensitive credentials and tokens.
  - Added safeguards to ensure credential redaction remains reliable across different command representations.

- **Tests**
  - Added regression coverage for credential leakage in path-qualified `curl` commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a credential leak and broken write-path reporting in the session ledger that #1117 introduced. `Telemetry.maskString`'s new path-masking pass collapsed `/usr/bin/curl` to `<path>` before `redactLedgerDetail`'s curl-context lookback ran, so path-qualified `curl -u user password` leaked unredacted into ledger text persisted across compaction; write paths also collapsed to `<path>`, breaking the ledger's file-reporting purpose. The leak is main-only, not in any release, and the change fixes the five tests that have been red on `origin/main`'s TypeScript CI since ~2026-09-04 07:28Z.

**Bug Fixes**
- `Telemetry.maskString` gains a `maskPaths` opt-out (default `true`, byte-for-byte unchanged for all existing callers); only the path pass is skipped, all other masks still apply.
- `redactLedgerDetail` now calls `maskString(value, { maskPaths: false })`, restoring write-path fidelity and the curl-context lookback.
- Curl-context detection is also derived from the raw pre-mask value (ordinally correlated with the masked matches), so a future mask rule that eats the command token can't reopen the leak.
- Adds regression tests for path-qualified `curl` and `curl.exe` with space-separated `-u user password`, confirmed failing against pre-fix code.

<sup>Written for commit 3463f0985af64e003a0aab18d5eb03ef961e26ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/1246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

