### PR TITLE
fix: Altimate Base 413 HTML body and missing header timeout

### DIFF
--- a/packages/opencode/src/altimate/free/client.ts
+++ b/packages/opencode/src/altimate/free/client.ts
@@ -536,27 +536,49 @@ export function describeRateLimit(
   return undefined
 }
 
-export function describeRequestTooLarge(body?: string): string | undefined {
+// altimate_change start — the generic (no byte-count) request-too-large message is shared by two
+// branches below: the parsed-JSON shape whose message didn't match the byte-count pattern, and
+// the unparseable/empty-body 413 fallback (nginx's raw HTML edge rejection).
+const REQUEST_TOO_LARGE_MESSAGE =
+  "This request is too large for Altimate Base. Start a new session, or switch to another model for this task."
+// altimate_change end
+
+export function describeRequestTooLarge(input: { status?: number; body?: string }): string | undefined {
+  const { status, body } = input
   type Inner = { code?: unknown; message?: unknown; provider_specific_fields?: { error?: Inner } }
   let parsed: { error?: Inner } | undefined
+  let validJson = true
   try {
     parsed = body ? JSON.parse(body) : undefined
   } catch {
-    return undefined
+    validJson = false
   }
-  const inner = parsed?.error?.provider_specific_fields?.error
-  if (parsed?.error?.code !== "request_too_large" && inner?.code !== "request_too_large") return undefined
-  const detail =
-    typeof parsed?.error?.message === "string"
-      ? parsed.error.message
-      : typeof inner?.message === "string"
-        ? inner.message
-        : ""
-  const sizes = detail.match(/Request is (\d+) bytes; the free tier limit is (\d+) bytes/)
-  const numbers = sizes
-    ? ` (${Math.round(Number(sizes[1]) / 1024)}KB against a ${Math.round(Number(sizes[2]) / 1024)}KB limit)`
-    : ""
-  return `This request is too large for Altimate Base${numbers}. Start a new session, or switch to another model for this task.`
+  if (validJson) {
+    const inner = parsed?.error?.provider_specific_fields?.error
+    const isRequestTooLarge = parsed?.error?.code === "request_too_large" || inner?.code === "request_too_large"
+    if (isRequestTooLarge) {
+      const detail =
+        typeof parsed?.error?.message === "string"
+          ? parsed.error.message
+          : typeof inner?.message === "string"
+            ? inner.message
+            : ""
+      const sizes = detail.match(/Request is (\d+) bytes; the free tier limit is (\d+) bytes/)
+      if (!sizes) return REQUEST_TOO_LARGE_MESSAGE
+      const numbers = ` (${Math.round(Number(sizes[1]) / 1024)}KB against a ${Math.round(Number(sizes[2]) / 1024)}KB limit)`
+      return `This request is too large for Altimate Base${numbers}. Start a new session, or switch to another model for this task.`
+    }
+    // Valid JSON but a shape unrelated to the free-tier byte cap (e.g. another provider's 413,
+    // or a different gateway error entirely) — never rewrite it, regardless of status.
+    if (body) return undefined
+  }
+  // altimate_change start — in production, an oversized request is rejected by nginx at the edge
+  // with a raw HTML error page, not LiteLLM's JSON `request_too_large` body. That body will never
+  // parse, so the friendly message must key off the actual HTTP status instead of a JSON shape
+  // that this failure mode can never produce.
+  if (status === 413) return REQUEST_TOO_LARGE_MESSAGE
+  // altimate_change end
+  return undefined
 }
 
 export * as FreeTier from "./client"

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -333,7 +333,10 @@ export namespace ProviderError {
     // The gateway's fixed request-byte cap is not a context overflow. Retrying compaction can
     // never help when system instructions and tool schemas alone exceed it.
     if (String(input.providerID) === FreeTier.PROVIDER_ID && input.error.statusCode === 413) {
-      const described = FreeTier.describeRequestTooLarge(input.error.responseBody)
+      const described = FreeTier.describeRequestTooLarge({
+        status: input.error.statusCode,
+        body: input.error.responseBody,
+      })
       if (described) {
         return {
           type: "api_error",

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -393,6 +393,9 @@ export namespace Provider {
           // authorizedFetch. Provider options are serialized by public provider APIs.
           apiKey: FreeTier.MANAGED_API_KEY_PLACEHOLDER,
           fetch: FreeTier.authorizedFetch,
+          // BUG FIX: without this, a hung gateway response never times out client-side, unlike
+          // the openai loader below which already sets this.
+          headerTimeout: OPENAI_HEADER_TIMEOUT_DEFAULT,
         },
       }
     },

--- a/packages/opencode/test/altimate/altimate-base-error-surfacing.test.ts
+++ b/packages/opencode/test/altimate/altimate-base-error-surfacing.test.ts
@@ -150,7 +150,7 @@ describe("malformed JSON response body during inference", () => {
     // The Altimate-Base-specific error mappers must also degrade gracefully on this same malformed
     // body — both already catch a `JSON.parse` failure and return `undefined` rather than crashing.
     expect(FreeTier.describeRateLimit({ body: raw })).toBeUndefined()
-    expect(FreeTier.describeRequestTooLarge(raw)).toBeUndefined()
+    expect(FreeTier.describeRequestTooLarge({ status: response.status, body: raw })).toBeUndefined()
   })
 })
 

--- a/packages/opencode/test/altimate/altimate-base-rate-limit-messages.test.ts
+++ b/packages/opencode/test/altimate/altimate-base-rate-limit-messages.test.ts
@@ -196,7 +196,7 @@ describe("describeRequestTooLarge — via the fake gateway (413 request_too_larg
     const response = await chat()
     expect(response.status).toBe(413)
 
-    const described = FreeTier.describeRequestTooLarge(await response.text())
+    const described = FreeTier.describeRequestTooLarge({ status: response.status, body: await response.text() })
     expect(described).toBe(
       "This request is too large for Altimate Base (175KB against a 125KB limit). Start a new session, or switch to another model for this task.",
     )
@@ -208,7 +208,7 @@ describe("describeRequestTooLarge — via the fake gateway (413 request_too_larg
     const response = await chat()
     expect(response.status).toBe(413)
 
-    const described = FreeTier.describeRequestTooLarge(await response.text())
+    const described = FreeTier.describeRequestTooLarge({ status: response.status, body: await response.text() })
     expect(described).toBe(
       "This request is too large for Altimate Base (977KB against a 488KB limit). Start a new session, or switch to another model for this task.",
     )
@@ -227,7 +227,7 @@ describe("describeRequestTooLarge — via the fake gateway (413 request_too_larg
     expect(body.error.provider_specific_fields.error.code).toBe("request_too_large")
 
     // 50000/1024 = 48.828125 -> round 49. 40000/1024 = 39.0625 -> round 39.
-    const described = FreeTier.describeRequestTooLarge(JSON.stringify(body))
+    const described = FreeTier.describeRequestTooLarge({ status: response.status, body: JSON.stringify(body) })
     expect(described).toBe(
       "This request is too large for Altimate Base (49KB against a 39KB limit). Start a new session, or switch to another model for this task.",
     )
@@ -236,19 +236,20 @@ describe("describeRequestTooLarge — via the fake gateway (413 request_too_larg
 
 describe("describeRequestTooLarge — pure-function edge cases FakeGateway's ChatMode cannot express", () => {
   test("absent body returns undefined", () => {
-    expect(FreeTier.describeRequestTooLarge(undefined)).toBeUndefined()
+    expect(FreeTier.describeRequestTooLarge({})).toBeUndefined()
   })
 
-  test("unparseable JSON body returns undefined", () => {
-    expect(FreeTier.describeRequestTooLarge("{not json")).toBeUndefined()
+  test("unparseable JSON body returns undefined when the status isn't 413", () => {
+    expect(FreeTier.describeRequestTooLarge({ body: "{not json" })).toBeUndefined()
   })
 
   test("a 413 without the request_too_large code (an unrelated provider 413) returns undefined", () => {
     // Falls through to error.ts's generic context_overflow handling instead of the
     // Altimate-Base-specific rewrite — request_too_large and context overflow are distinct
-    // gateway error codes.
+    // gateway error codes. Valid, parseable JSON with a different shape must never be rewritten,
+    // even though the status is 413 — that's what separates this from the HTML-body fallback below.
     const body = JSON.stringify({ error: { code: "some_other_413", message: "payload too large" } })
-    expect(FreeTier.describeRequestTooLarge(body)).toBeUndefined()
+    expect(FreeTier.describeRequestTooLarge({ status: 413, body })).toBeUndefined()
   })
 
   test("the outer error.code (not the nested provider_specific_fields shape) also matches", () => {
@@ -256,7 +257,7 @@ describe("describeRequestTooLarge — pure-function edge cases FakeGateway's Cha
       error: { code: "request_too_large", message: "Request is 300000 bytes; the free tier limit is 100000 bytes." },
     })
     // 300000/1024 = 292.96875 -> round 293. 100000/1024 = 97.65625 -> round 98.
-    expect(FreeTier.describeRequestTooLarge(body)).toBe(
+    expect(FreeTier.describeRequestTooLarge({ status: 413, body })).toBe(
       "This request is too large for Altimate Base (293KB against a 98KB limit). Start a new session, or switch to another model for this task.",
     )
   })
@@ -265,14 +266,14 @@ describe("describeRequestTooLarge — pure-function edge cases FakeGateway's Cha
     const body = JSON.stringify({
       error: { code: "request_too_large", message: "Payload rejected: too large for this tier." },
     })
-    expect(FreeTier.describeRequestTooLarge(body)).toBe(
+    expect(FreeTier.describeRequestTooLarge({ status: 413, body })).toBe(
       "This request is too large for Altimate Base. Start a new session, or switch to another model for this task.",
     )
   })
 
   test("request_too_large with no message at all on either the outer or inner error omits the KB parenthetical", () => {
     const body = JSON.stringify({ error: { code: "request_too_large" } })
-    expect(FreeTier.describeRequestTooLarge(body)).toBe(
+    expect(FreeTier.describeRequestTooLarge({ status: 413, body })).toBe(
       "This request is too large for Altimate Base. Start a new session, or switch to another model for this task.",
     )
   })
@@ -292,8 +293,44 @@ describe("describeRequestTooLarge — pure-function edge cases FakeGateway's Cha
       },
     })
     // 250000/1024 = 244.140625 -> round 244. 128000/1024 = 125 exactly.
-    expect(FreeTier.describeRequestTooLarge(body)).toBe(
+    expect(FreeTier.describeRequestTooLarge({ status: 413, body })).toBe(
       "This request is too large for Altimate Base (244KB against a 125KB limit). Start a new session, or switch to another model for this task.",
     )
+  })
+})
+
+// BUG FIX: in production, nginx rejects oversized requests at the edge with a raw HTML error
+// page — not LiteLLM's JSON `request_too_large` shape. The unparseable/empty body previously fell
+// through to `undefined` (a generic fallback), even though the status line already says 413.
+describe("describeRequestTooLarge — 413 with a body that never parses (nginx edge rejection)", () => {
+  test("a 413 with a raw HTML body returns the friendly fallback message, not undefined", () => {
+    const html =
+      "<html>\n<head><title>413 Request Entity Too Large</title></head>\n<body>\n<center>413 Request Entity Too Large</center>\n<hr><center>nginx</center>\n</body>\n</html>"
+    expect(FreeTier.describeRequestTooLarge({ status: 413, body: html })).toBe(
+      "This request is too large for Altimate Base. Start a new session, or switch to another model for this task.",
+    )
+  })
+
+  test("a 413 with an empty body returns the same friendly fallback message", () => {
+    expect(FreeTier.describeRequestTooLarge({ status: 413, body: "" })).toBe(
+      "This request is too large for Altimate Base. Start a new session, or switch to another model for this task.",
+    )
+    expect(FreeTier.describeRequestTooLarge({ status: 413 })).toBe(
+      "This request is too large for Altimate Base. Start a new session, or switch to another model for this task.",
+    )
+  })
+
+  test("a 413 with the known JSON shape still returns the specific byte-count message, not the generic fallback", () => {
+    const body = JSON.stringify({
+      error: { code: "request_too_large", message: "Request is 179608 bytes; the free tier limit is 128000 bytes." },
+    })
+    expect(FreeTier.describeRequestTooLarge({ status: 413, body })).toBe(
+      "This request is too large for Altimate Base (175KB against a 125KB limit). Start a new session, or switch to another model for this task.",
+    )
+  })
+
+  test("an HTML body on a non-413 status still returns undefined (status is what gates the fallback)", () => {
+    const html = "<html><body>502 Bad Gateway</body></html>"
+    expect(FreeTier.describeRequestTooLarge({ status: 502, body: html })).toBeUndefined()
   })
 })

--- a/packages/opencode/test/provider/error.test.ts
+++ b/packages/opencode/test/provider/error.test.ts
@@ -466,4 +466,24 @@ describe("ProviderError.parseAPICallError: Altimate Base isolation", () => {
     })
     expect(result.type).toBe("context_overflow")
   })
+
+  // altimate_change start — BUG FIX: production rejects oversized requests with nginx's raw HTML
+  // edge page, not LiteLLM's JSON body. That body never parses, so this must still resolve to the
+  // friendly Altimate Base message instead of falling through to the generic context_overflow path.
+  test("a 413 with an unparseable HTML body (nginx edge rejection) still gets the friendly Altimate Base message", () => {
+    const htmlBody =
+      "<html>\n<head><title>413 Request Entity Too Large</title></head>\n<body>\n<center>413 Request Entity Too Large</center>\n<hr><center>nginx</center>\n</body>\n</html>"
+    const result = ProviderError.parseAPICallError({
+      providerID: "altimate-free" as any,
+      error: makeAPICallError({ message: "Payload Too Large", statusCode: 413, responseBody: htmlBody }),
+    })
+    expect(result.type).toBe("api_error")
+    if (result.type === "api_error") {
+      expect(result.message).toBe(
+        "This request is too large for Altimate Base. Start a new session, or switch to another model for this task.",
+      )
+      expect(result.isRetryable).toBe(false)
+    }
+  })
+  // altimate_change end
 })

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -80,6 +80,9 @@ test("Altimate Base is pinned to the hosted model contract without affecting oth
         expect(base.env).toEqual([])
         expect(base.options.baseURL).toBe(`${ALTIMATE_BASE_GATEWAY_URL}/v1`)
         expect(base.options.apiKey).toBe(FreeTier.MANAGED_API_KEY_PLACEHOLDER)
+        // BUG FIX: without a client-side header timeout, a hung gateway response never resolves
+        // or rejects — the CLI just hangs. This mirrors the openai loader's default.
+        expect(base.options.headerTimeout).toBe(10_000)
         expect(JSON.stringify(base)).not.toContain("sk-altimate-base")
 
         const model = base.models[FreeTier.MODEL_ID]


### PR DESCRIPTION
### Issue for this PR

Closes #1255

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes two client-side Altimate Base bugs found by live-prod E2E of the `v0.11.0-beta.2` release.

**Bug 1 — 413 oversize error showed a generic message instead of the friendly one.**

`FreeTier.describeRequestTooLarge` in `packages/opencode/src/altimate/free/client.ts` did `JSON.parse(body)` in a try/catch that returned `undefined` on a parse failure. In production, oversized requests are rejected by the gateway's edge proxy with a raw **HTML** error page (not a JSON body), so the parse always throws for that case, the function always returned `undefined`, and the user saw a generic fallback error instead of the friendly "your request is too large — start a new session or shorten it" message.

Fix: `describeRequestTooLarge` now takes `{ status, body }` instead of a bare body string. Its logic is now:
- If the body parses as JSON and matches the known `request_too_large` shape, keep the existing specific message (with the KB byte-count detail when present).
- If the body parses as JSON but is a *different* shape (e.g. another provider's 413, or an unrelated gateway error), still return `undefined` — unchanged behavior, no false positives even though the status is 413.
- If the body does **not** parse as JSON (or is empty) **and** the status is `413`, return the same friendly fallback message the JSON path produces.
- Any non-413 status still returns `undefined` for an unparseable body — unchanged.

The sole caller in `packages/opencode/src/provider/error.ts` already knew the status was 413 before calling (it gates on `input.error.statusCode === 413`); it now threads `input.error.statusCode` through explicitly so the function itself can make the same decision without relying on caller-side control flow alone. All existing test call sites were updated to the new object signature.

**Bug 2 — Altimate Base provider had no client-side header timeout.**

The `"altimate-free"` loader in `packages/opencode/src/provider/provider.ts` returned `options: { baseURL, apiKey, fetch }` with no `headerTimeout`, unlike the `openai` loader in the same file, which sets `headerTimeout: OPENAI_HEADER_TIMEOUT_DEFAULT`. If the gateway hung before sending response headers, a request through Altimate Base had no client-side timeout and could hang the CLI indefinitely.

Fix: added `headerTimeout: OPENAI_HEADER_TIMEOUT_DEFAULT` to the `altimate-free` loader's options, matching the `openai` loader's existing default.

### How did you verify your code works?

- `bun run typecheck` (root, via turbo) — passes across all 15 packages.
- Added/extended unit tests:
  - New cases in `test/altimate/altimate-base-rate-limit-messages.test.ts`: a raw-HTML 413 body returns the friendly fallback; an empty/absent-body 413 returns the same fallback; a 413 with the known JSON shape still returns the specific byte-count message (not the fallback); a non-413 status with an HTML body still returns `undefined`; a 413 with valid-but-unrelated JSON still returns `undefined`.
  - New integration test in `test/provider/error.test.ts` exercising the full `ProviderError.parseAPICallError` path with a 413 + raw HTML body, asserting the friendly message comes out end-to-end.
  - Extended the existing Altimate Base provider-shape test in `test/provider/provider.test.ts` to assert `options.headerTimeout` is set to the same default the `openai` loader uses.
  - Updated every existing `describeRequestTooLarge` call site (production and test) to the new `{ status, body }` signature.
- Ran the full affected suites locally: `test/altimate/altimate-base-rate-limit-messages.test.ts`, `test/altimate/altimate-base-error-surfacing.test.ts`, `test/provider/error.test.ts`, `test/provider/provider.test.ts`, `test/provider/header-timeout.test.ts`, and the full `test/altimate/` directory — all green (5104 pass / 0 fail across the altimate suite; 150 pass / 0 fail for the four directly-targeted files).
- Ran `bun run script/upstream/analyze.ts --markers --base origin/main --strict` — reports no upstream-shared files were touched (`client.ts` and `provider.ts` are altimate-owned, not upstream-shared), so no marker violations; new hunks are still wrapped in `altimate_change` comments for consistency with the surrounding code.

**Not verified:** the 413 fix is verified by unit test (a synthetic raw-HTML body) and by the `parseAPICallError` integration test, but has **not** been re-run against a live oversized request through the real production nginx edge — that would require reproducing a >1MiB request against the live gateway, which wasn't done as part of this fix.

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Altimate Base error mapping and provider timeout defaults; behavior is well covered by unit/integration tests with no auth or data-model changes.
> 
> **Overview**
> Fixes two Altimate Base client bugs: oversized-request errors and hung gateway calls.
> 
> **413 / request too large:** `describeRequestTooLarge` now takes `{ status, body }` instead of a raw body string. When the response is **413** with HTML or empty/unparseable bodies (production nginx edge rejection), it returns the same friendly Altimate Base message instead of `undefined`, so `parseAPICallError` no longer falls through to generic `context_overflow`. JSON `request_too_large` responses still get byte-count detail when available; unrelated 413 JSON shapes are left unchanged.
> 
> **Header timeout:** The `altimate-free` provider loader sets `headerTimeout: OPENAI_HEADER_TIMEOUT_DEFAULT` (10s), matching OpenAI so a stalled gateway cannot hang the CLI indefinitely.
> 
> Tests cover nginx HTML 413 end-to-end, edge cases for the new signature, and provider `headerTimeout` assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeccaa98269bd9c959fd060cf97d55ba60d08bc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two Altimate Base client-side bugs found in live-prod E2E: oversized requests now show the friendly "request too large" message even when the gateway rejects with raw HTML, and a hung gateway response no longer hangs the CLI. Closes #1255.

**Bug Fixes**
- `describeRequestTooLarge` now takes `{ status, body }` and returns the friendly message on any 413, even when the body doesn't parse as JSON.
- A 413 with valid JSON that isn't the known `request_too_large` shape still returns `undefined`, as does any non-413 status.
- The `altimate-free` provider loader now sets `headerTimeout`, matching the `openai` loader's default.

<sup>Written for commit eeccaa98269bd9c959fd060cf97d55ba60d08bc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/1256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of oversized request errors, including gateway responses with empty or unparseable bodies.
  * Displays a friendly “request too large” message for HTTP 413 responses instead of a generic error.
  * Prevents stalled gateway responses by applying a 10-second response-header timeout.

* **Tests**
  * Added coverage for malformed, empty, and oversized response scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->