### PR TITLE
fix: trim per-install-id line from Altimate Base consent gate; soften rate-limit wording

### DIFF
--- a/packages/tui/src/component/altimate-onboarding.tsx
+++ b/packages/tui/src/component/altimate-onboarding.tsx
@@ -347,11 +347,12 @@ export function DialogModelWelcome(props: {
 
 // altimate_change start — surfaced in the DialogAltimateBaseConfirm consent gate before any Base
 // credential is minted. This is the text a user actually consents against before any registration
-// request, so it must disclose that requests are linkable across launches — not defer that to
-// docs/docs/configure/providers.md, which a user never sees before accepting. Keep this in sync
-// with that fuller "Data handling" note.
+// request, so it states the core data terms up front: requests/responses may be logged and used to
+// improve Altimate's products (including the model), so users should not send secrets. The
+// persistent per-install-id linkage detail is disclosed in docs/docs/configure/providers.md
+// ("Data handling"), not repeated in this gate; keep the core terms in sync with that note.
 export const ALTIMATE_BASE_DISCLOSURE =
-  "Altimate Base is free and requires no signup. Requests and responses may be logged and used to improve Altimate's products, including the model. Secrets are automatically masked before storage, but don't rely on it — avoid sending secrets or confidential code. Logs are linked to a persistent per-installation identifier. Usage is rate limited."
+  "Altimate Base is free and requires no signup. Requests and responses may be logged and used to improve Altimate's products, including the model. Secrets are automatically masked before storage, but don't rely on it — avoid sending secrets or confidential code. Usage can be rate limited."
 // altimate_change end
 
 type RegisterOutcome =

--- a/packages/tui/test/cli/tui/dialog-altimate-base.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-altimate-base.test.tsx
@@ -205,7 +205,9 @@ test.serial("Altimate Base shows the privacy disclosure before registration and 
   const confirm = await mountConfirm()
   try {
     const frame = confirm.app.captureCharFrame()
-    expect(confirm.disclosure).toContain("Requests and responses may be logged")
+    expect(confirm.disclosure).toContain("Requests and responses may be logged and used")
+    // The persistent per-install-id linkage line is intentionally not in the gate (it lives in docs).
+    expect(confirm.disclosure).not.toContain("per-installation identifier")
     expect(frame).toContain("Use Altimate Base?")
     expect(frame.replace(/\s+/g, " ")).toContain("Requests and responses may be logged and used")
     expect(frame).toContain("No — pick something else")


### PR DESCRIPTION
### Issue for this PR

Closes #1267

### Type of change

- [x] Refactor / code improvement (user-facing copy)

### What does this PR do?

Two small edits to the `DialogAltimateBaseConfirm` consent disclosure (`ALTIMATE_BASE_DISCLOSURE`):

- Remove `Logs are linked to a persistent per-installation identifier.` from the gate.
- `Usage is rate limited` → `Usage can be rate limited`.

Final gate copy:

> Altimate Base is free and requires no signup. Requests and responses may be logged and used to improve Altimate's products, including the model. Secrets are automatically masked before storage, but don't rely on it — avoid sending secrets or confidential code. Usage can be rate limited.

**Privacy note (please review):** the persistent per-install-id linkage remains disclosed in `docs/docs/configure/providers.md` ("Data handling") — this PR only removes it from the consent gate. Worth a privacy/legal glance on gate-vs-docs disclosure, since the linkage is a real practice.

### How did you verify your code works?

- `packages/tui` `dialog-altimate-base.test.tsx` updated, plus a guard asserting `per-installation identifier` stays out of the gate — 7/7 pass.
- Not verified: a live TUI screenshot (copy-only change; dialog layout unchanged).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
