### PR TITLE
fix(ci): validate cached dbt e2e environments; pin the uv venv to the system Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,14 +559,21 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.dbt-tools == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Runs pull-request code (setup scripts, tests), so it gets the same
+    # read-only token scope and no persisted credentials as tracker-leaks.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2
         with:
           bun-version: "1.3.14"
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        id: python
         with:
           python-version: "3.11"
 
@@ -598,6 +605,10 @@ jobs:
       - name: Set up Python env scenarios
         run: ./test/e2e/setup-resolve.sh venv uv system
         working-directory: packages/dbt-tools
+        env:
+          # Build the scenario venvs on the interpreter setup-python installed,
+          # not the image's /usr/bin/python3; setup-resolve.sh honours this.
+          DBT_E2E_PYTHON: ${{ steps.python.outputs.python-path }}
 
       - name: Run dbt-tools E2E tests
         run: bun run test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,14 +546,17 @@ jobs:
   # altimate_change end
 
   # ---------------------------------------------------------------------------
-  # dbt-tools E2E — slow (~3 min), only on push to main.
+  # dbt-tools E2E — slow (~3 min): on push to main, and on pull requests that
+  # touch packages/dbt-tools (the `dbt-tools` change filter above). Without the
+  # PR path a fix to this job's own environment setup could only be proven
+  # after merging.
   # Tests dbt CLI fallbacks against real dbt versions (1.8, 1.10, 1.11) and
   # real Python environments (venv, uv, system).
   # ---------------------------------------------------------------------------
   dbt-tools-e2e:
     name: "dbt-tools E2E"
     needs: changes
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || needs.changes.outputs.dbt-tools == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -583,7 +583,10 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: packages/dbt-tools/test/.dbt-resolve-envs
-          key: dbt-resolve-envs-${{ runner.os }}-v1
+          # v2: the v1 cache held a uv venv linked to a uv-managed Python that
+          # fresh runners lack (bin/dbt present, exec ENOENT). setup-resolve.sh
+          # now validates cached envs and pins uv to the system interpreter.
+          key: dbt-resolve-envs-${{ runner.os }}-v2
 
       - name: Set up dbt versions
         run: ./test/e2e/setup-versions.sh 1.8 1.10 1.11

--- a/packages/dbt-tools/test/e2e/setup-resolve.sh
+++ b/packages/dbt-tools/test/e2e/setup-resolve.sh
@@ -33,6 +33,29 @@ ok() { echo "  ✓ $1"; }
 skip() { echo "  ⊘ $1 — skipped ($2)"; }
 fail() { echo "  ✗ $1 — $2"; }
 
