### PR TITLE
fix: Altimate Base header timeout too short (10s) for reasoning backend

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -83,6 +83,24 @@ const DEFAULT_CHUNK_TIMEOUT = 300_000
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 10_000
 const HEADER_TIMEOUT = Symbol.for("opencode.provider.header-timeout")
 // altimate_change end
+// altimate_change start — Altimate Base needs a far more generous header timeout than OpenAI.
+// Its gateway can queue for a capacity slot, cold-start the backend, or reason before flushing
+// response headers — any of which exceeds OpenAI's near-instant reply. OpenAI's 10s default
+// therefore false-positives on healthy Altimate Base requests ("Provider response headers timed
+// out after 10000ms"). Default to the same 5min the SSE chunk watchdog uses, and expose an env
+// override so it is tunable in the field without a release: a positive number of milliseconds,
+// or 0/off/false/none to disable the header timeout entirely.
+const FREE_TIER_HEADER_TIMEOUT_DEFAULT = 300_000
+function freeTierHeaderTimeout(): number | false {
+  const raw = Env.get("ALTIMATE_BASE_HEADER_TIMEOUT_MS")?.trim()
+  if (raw) {
+    if (["0", "off", "false", "none"].includes(raw.toLowerCase())) return false
+    const parsed = Number(raw)
+    if (Number.isFinite(parsed) && parsed > 0) return parsed
+  }
+  return FREE_TIER_HEADER_TIMEOUT_DEFAULT
+}
+// altimate_change end
 
 export namespace Provider {
   const log = Log.create({ service: "provider" })
@@ -393,9 +411,11 @@ export namespace Provider {
           // authorizedFetch. Provider options are serialized by public provider APIs.
           apiKey: FreeTier.MANAGED_API_KEY_PLACEHOLDER,
           fetch: FreeTier.authorizedFetch,
-          // BUG FIX: without this, a hung gateway response never times out client-side, unlike
-          // the openai loader below which already sets this.
-          headerTimeout: OPENAI_HEADER_TIMEOUT_DEFAULT,
+          // Without a header timeout a hung gateway (connected, never replies) never aborts
+          // client-side — the SSE chunk watchdog only starts once headers arrive. OpenAI's 10s
+          // is far too tight for Altimate Base's queue/cold-start/reasoning latency to first
+          // byte, so use the free tier's generous, env-tunable value instead.
+          headerTimeout: freeTierHeaderTimeout(),
         },
       }
     },


### PR DESCRIPTION
### Issue for this PR

Closes #1259

### Type of change

- [x] Bug fix

### What does this PR do?

Beta.3 users on Altimate Base hit `Provider response headers timed out after 10000ms`.

The `altimate-free` loader borrowed the `openai` loader's 10s header timeout (`OPENAI_HEADER_TIMEOUT_DEFAULT`, added in #1256 to catch a hung gateway). That value is correct for OpenAI (near-instant headers) but wrong for Altimate Base: its gateway holds the HTTP 200 until the backend's first token, and queue wait / cold start / reasoning latency routinely exceeds 10s — so healthy requests abort client-side.

Changes:
- Add `FREE_TIER_HEADER_TIMEOUT_DEFAULT` = `300_000`ms (matching `DEFAULT_CHUNK_TIMEOUT`, the SSE chunk watchdog) and use it in the free-tier loader instead of the 10s OpenAI default.
- Add an `ALTIMATE_BASE_HEADER_TIMEOUT_MS` env override (positive ms, or `0`/`off`/`false`/`none` to disable). The free-tier provider is deliberately excluded from `opencode.json` config merging (`provider.ts` filters `PROVIDER_ID`), so this env var is the only field-tunable override for affected users.

Why it works: the 5-min `chunkTimeout` still guards mid-stream hangs, so the header phase only needs to tolerate the backend's real time-to-first-byte. nginx already streams the completions path (`proxy_buffering off`, `proxy_read_timeout 900s`), confirming the delay is litellm holding headers until the first upstream token — so the client timeout is the correct fix.

### How did you verify your code works?

- `tsc --noEmit` on `packages/opencode` — `provider.ts` compiles clean (remaining errors are pre-existing fresh-worktree module-resolution noise, unrelated).
- Upstream marker guard clean (`analyze.ts --markers --base origin/main --strict`).
- Static gateway audit: nginx completions path is unbuffered with a 900s read timeout, so the header delay is not a proxy-buffering issue — the client-side timeout value is the correct remedy.
- Not verified: a live reproduction against prod (needs a managed credential); the value is chosen to comfortably exceed the backend's worst-case reasoning latency.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Altimate Base provider options; behavior is more permissive by default with an env override, and does not alter auth or other providers.
> 
> **Overview**
> Fixes false **Provider response headers timed out after 10000ms** errors on **Altimate Base** (`altimate-free`) when the gateway is slow to return the first byte (queue, cold start, or reasoning before headers).
> 
> The free-tier loader no longer reuses OpenAI’s **10s** `headerTimeout`. It now defaults to **300_000ms** (aligned with the SSE chunk watchdog) via `freeTierHeaderTimeout()`, and operators can tune or disable it with **`ALTIMATE_BASE_HEADER_TIMEOUT_MS`** (positive milliseconds, or `0`/`off`/`false`/`none` to turn the header timeout off). OpenAI’s loader is unchanged at 10s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39a7beb28b7d18fbb8962651817a6741e9ee3794. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Altimate Base requests aborting on healthy requests with `Provider response headers timed out after 10000ms`. The free-tier loader now uses a 300s header timeout instead of OpenAI's 10s default, since Altimate's gateway holds response headers until the first token (queue wait, cold start, or reasoning).

- Adds an `ALTIMATE_BASE_HEADER_TIMEOUT_MS` env override (positive ms, or `0`/`off`/`false`/`none` to disable).
- The 5-minute chunk timeout still guards mid-stream hangs.

<sup>Written for commit 39a7beb28b7d18fbb8962651817a6741e9ee3794. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/1260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connection reliability for the Altimate Base free tier by allowing more time for initial response headers.
  - The default header timeout is now five minutes, reducing premature timeouts during slower responses.

- **Configuration**
  - Administrators can customize the header timeout in milliseconds using `ALTIMATE_BASE_HEADER_TIMEOUT_MS`.
  - Set the value to `0`, `off`, `false`, or `none` to disable the header timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->