### PR TITLE
chore(release): v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-09-09
+
+Altimate Base — a free, no-signup hosted model — plus a round of driver, redaction, and skill-discovery hardening. Soaked across five beta releases (see below) before promotion to `latest`.
+
+### Added
+
+- **Altimate Base — a free, no-signup, no-API-key hosted model.** Choose it from the first-run picker, `/connect`, or `/model`. Rate limited; requests and responses are logged and may be used to improve Altimate's products, linked to a persistent per-installation identifier (**pseudonymous, not anonymous**) — avoid sending secrets or confidential code. The consent dialog defaults to **No**; nothing is sent until you accept. Waits up to 5 minutes for the gateway's first response byte (tunable via `ALTIMATE_BASE_HEADER_TIMEOUT_MS`), and surfaces legible errors for rate limits, oversized requests, and daily-allowance exhaustion instead of raw gateway output. `ALTIMATE_BASE_GATEWAY_URL` lets operators point it at a self-hosted gateway (HTTPS required, no embedded credentials). Registration is also reachable over HTTP for non-TUI hosts talking to `altimate serve` — currently a backend capability only; no shipping Altimate client (including the VS Code extension) calls it yet. (#1199, #1256, #1260, #1266, #1268)
+- **Five deterministic completion-gate validators** (`dbt-build-green`, `dbt-nothing-built`, `dbt-deliverable-names`, `dbt-incremental-config`, `dbt-dialect-guard`) that refuse to terminate a session on a broken, vacuous, or misnamed dbt result. **Opt-in, shadow-mode only** for now (`ALTIMATE_VALIDATORS_SHADOW=1`); off by default — no cost or behavior change unless you opt in. (#1175)
+- **`datamate_manager list-integrations` now lists extension-type integrations** (marked "(via VS Code)") and counts them when a live IDE bridge is serving them, instead of reporting them as categorically unusable. The attach announcement now mentions extension tools served this way. (#1236)
+
+### Changed
+
+- **Big Pickle retired** as a new-user option. Existing users are detected on launch and offered Altimate Base through the consent gate (not silently migrated); declining routes to the model picker. (#1199)
+- **Altimate Base consent gate copy simplified** — shorter dialog text; full data-handling details (including the persistent per-installation identifier) remain in the docs. (#1268)
+- **Agent `data-qa` renamed to `analyst`**, now the documented "ask questions about your data" agent. Existing `default_agent: "data-qa"` configs keep working — they fall back to `analyst` with a one-time notice. (#1239)
+- Builder prompt split into an invariant core plus named packs (byte-identical assembly), with an opt-in data-qa profile. (#1217)
+
+### Breaking Changes
+
+- **DuckDB and SQLite connections now require an explicit `path`.** A missing `path` used to silently default to an in-memory store — which could read a populated on-disk store as empty — and now errors. Set `"path": ":memory:"` if you want in-memory behavior. See [warehouses.md](docs/docs/configure/warehouses.md). (#1204)
+
+### Fixed
+
+- **Improved credential redaction** in the session-compaction ledger. (#1246)
+- **Telemetry error text** now masks filesystem paths (home directories, cloud URIs, Windows/UNC). (#1117)
+- **Safety threat messages** no longer echo raw non-SQL content that could resurrect a redacted secret. (#1111)
+- **Clear error on non-JSON API responses** — the SDK client no longer crashes when an API returns a non-JSON body (e.g. an HTML error page); it surfaces a clear, actionable error instead. (#1093)
+- `--dir` no longer reads a populated warehouse store as empty. (#1204)
+- Drivers: load from the location the failing runtime named; concurrency-safe installs; a 2s deadline no longer fails healthy DuckDB stores; a broken client now says so. (#1201, #1198, #1238)
+- `auth login` accepts a provider id and diagnoses plan/account on a Codex 400. (#1181)
+- Skills no longer walk the whole tree to answer "does any file match" — cuts per-session skill auto-load cost outside a git repo from ~50s to ~7s, and fixes a correctness bug where a `dbt_project.yml` anywhere on the machine could auto-load dbt skills into an unrelated session. (#1213)
+- **Datamate stdio MCP server now inherits the IDE entry's env** when wired from an IDE integration. (#1081)
+- Main CI `dbt-tools E2E` job un-broken — restored the missing `--version` fallback that killed the setup script under `set -euo pipefail`. (#1252)
+
 ## [0.11.0-beta.5] - 2026-09-09
 
 > **Beta channel release.** Publishes to the npm `beta` dist-tag; `latest` (0.10.0) is unaffected. Install: `npm i -g @altimateai/altimate-code@beta`.

--- a/packages/opencode/test/skill/release-v0.11.0-adversarial.test.ts
+++ b/packages/opencode/test/skill/release-v0.11.0-adversarial.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Adversarial coverage for the v0.11.0 stable release payload (v0.10.0..HEAD).
+ *
+ * The 26 commits in this range already carry unusually deep dedicated test
+ * suites — confirmed during the release's multi-persona review (2,204 lines
+ * for packages/opencode/src/altimate/free/*, a targeted regression test for
+ * the #1246 credential leak, 425 lines of install-lock concurrency tests, six
+ * resolve-*.test.ts files for driver path harvesting, and an exhaustive
+ * describeRateLimit/describeRequestTooLarge suite in
+ * test/altimate/altimate-base-rate-limit-messages.test.ts). This file does
+ * NOT re-cover any of that ground. It adds two genuinely untested boundary
+ * classes that the release review's End User and Tech Lead personas flagged
+ * as risk areas but that no existing file exercises:
+ *
+ *   1. Symlinked store paths for the #1204 "populated store reads as empty"
+ *      fix (packages/drivers/src/file-store.ts's assertStoreExists /
+ *      rejectIfDirectory). Every existing test in file-store-guard.test.ts
+ *      uses a plain path; none go through a symlink. fs.existsSync/statSync
+ *      follow symlinks by default, so this is expected to already be
+ *      correct — these tests PIN that behavior rather than allege a bug.
+ *
+ *   2. Adversarial content in the free-tier gateway's own error text
+ *      (packages/opencode/src/altimate/free/client.ts's describeRateLimit /
+ *      describeRequestTooLarge) — control characters, absurd numeric
+ *      strings, and oversized detail text embedded in a gateway response.
+ *      The existing rate-limit-messages suite covers every real ChatMode
+ *      shape and several pure-function edge cases, but not what happens when
+ *      the numeric fields those parsers extract are adversarial rather than
+ *      merely absent or malformed.
+ */
+import { afterEach, describe, expect, test } from "bun:test"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import { assertStoreExists } from "../../../drivers/src/file-store"
+import { FreeTier } from "../../src/altimate/free/client"
+
+const tmpDirs: string[] = []
+function tmp(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "release-v0.11.0-adversarial-"))
+  tmpDirs.push(dir)
+  return dir
+}
+afterEach(() => {
+  while (tmpDirs.length) fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true })
+})
+
+describe("assertStoreExists — symlinked store paths (#1204 boundary, not covered by file-store-guard.test.ts)", () => {
+  test("a symlink to an existing file is treated as existing (fs.existsSync follows it)", () => {
+    const dir = tmp()
+    const real = path.join(dir, "real.duckdb")
+    fs.writeFileSync(real, "")
+    const link = path.join(dir, "link.duckdb")
+    fs.symlinkSync(real, link)
+    expect(() => assertStoreExists({ type: "duckdb" }, link, "DuckDB")).not.toThrow()
+  })
+
+  test("a dangling symlink is treated as missing — never silently opened as a new empty store", () => {
+    const dir = tmp()
+    const link = path.join(dir, "dangling.duckdb")
+    fs.symlinkSync(path.join(dir, "does-not-exist.duckdb"), link)
+    expect(() => assertStoreExists({ type: "duckdb" }, link, "DuckDB")).toThrow(/database file not found/)
+  })
+
+  test("a symlink to a directory is rejected as a directory, not silently treated as a missing file", () => {
+    const dir = tmp()
+    const realDir = path.join(dir, "realdir")
+    fs.mkdirSync(realDir)
+    const link = path.join(dir, "dirlink.duckdb")
+    fs.symlinkSync(realDir, link)
+    expect(() => assertStoreExists({ type: "duckdb" }, link, "DuckDB")).toThrow(/is a directory, not a file/)
+  })
+
+  test("a symlink to a directory is rejected even with create: true — the directory check runs before the create bypass", () => {
+    const dir = tmp()
+    const realDir = path.join(dir, "realdir2")
+    fs.mkdirSync(realDir)
+    const link = path.join(dir, "dirlink2.duckdb")
+    fs.symlinkSync(realDir, link)
+    expect(() => assertStoreExists({ type: "duckdb", create: true }, link, "DuckDB", true)).toThrow(
+      /is a directory, not a file/,
+    )
+  })
+
+  test("a broken symlink chain (link to a link to nothing) is still treated as missing, not crashed on", () => {
+    const dir = tmp()
+    const linkA = path.join(dir, "a.duckdb")
+    const linkB = path.join(dir, "b.duckdb")
+    fs.symlinkSync(path.join(dir, "nowhere.duckdb"), linkA)
+    fs.symlinkSync(linkA, linkB)
+    expect(() => assertStoreExists({ type: "duckdb" }, linkB, "DuckDB")).toThrow(/database file not found/)
+  })
+})
+
+describe("describeRateLimit — adversarial retryAfter values (beyond the 45.7 / 0 / absent shapes already covered)", () => {
+  const throttleBody = JSON.stringify({ error: { type: "throttling_error", message: "burst limit" } })
+
+  test("a retryAfter far beyond any plausible wait still renders without NaN/Infinity", () => {
+    const described = FreeTier.describeRateLimit({ body: throttleBody, retryAfter: "99999999999999" })
+    expect(described?.message).not.toContain("NaN")
+    expect(described?.message).not.toContain("Infinity")
+    expect(described?.message).toBe("Too many requests to Altimate Base right now. Try again in 99999999999999s.")
+  })
+
+  test("a scientific-notation retryAfter is parsed by Number() and rendered, not rejected", () => {
+    const described = FreeTier.describeRateLimit({ body: throttleBody, retryAfter: "4.5e1" })
+    expect(described?.message).toBe("Too many requests to Altimate Base right now. Try again in 45s.")
+  })
+
+  test("a non-numeric retryAfter (Number() -> NaN) falls back to 'shortly', never renders the literal string", () => {
+    for (const garbage of ["soon", "5 seconds", "Infinity", "-Infinity", "1,000", ""]) {
+      const described = FreeTier.describeRateLimit({ body: throttleBody, retryAfter: garbage })
+      expect(described?.message).toBe("Too many requests to Altimate Base right now. Try again shortly.")
+    }
+  })
+
+  test("a negative-but-not-zero retryAfter is treated as absent (not > 0), falls back to 'shortly'", () => {
+    const described = FreeTier.describeRateLimit({ body: throttleBody, retryAfter: "-45" })
+    expect(described?.message).toBe("Too many requests to Altimate Base right now. Try again shortly.")
+  })
+
+  test("control characters and a null byte inside the throttle detail do not crash the token-limit substring check", () => {
+    const body = JSON.stringify({
+      error: { type: "throttling_error", message: "Limit type: tokens\x00\x07, quota exceeded" },
+    })
+    const described = FreeTier.describeRateLimit({ body })
+    expect(described).toEqual({
+      message:
+        "This request is too large for Altimate Base's per-minute token limit. Start a new session or shorten the context, then try again.",
+      retryable: false,
+    })
+  })
+
+  test("an extremely long detail string (10KB) is handled without throwing or truncation artifacts in the match", () => {
+    const padding = "x".repeat(10_000)
+    const body = JSON.stringify({ error: { type: "throttling_error", message: `${padding} Limit type: tokens` } })
+    expect(() => FreeTier.describeRateLimit({ body })).not.toThrow()
+    const described = FreeTier.describeRateLimit({ body })
+    expect(described?.retryable).toBe(false)
+  })
+
+  test("budget detail containing HTML/script-like content is never echoed into the returned message", () => {
+    const body = JSON.stringify({
+      error: { type: "budget_exceeded", message: '<script>alert(1)</script> ExceededBudget: User=<img src=x>' },
+    })
+    const described = FreeTier.describeRateLimit({ body })
+    expect(described?.message).toBe(
+      "You've used today's free Altimate Base allowance. It resets tomorrow—switch models to keep going.",
+    )
+    expect(described?.message).not.toContain("<script>")
+    expect(described?.message).not.toContain("<img")
+  })
+})
+
+describe("describeRequestTooLarge — adversarial numeric content in the byte-count message", () => {
+  test("byte counts at Number.MAX_SAFE_INTEGER scale render without Infinity/NaN in the KB parenthetical", () => {
+    const body = JSON.stringify({
+      error: {
+        code: "request_too_large",
+        message: `Request is ${Number.MAX_SAFE_INTEGER} bytes; the free tier limit is ${Number.MAX_SAFE_INTEGER} bytes.`,
+      },
+    })
+    const described = FreeTier.describeRequestTooLarge({ status: 413, body })
+    expect(described).not.toContain("NaN")
+    expect(described).not.toContain("Infinity")
+    expect(described).toContain("KB against a")
+  })
+
+  test("a zero-byte limit (degenerate gateway config) renders 0KB rather than dividing into NaN", () => {
+    const body = JSON.stringify({
+      error: { code: "request_too_large", message: "Request is 1000 bytes; the free tier limit is 0 bytes." },
+    })
+    const described = FreeTier.describeRequestTooLarge({ status: 413, body })
+    expect(described).toContain("0KB limit")
+    expect(described).not.toContain("NaN")
+  })
+
+  test("control characters embedded in the message do not break the byte-count regex match or crash", () => {
+    const body = JSON.stringify({
+      error: {
+        code: "request_too_large",
+        message: "Request is 179608 bytes;\x00\x1b[31m the free tier limit is 128000 bytes.",
+      },
+    })
+    expect(() => FreeTier.describeRequestTooLarge({ status: 413, body })).not.toThrow()
+    // The control characters break the exact regex match (by design — the regex requires the
+    // literal "; the free tier limit is" substring), so this falls back to the generic message
+    // rather than fabricating numbers from a mangled match. Pinning that fallback, not a crash.
+    expect(FreeTier.describeRequestTooLarge({ status: 413, body })).toBe(
+      "This request is too large for Altimate Base. Start a new session, or switch to another model for this task.",
+    )
+  })
+
+  test("a deeply nested provider_specific_fields.error with prototype-pollution-shaped keys is inert", () => {
+    // Built as a raw JSON string, not a JS object literal: `{ __proto__: ... }` as a literal sets the
+    // prototype and is dropped by JSON.stringify, which would make this payload never actually contain
+    // "__proto__" and the test would pass regardless of whether the code under test guards against it.
+    // JSON.parse has no such special-casing — it creates a genuine own "__proto__" property — so a raw
+    // string is what an actual adversarial gateway response looks like on the wire.
+    const body =
+      '{"error":{"code":"request_too_large","__proto__":{"polluted":true},' +
+      '"provider_specific_fields":{"error":{"code":"request_too_large","__proto__":{"polluted":true}}}}}'
+    expect(() => FreeTier.describeRequestTooLarge({ status: 413, body })).not.toThrow()
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+  })
+
+  test("a non-string, numeric JSON message field is ignored rather than coerced into the byte-count text", () => {
+    const body = JSON.stringify({ error: { code: "request_too_large", message: 12345 } })
+    expect(FreeTier.describeRequestTooLarge({ status: 413, body })).toBe(
+      "This request is too large for Altimate Base. Start a new session, or switch to another model for this task.",
+    )
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #

This is the release PR promoting `v0.11.0-beta.1` through `beta.5` to stable. It doesn't close a single issue — the review findings from this promotion are tracked separately as #1283–#1289 (already filed, not blocking this PR).

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Everything in this release (Altimate Base, the opt-in dbt validators, driver/redaction fixes, etc.) already merged to `main` across the 26 commits since `v0.10.0` — none of that is new in this diff. This PR adds only the two things that couldn't land before the tag: the stable `## [0.11.0]` CHANGELOG entry (rolling the five beta entries into one coherent narrative for a first-time reader, per the PM review), and one adversarial test file covering two boundary cases the multi-persona release review flagged as untested (symlinked warehouse store paths, and adversarial content in the Altimate Base gateway's error messages).

It needs a PR because `main`'s branch ruleset requires one for any push — no review is actually required to merge (`required_approving_review_count: 0`), I just don't have bypass rights on the ruleset myself. Once this merges, I'll tag `v0.11.0` off the new `main` tip directly (tags aren't covered by the ruleset).

### How did you verify your code works?

- Full `bun test` suite: 13,390 pass. 6 failures on the first run turned out to be pre-existing flaky timeouts in test files that predate this release and aren't touched by its diff — confirmed by re-running just those 6 in isolation, where they pass clean.
- The new adversarial test file: 17/17 pass.
- Full monorepo typecheck (`bun turbo typecheck --force`): 13/13 packages clean.
- Marker guard: clean.
- Built the actual dist binary with `OPENCODE_VERSION=0.11.0` and smoke-tested it by exact path (not `$PATH`) — reports `0.11.0` correctly.
- Ran the Verdaccio sanity suite locally against a genuine cross-built `linux-arm64` binary (per #1231 — `bun install --os='*' --cpu='*'` then `build.ts --target-index=0`, which produces a real ELF executable, not the cross-build myth the docs used to claim). All phases passed: install 13/0, extended install 22/0, resilience 3/0+8skip, extended resilience 14/0+1skip, security 16/0. Also chased down an apparent ~2x package-size jump this surfaced — traced it to testing with a non-release build (`Script.release=false` skips the `bin/altimate`/`bin/altimate-code` de-dupe step in `build.ts`, which only runs for real tagged releases); confirmed against the actual v0.10.0 published tarball that the real single-binary size is unchanged (242.5MB uncompressed / 89.5MB compressed, well under npm's E413 ceiling) — no real regression.
- The five-persona release review (CTO, PM, End User, Tech Lead, and a Chaos Gremlin doing a privacy/compliance pass) is what surfaced the two things fixed in this PR (a `ConnectionConfig` typecheck gap and a couple of literal control-byte characters in the test file that made git treat it as binary) and the six items now tracked as #1283–#1289.

### Screenshots / recordings

N/A — this PR itself only touches `CHANGELOG.md` and one test file.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes `v0.11.0` from beta to stable. All 26 release commits already landed on `main`; this PR adds the stable `[0.11.0]` CHANGELOG entry (consolidating five beta entries) and an adversarial test file covering symlinked warehouse store paths and malformed Altimate Base gateway error text.

Once merged, tag `v0.11.0` off the `main` tip.

<sup>Written for commit 69c0b84730ed368a032e064f48bed5d47ed4662e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/1290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Altimate Base is now the latest free, no-signup hosted model, with consent controls and configurable header timeouts.
  - Added opt-in shadow-mode completion validation and extension-type support for integration listings.

- **Changes**
  - Big Pickle is no longer offered to new users.
  - Updated consent messaging, agent naming, and builder prompt organization.

- **Breaking Changes**
  - DuckDB and SQLite connections now require an explicit storage path.

- **Bug Fixes**
  - Improved credential, telemetry, and safety-message redaction; API error handling; warehouse-store reads; authentication; driver installation; and environment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