+# A restored cache can hold an environment whose interpreter no longer exists:
+# CI caches only this directory, and a venv's `bin/python` is a symlink (or a
+# launcher shebang) into an interpreter outside it. uv in particular links to
+# its own managed Python under ~/.local/share/uv, which a fresh runner lacks,
+# so `bin/dbt` is present on disk yet fails with ENOENT when executed. The
+# `.done` marker alone therefore proves nothing; a cached environment counts
+# only if its dbt actually runs.
+with_timeout() {
+  if has timeout; then timeout "$TIMEOUT" "$@"; else "$@"; fi
+}
+env_ok() {
+  [ -x "$1" ] && with_timeout "$1" --version >/dev/null 2>&1
+}
+# Usage: cached_or_rebuild <scenario> <dbt binary>; returns 0 when the cached
+# environment is usable (caller returns), 1 when it must be rebuilt.
+cached_or_rebuild() {
+  local dir="$ENVS_DIR/$1"
+  [ -f "$dir/.done" ] || return 1
+  if env_ok "$2"; then ok "$1 (cached)"; return 0; fi
+  echo "  ↻ $1 cache is stale (dbt does not run) — rebuilding..."
+  return 1
+}
+
 # Find a real (non-shim) python3 for venv creation
 find_real_python() {
   # Try pyenv's actual python first
@@ -55,7 +78,7 @@ echo "Using Python: $REAL_PYTHON ($($REAL_PYTHON --version 2>&1))"
 
 setup_venv() {
   local dir="$ENVS_DIR/venv"
-  if [ -f "$dir/.done" ]; then ok "venv (cached)"; return; fi
+  cached_or_rebuild venv "$dir/bin/dbt" && return
   rm -rf "$dir"
   echo "  → Setting up venv..."
   "$REAL_PYTHON" -m venv "$dir"
@@ -68,12 +91,14 @@ setup_venv() {
 setup_uv() {
   local dir="$ENVS_DIR/uv"
   if ! has uv; then skip "uv" "uv not installed"; return; fi
-  if [ -f "$dir/.done" ]; then ok "uv (cached)"; return; fi
+  cached_or_rebuild uv "$dir/.venv/bin/dbt" && return
   rm -rf "$dir"
   echo "  → Setting up uv..."
   mkdir -p "$dir"
-  # uv project mode: create .venv in dir
-  uv venv "$dir/.venv" --quiet
+  # uv project mode: create .venv in dir. Pin the interpreter to the system
+  # Python so the venv survives a cache restore on a fresh runner; left to
+  # itself uv links a managed Python that lives outside the cached directory.
+  uv venv "$dir/.venv" --python "$REAL_PYTHON" --quiet
   uv pip install --quiet --python "$dir/.venv/bin/python" "$DBT_SPEC"
   touch "$dir/.done"
   ok "uv ($("$dir/.venv/bin/dbt" --version 2>&1 | grep -oE 'installed:\s+\S+' | head -1))"
@@ -82,7 +107,7 @@ setup_uv() {
 setup_pipx() {
   local dir="$ENVS_DIR/pipx"
   if ! has pipx; then skip "pipx" "pipx not installed"; return; fi
-  if [ -f "$dir/.done" ]; then ok "pipx (cached)"; return; fi
+  cached_or_rebuild pipx "$dir/bin/dbt" && return
   rm -rf "$dir"
   echo "  → Setting up pipx..."
   mkdir -p "$dir/bin" "$dir/venvs"
@@ -100,7 +125,7 @@ setup_pipx() {
 setup_conda() {
   local dir="$ENVS_DIR/conda"
   if ! has conda; then skip "conda" "conda not installed"; return; fi
-  if [ -f "$dir/.done" ]; then ok "conda (cached)"; return; fi
+  cached_or_rebuild conda "$dir/bin/dbt" && return
   rm -rf "$dir"
   echo "  → Setting up conda..."
   conda create -y -p "$dir" python=3.11 --quiet 2>/dev/null
@@ -117,7 +142,7 @@ setup_conda() {
 setup_poetry() {
   local dir="$ENVS_DIR/poetry"
   if ! has poetry; then skip "poetry" "poetry not installed"; return; fi
-  if [ -f "$dir/.done" ]; then ok "poetry (cached)"; return; fi
+  cached_or_rebuild poetry "$dir/.venv/bin/dbt" && return
   rm -rf "$dir"
   echo "  → Setting up poetry (in-project venv)..."
   mkdir -p "$dir"
@@ -153,7 +178,7 @@ setup_pyenv_venv() {
   # Simulates a pyenv user who creates a venv with their pyenv-managed python
   local dir="$ENVS_DIR/pyenv-venv"
   if ! has pyenv; then skip "pyenv-venv" "pyenv not installed"; return; fi
-  if [ -f "$dir/.done" ]; then ok "pyenv-venv (cached)"; return; fi
+  cached_or_rebuild pyenv-venv "$dir/bin/dbt" && return
   rm -rf "$dir"
   echo "  → Setting up pyenv + venv..."
   local pyenv_python

--- a/packages/dbt-tools/test/e2e/setup-resolve.sh
+++ b/packages/dbt-tools/test/e2e/setup-resolve.sh
@@ -41,7 +41,11 @@ fail() { echo "  ✗ $1 — $2"; }
 # `.done` marker alone therefore proves nothing; a cached environment counts
 # only if its dbt actually runs.
 with_timeout() {
-  if has timeout; then timeout "$TIMEOUT" "$@"; else "$@"; fi
+  # GNU timeout on Linux; Homebrew coreutils installs it as gtimeout on macOS.
+  # Without either, the check still runs, just unbounded.
+  if has timeout; then timeout "$TIMEOUT" "$@"
+  elif has gtimeout; then gtimeout "$TIMEOUT" "$@"
+  else "$@"; fi
 }
 env_ok() {
   [ -x "$1" ] && with_timeout "$1" --version >/dev/null 2>&1
@@ -58,6 +62,10 @@ cached_or_rebuild() {
 
 # Find a real (non-shim) python3 for venv creation
 find_real_python() {
+  # An explicit interpreter wins. CI sets DBT_E2E_PYTHON to the interpreter
+  # actions/setup-python installed, so the venvs build on the Python the
+  # workflow chose rather than whatever the runner image happens to ship.
+  if [ -n "${DBT_E2E_PYTHON:-}" ] && [ -x "$DBT_E2E_PYTHON" ]; then echo "$DBT_E2E_PYTHON"; return; fi
   # Try pyenv's actual python first
   if has pyenv; then
     local p


### PR DESCRIPTION
### Issue for this PR

Closes #1257

### Type of change

- [x] Bug fix (CI)

### What does this PR do?

Main's `dbt-tools E2E` job has been red since 2026-09-07: three `dbt resolver e2e > uv` tests fail with `ENOENT ... uv/.venv/bin/dbt` even though the resolver finds the file. The restored `dbt-resolve-envs-Linux-v1` cache holds a uv venv whose `bin/python` links to a uv-managed interpreter under `~/.local/share/uv`, outside the cached directory and absent on a fresh runner; `bin/dbt` exists but its interpreter does not. `setup-resolve.sh` trusted the `.done` marker and skipped setup, and `actions/cache` only saves on a miss, so the broken environment was restored on every run.

- `packages/dbt-tools/test/e2e/setup-resolve.sh`: a cached environment now counts only if `<env>/bin/dbt --version` runs (under `timeout` where available); otherwise it prints `↻ <scenario> cache is stale (dbt does not run) — rebuilding...` and rebuilds. Applied to every scenario via one `cached_or_rebuild` helper. The uv venv is created with `--python "$REAL_PYTHON"` so it links to the system interpreter.
- `.github/workflows/ci.yml`: cache key `dbt-resolve-envs-<os>-v1` → `-v2` with a comment explaining why, so the broken cache is not restored while the validation guards against the next occurrence.
- `.github/workflows/ci.yml` (second commit): the `dbt-tools E2E` job now also runs on pull requests that touch `packages/dbt-tools/**`, using the `dbt-tools` change filter that already existed but was unused by this job. Previously it ran only on push to `main`, so a fix to its own setup could not be proven before merging. Cost: about 3 minutes, only on PRs that change dbt-tools.

### How did you verify your code works?

Locally on macOS (uv, pyenv Python 3.9) from `packages/dbt-tools`:

1. Fresh run of `./test/e2e/setup-resolve.sh venv uv`: both environments built (dbt-duckdb 1.10.23).
2. Second run: both reported `(cached)` after the validation ran.
3. Reproduced the CI shape: replaced `uv/.venv/bin/python` with a dangling symlink; `bin/dbt --version` then fails exactly like CI. The next setup run printed `↻ uv cache is stale (dbt does not run) — rebuilding...`, rebuilt, and `dbt --version` worked again.
4. `bun test test/e2e/resolve.test.ts`: 23 pass, 0 fail.
5. Workflow YAML parses; the E2E job condition reads `github.event_name == 'push' || needs.changes.outputs.dbt-tools == 'true'`.

On CI: with the second commit this PR's own `dbt-tools E2E` job runs. It misses the v2 cache, builds fresh with the pinned interpreter, and saves; the first push to `main` afterwards exercises the restore path. Check that job on this PR before merging.

Committed through the GitHub API from the session's worktree (the branch there is PR #1241's, so the files were uploaded rather than pushed from a checkout).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - End-to-end checks now run for relevant changes in both pull requests and pushes.
  - Cached Python environments are validated before use and automatically rebuilt when cached tools are unusable.
  - Environment setup is more reliable after cache restoration by consistently using the detected system Python.
  - CI checkout access is restricted to read-only permissions for improved security.

- **Chores**
  - Updated environment cache versioning to ensure refreshed scenarios use the latest validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflow and E2E setup scripts; they do not alter shipped application or resolver runtime behavior in production.
> 
> **Overview**
> Fixes **dbt-tools E2E** failures where a restored GitHub Actions cache looked healthy (`.done` present, `bin/dbt` on disk) but **`dbt` exited with ENOENT** because the uv venv pointed at a uv-managed Python outside the cached tree.
> 
> **`setup-resolve.sh`** now treats a cache hit as valid only after **`dbt --version` succeeds** (with optional `timeout`); stale caches are rebuilt with a clear message. **uv** venvs are created with **`--python "$REAL_PYTHON"`**, and **`DBT_E2E_PYTHON`** lets CI prefer **`setup-python`**’s interpreter over the image default. All scenarios share a **`cached_or_rebuild`** helper instead of trusting `.done` alone.
> 
> **`.github/workflows/ci.yml`** bumps the resolve-env cache key **v1 → v2**, passes **`DBT_E2E_PYTHON`** into setup, and runs **dbt-tools E2E on PRs** that touch **`packages/dbt-tools`** (not only on push to main). The job uses **read-only `contents`** and **`persist-credentials: false`** on checkout, matching other PR-scoped jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b443456e768c7e1a25b686e49cad59e988a02117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->