### PR TITLE
feat: read the engine's unfulfilled-keys report instead of diffing declared vs delivered

### DIFF
--- a/packages/opencode/src/altimate/workspace/engine-overlay.ts
+++ b/packages/opencode/src/altimate/workspace/engine-overlay.ts
@@ -45,6 +45,8 @@ import {
   clearsFloor,
   describeExtensionServed,
   describeMissing,
+  parseUnfulfilled,
+  reportedMissing,
   describeRefusal,
   engineEntry,
   engineToolKeys,
@@ -338,6 +340,7 @@ function mcp() {
       add: (name: string, cfg: LocalMcpConfig | McpEntry) => MCP.add(name, cfg as Parameters<typeof MCP.add>[1]),
       remove: (name: string) => MCP.remove(name),
       tools: () => MCP.tools() as Promise<Record<string, unknown>>,
+      listMeta: (name: string) => MCP.listMeta(name),
     }
   )
 }
@@ -645,12 +648,18 @@ async function reconcile(sessionID: string, directory: string, state: DirectoryS
     return
   }
 
-  const present = engineToolKeys(await mcp().tools())
-  const missing = declared ? declared.keys.filter((k) => !present.has(k)) : undefined
+  const [tools, meta] = await Promise.all([mcp().tools(), mcp().listMeta(DATAMATE_KEY)])
+  const present = engineToolKeys(tools)
+  // The gaps come from the engine's own report, with reasons; this client no
+  // longer diffs the allowlist against what arrived. No report (nothing at or
+  // above the floor omits it) means no gap is claimed, not that there is none.
+  const unfulfilled = parseUnfulfilled(meta)
+  const missingReport = unfulfilled === undefined ? undefined : reportedMissing(unfulfilled)
+  const missing = missingReport?.map((u) => u.key)
   // `available` is everything the engine serves under the key. The engine adds
   // tools beyond the allowlist (knowledge, memory) when the workspace enables
   // them, so the "N of M declared" line counts only the declared ones present.
-  const served = declared ? declared.keys.length - (missing?.length ?? 0) : present.size
+  const served = declared ? declared.keys.filter((k) => present.has(k)).length : present.size
   // Extension-declared tools appear in `present` only while the engine holds a
   // live IDE bridge; when they do they are real capability and the line names
   // them, but their absence is the normal no-IDE case, never `missing`.
@@ -658,7 +667,9 @@ async function reconcile(sessionID: string, directory: string, state: DirectoryS
   const outcome: Outcome = {
     kind: "attached",
     available: present.size,
-    ...(declared ? { declared: declared.keys.length, missing } : {}),
+    ...(declared ? { declared: declared.keys.length } : {}),
+    ...(missing === undefined ? {} : { missing }),
+    ...(unfulfilled === undefined ? {} : { unfulfilled }),
   }
   const rec = record(sessionID, outcome)
   // Keyed on the workspace too: a re-link with an identical inventory is still
@@ -666,22 +677,26 @@ async function reconcile(sessionID: string, directory: string, state: DirectoryS
   // extServed is part of what the user hears, so it is part of the signature:
   // an equal-count tool swap that changes only the extension share must still
   // re-announce. (bot review)
-  const signature = `attached:${workspace.key}:${outcome.available}:${outcome.declared ?? "?"}:${(missing ?? []).join(",")}:${extServed}`
+  // A gap whose reason changed (a connection fixed, a binary still absent)
+  // is a new verdict too, so the reasons are in the signature.
+  const gaps = (missingReport ?? []).map((u) => `${u.key}=${u.reason}`).join(",")
+  const signature = `attached:${workspace.key}:${outcome.available}:${outcome.declared ?? "?"}:${gaps}:${extServed}`
   if (rec.announced === signature) return
   rec.announced = signature
   log.info("workspace engine attached", {
     workspaceId: workspace.id,
     available: outcome.available,
     declared: outcome.declared,
-    missing,
+    unfulfilled,
   })
   if (isHeadless()) return
+  const headline = declared
+    ? `${served} of ${declared.keys.length} declared integration tools available.`
+    : `${outcome.available} integration tools available.`
   await notify({
     title: `Workspace "${workspace.name}"`,
-    message: declared
-      ? `${served} of ${declared.keys.length} declared integration tools available.${describeMissing(missing ?? [])}${describeExtensionServed(extServed)}`
-      : `${outcome.available} integration tools available.`,
-    variant: missing && missing.length > 0 ? "warning" : "info",
+    message: `${headline}${describeMissing(missingReport ?? [])}${describeExtensionServed(extServed)}`,
+    variant: missingReport !== undefined && missingReport.length > 0 ? "warning" : "info",
   })
 }
 

--- a/packages/opencode/src/altimate/workspace/engine-seams.ts
+++ b/packages/opencode/src/altimate/workspace/engine-seams.ts
@@ -50,6 +50,7 @@ export const syncInternals: {
     add: (name: string, cfg: LocalMcpConfig | McpEntry) => Promise<unknown>
     remove: (name: string) => Promise<unknown>
     tools: () => Promise<Record<string, unknown>>
+    listMeta: (name: string) => Promise<Record<string, unknown> | undefined>
   }
   config?: {
     invalidate: () => Promise<void>

--- a/packages/opencode/src/altimate/workspace/engine-types.ts
+++ b/packages/opencode/src/altimate/workspace/engine-types.ts
@@ -14,9 +14,11 @@ import { DATAMATE_KEY } from "@/altimate/datamate-transport"
  * workspace promise rests on: integrations configured purely in the workspace
  * UI must produce working tools with no local files. It also passes the
  * resolved connection to MCP-type handlers, so their credential placeholders
- * resolve. A 0.7.0 engine holds the pin but serves none of those tools, which
- * is why the floor is 0.7.1. */
-export const MIN_ENGINE_VERSION = "0.7.1"
+ * resolve. A 0.7.0 engine holds the pin but serves none of those tools. 0.7.2
+ * is the first that reports, on every tools/list, the allowlist keys it could
+ * not serve and why (`UNFULFILLED_META_KEY`); this client no longer diffs the
+ * allowlist itself, so below 0.7.2 it would announce no gaps at all. */
+export const MIN_ENGINE_VERSION = "0.7.2"
 export const ENGINE_PACKAGE = "@altimateai/datamate"
 export const ENGINE_BINARY = "datamate"
 export const INSTALL_COMMAND = `npm i -g ${ENGINE_PACKAGE}@${MIN_ENGINE_VERSION}`
@@ -29,7 +31,16 @@ export const TOOL_PREFIX = `${DATAMATE_KEY}_`
 export type Outcome =
   | { kind: "disabled" }
   | { kind: "unbound" }
-  | { kind: "attached"; available: number; declared?: number; missing?: string[] }
+  | {
+      kind: "attached"
+      available: number
+      declared?: number
+      /** Keys of `unfulfilled` that count as gaps (see `reportedMissing`). */
+      missing?: string[]
+      /** The engine's full report, `no-bridge` entries included; absent when
+       * the engine sent none. */
+      unfulfilled?: Unfulfilled[]
+    }
   | { kind: "engine-missing"; declared?: number }
   /** `found` is null when the binary ran but printed nothing usable — broken
    * rather than old; the message says so. */
@@ -207,11 +218,91 @@ export function describeRefusal(
   )
 }
 
-export function describeMissing(missing: string[]): string {
+/** Where the engine (0.7.2+) reports the allowlist keys it could not serve,
+ * on every tools/list response, so the client never diffs the allowlist
+ * against what arrived: a diff can name the keys, never the reason. */
+export const UNFULFILLED_META_KEY = "ai.altimate/unfulfilled"
+
+export type UnfulfilledReason =
+  | "catalog-missing"
+  | "invalid-connection"
+  | "spawn-failed"
+  | "no-bridge"
+  | "unknown-key"
+  | "exception"
+
+/** One declared key the engine did not serve, in the engine's own words. A
+ * reason outside the known set is kept verbatim: a newer engine may add one. */
+export type Unfulfilled = {
+  key: string
+  integrationId: string
+  reason: UnfulfilledReason | (string & {})
+  detail?: string
+}
+
+/** The engine's report out of a tools/list `_meta`. Undefined when there is
+ * none, or it is malformed: the caller then knows nothing about gaps, which
+ * is not the same as knowing there are none. */
+export function parseUnfulfilled(meta: Record<string, unknown> | undefined): Unfulfilled[] | undefined {
+  const raw = meta?.[UNFULFILLED_META_KEY]
+  if (!Array.isArray(raw)) return undefined
+  const out: Unfulfilled[] = []
+  for (const item of raw) {
+    if (typeof item !== "object" || item === null) return undefined
+    const { key, integrationId, reason, detail } = item as Record<string, unknown>
+    if (typeof key !== "string" || typeof integrationId !== "string" || typeof reason !== "string") return undefined
+    out.push({ key, integrationId, reason, ...(typeof detail === "string" && detail !== "" ? { detail } : {}) })
+  }
+  return out
+}
+
+/** Absent extension tools without an IDE window are expected, not missing:
+ * `no-bridge` entries never join the "declared but not available" line.
+ * Everything else the engine reports is a real gap. */
+export function reportedMissing(unfulfilled: Unfulfilled[]): Unfulfilled[] {
+  return unfulfilled.filter((u) => u.reason !== "no-bridge")
+}
+
+const REASON_PHRASE: Record<UnfulfilledReason, string> = {
+  "invalid-connection": "no usable connection",
+  "spawn-failed": "server failed to start",
+  "catalog-missing": "no longer in the catalog",
+  "unknown-key": "not offered by the integration",
+  exception: "failed to load",
+  "no-bridge": "needs a VS Code window",
+}
+
+const MISSING_SHOWN = 5
+const DETAIL_CHARS = 60
+
+/** The gaps, grouped by reason in report order, at most `MISSING_SHOWN` keys
+ * across the groups; a group's first detail (the engine's error text, e.g.
+ * `spawn docker ENOENT`) stands for the group. */
+export function describeMissing(missing: Unfulfilled[]): string {
   if (missing.length === 0) return ""
-  const shown = missing.slice(0, 5).join(", ")
-  const more = missing.length > 5 ? ` (+${missing.length - 5} more)` : ""
-  return ` Declared but not available: ${shown}${more}.`
+  const groups = new Map<string, { keys: string[]; detail?: string }>()
+  for (const u of missing) {
+    const group = groups.get(u.reason) ?? { keys: [] }
+    group.keys.push(u.key)
+    if (group.detail === undefined && u.detail) group.detail = u.detail
+    groups.set(u.reason, group)
+  }
+  let budget = MISSING_SHOWN
+  const parts: string[] = []
+  for (const [reason, group] of groups) {
+    if (budget <= 0) break
+    const shown = group.keys.slice(0, budget)
+    budget -= shown.length
+    const phrase = (REASON_PHRASE as Record<string, string>)[reason] ?? reason
+    const detail = group.detail === undefined ? "" : ` (${truncate(group.detail, DETAIL_CHARS)})`
+    parts.push(`${phrase}${detail}: ${shown.join(", ")}`)
+  }
+  const more = missing.length > MISSING_SHOWN ? ` (+${missing.length - MISSING_SHOWN} more)` : ""
+  return ` Declared but not available — ${parts.join("; ")}${more}.`
+}
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`
 }
 
 /** Extension-declared tools a connected IDE bridge is actually serving. Zero

--- a/packages/opencode/src/altimate/workspace/engine-types.ts
+++ b/packages/opencode/src/altimate/workspace/engine-types.ts
@@ -250,8 +250,10 @@ export function parseUnfulfilled(meta: Record<string, unknown> | undefined): Unf
   for (const item of raw) {
     if (typeof item !== "object" || item === null) return undefined
     const { key, integrationId, reason, detail } = item as Record<string, unknown>
-    if (typeof key !== "string" || typeof integrationId !== "string" || typeof reason !== "string") return undefined
-    out.push({ key, integrationId, reason, ...(typeof detail === "string" && detail !== "" ? { detail } : {}) })
+    // Custom (tenant-created) integrations carry numeric ids; take them as strings.
+    const id = typeof integrationId === "number" ? String(integrationId) : integrationId
+    if (typeof key !== "string" || typeof id !== "string" || typeof reason !== "string") return undefined
+    out.push({ key, integrationId: id, reason, ...(typeof detail === "string" && detail !== "" ? { detail } : {}) })
   }
   return out
 }

--- a/packages/opencode/src/mcp/catalog.ts
+++ b/packages/opencode/src/mcp/catalog.ts
@@ -162,10 +162,11 @@ export function resources(client: Client, timeout?: number) {
 
 function listTools(client: Client, timeout: number) {
   return Effect.tryPromise({
+    // altimate_change start — a fresh listing starts with no `_meta` (see listMeta).
     try: () => {
-      // altimate_change — a fresh listing starts with no `_meta` (see listMeta).
       listMetaByClient.delete(client)
       return paginate(
+        // altimate_change end
         async (cursor) => {
           const params = cursor === undefined ? undefined : { cursor }
           try {
@@ -183,13 +184,14 @@ function listTools(client: Client, timeout: number) {
             // altimate_change end
           }
         },
+        // altimate_change start — remember this page's `_meta` (see listMeta).
         (result) => {
-          // altimate_change — remember this page's `_meta` (see listMeta).
           if (result._meta !== undefined) listMetaByClient.set(client, result._meta as Record<string, unknown>)
           return result.tools
         },
       )
     },
+    // altimate_change end
     catch: (error) => (error instanceof Error ? error : new Error(String(error))),
   })
 }

--- a/packages/opencode/src/mcp/catalog.ts
+++ b/packages/opencode/src/mcp/catalog.ts
@@ -15,6 +15,18 @@ import z from "zod/v4"
 const DEFAULT_TIMEOUT = 30_000
 const MAX_LIST_PAGES = 1_000
 
+// altimate_change start — keep the `_meta` of a server's last tools/list page.
+// `paginate` keeps only each page's items, so the result object — the sole
+// carrier of `_meta` — is dropped. The workspace engine reports the allowlist
+// keys it could not serve there (altimate/workspace/engine-types). Kept per
+// client, cleared when a listing starts, set by any page that carries one.
+const listMetaByClient = new WeakMap<Client, Record<string, unknown>>()
+
+export function listMeta(client: Client): Record<string, unknown> | undefined {
+  return listMetaByClient.get(client)
+}
+// altimate_change end
+
 // altimate_change start — Microsoft Fabric Core MCP returns `null` (instead of
 // omitting the field) for `tool.annotations.{readOnlyHint,destructiveHint,
 // idempotentHint,openWorldHint}`, which the SDK's strict schema (boolean,
@@ -150,8 +162,10 @@ export function resources(client: Client, timeout?: number) {
 
 function listTools(client: Client, timeout: number) {
   return Effect.tryPromise({
-    try: () =>
-      paginate(
+    try: () => {
+      // altimate_change — a fresh listing starts with no `_meta` (see listMeta).
+      listMetaByClient.delete(client)
+      return paginate(
         async (cursor) => {
           const params = cursor === undefined ? undefined : { cursor }
           try {
@@ -169,8 +183,13 @@ function listTools(client: Client, timeout: number) {
             // altimate_change end
           }
         },
-        (result) => result.tools,
-      ),
+        (result) => {
+          // altimate_change — remember this page's `_meta` (see listMeta).
+          if (result._meta !== undefined) listMetaByClient.set(client, result._meta as Record<string, unknown>)
+          return result.tools
+        },
+      )
+    },
     catch: (error) => (error instanceof Error ? error : new Error(String(error))),
   })
 }

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -332,6 +332,11 @@ export interface Interface {
   // without re-deriving the merge.
   readonly entry: (name: string) => Effect.Effect<ConfigMCPV1.Info | undefined>
   // altimate_change end
+  // altimate_change start — the `_meta` of a connected server's last tools/list
+  // (undefined while not connected, or when the server sent none). The
+  // workspace engine reports the allowlist keys it could not serve there.
+  readonly listMeta: (name: string) => Effect.Effect<Record<string, unknown> | undefined>
+  // altimate_change end
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/MCP") {}
@@ -915,6 +920,15 @@ export const layer = Layer.effect(
       return s.clients
     })
 
+    // altimate_change start — see Interface.listMeta
+    const listMeta = Effect.fn("MCP.listMeta")(function* (name: string) {
+      const s = yield* InstanceState.get(state)
+      const client = s.clients[name]
+      if (!client || s.status[name]?.status !== "connected") return undefined
+      return McpCatalog.listMeta(client)
+    })
+    // altimate_change end
+
     const createAndStore = Effect.fn("MCP.createAndStore")(function* (name: string, mcp: ConfigMCPV1.Info) {
       const s = yield* InstanceState.get(state)
       const result = yield* create(name, mcp)
@@ -1360,6 +1374,9 @@ export const layer = Layer.effect(
     return Service.of({
       status,
       clients,
+      // altimate_change start
+      listMeta,
+      // altimate_change end
       tools,
       prompts,
       resources,
@@ -1413,6 +1430,11 @@ export async function status() {
 export async function tools() {
   return runMcp((svc) => svc.tools())
 }
+// altimate_change start — see Interface.listMeta
+export async function listMeta(name: string) {
+  return runMcp((svc) => svc.listMeta(name))
+}
+// altimate_change end
 // altimate_change start — see Interface.entry
 export async function entry(name: string) {
   return runMcp((svc) => svc.entry(name))

--- a/packages/opencode/test/altimate/workspace/engine-install-offer.test.ts
+++ b/packages/opencode/test/altimate/workspace/engine-install-offer.test.ts
@@ -100,6 +100,7 @@ function install(opts: {
     add: async () => {},
     remove: async () => {},
     tools: async () => ({}),
+    listMeta: async () => undefined,
   }
   return h
 }

--- a/packages/opencode/test/altimate/workspace/engine-overlay.test.ts
+++ b/packages/opencode/test/altimate/workspace/engine-overlay.test.ts
@@ -20,6 +20,7 @@ import {
   resetForTests,
   settledOutcome,
   syncInternals,
+  UNFULFILLED_META_KEY,
   trackedSessionsForTests,
   type Declared,
   type LocalMcpConfig,
@@ -44,6 +45,7 @@ type Harness = {
   statusError?: string
   onAdd?: () => void
   tools: Record<string, unknown>
+  meta: Record<string, unknown> | null
   added: Array<LocalMcpConfig | McpEntry>
   removes: number
   gets: number
@@ -70,6 +72,8 @@ function install(opts: {
   statusError?: string
   onAdd?: () => void
   tools?: Record<string, unknown>
+  /** The engine's tools/list `_meta`; `null` models an engine that sends none. */
+  meta?: Record<string, unknown> | null
   mcp?: Record<string, unknown>
   noMcpKey?: boolean
   managed?: boolean
@@ -78,11 +82,12 @@ function install(opts: {
     config: opts.noMcpKey ? {} : { mcp: opts.mcp ?? {} },
     binding: opts.binding === undefined ? bound(42) : opts.binding,
     which: opts.which === undefined ? "/usr/local/bin/datamate" : opts.which,
-    version: opts.version === undefined ? "0.7.1" : opts.version,
+    version: opts.version === undefined ? "0.7.2" : opts.version,
     status: opts.status ?? "connected",
     statusError: opts.statusError,
     onAdd: opts.onAdd,
     tools: opts.tools ?? { datamate_dbt_build_model: {}, datamate_dbt_compile_model: {} },
+    meta: opts.meta === undefined ? { [UNFULFILLED_META_KEY]: [] } : opts.meta,
     added: [],
     removes: 0,
     gets: 0,
@@ -131,6 +136,7 @@ function install(opts: {
       h.removes += 1
     },
     tools: async () => h.tools,
+    listMeta: async () => h.meta ?? undefined,
   }
   // Models the real Config cache: `get` loads once and is then served from
   // cache until `invalidate`; a load rebuilds the config from its sources (so
@@ -390,17 +396,19 @@ describe("beforeTurn — what a turn boundary does", () => {
   })
 
   test("a connected engine settles attached with the inventory and announces it once", async () => {
-    const h = install({})
+    const report = [{ key: "dbt_execute_sql", integrationId: "dbt", reason: "invalid-connection" }]
+    const h = install({ meta: { [UNFULFILLED_META_KEY]: report } })
     await beforeTurn("s1")
     expect(settledOutcome("s1")).toEqual({
       kind: "attached",
       available: 2,
       declared: 3,
       missing: ["dbt_execute_sql"],
+      unfulfilled: report,
     })
     expect(h.toasts).toHaveLength(1)
     expect(h.toasts[0].message).toContain("2 of 3 declared integration tools available")
-    expect(h.toasts[0].message).toContain("dbt_execute_sql")
+    expect(h.toasts[0].message).toContain("no usable connection: dbt_execute_sql")
     // The engine was started by MCP bootstrap from the injected entry, not by the hook.
     expect(h.added).toEqual([])
     await beforeTurn("s1")
@@ -414,14 +422,14 @@ describe("beforeTurn — what a turn boundary does", () => {
       declared: { keys: ["dbt_build_model", "dbt_compile_model"], extensionKeys: [] },
     })
     await beforeTurn("s1")
-    expect(settledOutcome("s1")).toEqual({ kind: "attached", available: 3, declared: 2, missing: [] })
+    expect(settledOutcome("s1")).toEqual({ kind: "attached", available: 3, declared: 2, missing: [], unfulfilled: [] })
     expect(h.toasts[0].message).toBe("2 of 2 declared integration tools available.")
   })
 
   test("attached without an allowlist reports only what is available", async () => {
     const h = install({ declared: null })
     await beforeTurn("s1")
-    expect(settledOutcome("s1")).toEqual({ kind: "attached", available: 2 })
+    expect(settledOutcome("s1")).toEqual({ kind: "attached", available: 2, missing: [], unfulfilled: [] })
     expect(h.toasts[0].message).toBe("2 integration tools available.")
   })
 
@@ -433,11 +441,88 @@ describe("beforeTurn — what a turn boundary does", () => {
     await beforeTurn("s1")
     // `run_model` is declared extension-type but no bridge serves it: that is
     // the normal no-IDE case, so the outcome stays clean and unwarned.
-    expect(settledOutcome("s1")).toEqual({ kind: "attached", available: 3, declared: 2, missing: [] })
+    expect(settledOutcome("s1")).toEqual({ kind: "attached", available: 3, declared: 2, missing: [], unfulfilled: [] })
     expect(h.toasts[0].message).toBe(
       "2 of 2 declared integration tools available. Plus 1 extension tool via the connected VS Code window.",
     )
     expect(h.toasts[0].variant).toBe("info")
+  })
+
+  test("gaps come from the engine's report, with reasons — not from a client-side diff", async () => {
+    // The report names a key the allowlist lookup never saw (`gh_list_prs`):
+    // it is still a gap, because the engine says so.
+    const report = [
+      { key: "dbt_execute_sql", integrationId: "dbt", reason: "invalid-connection" },
+      { key: "gh_list_prs", integrationId: "github-mcp", reason: "spawn-failed", detail: "spawn docker ENOENT" },
+      { key: "gh_create_pr", integrationId: "github-mcp", reason: "spawn-failed", detail: "spawn docker ENOENT" },
+    ]
+    const h = install({ meta: { [UNFULFILLED_META_KEY]: report } })
+    await beforeTurn("s1")
+    expect(settledOutcome("s1")).toMatchObject({ missing: ["dbt_execute_sql", "gh_list_prs", "gh_create_pr"] })
+    expect(h.toasts[0].message).toBe(
+      "2 of 3 declared integration tools available. Declared but not available — no usable connection: dbt_execute_sql; " +
+        "server failed to start (spawn docker ENOENT): gh_list_prs, gh_create_pr.",
+    )
+    expect(h.toasts[0].variant).toBe("warning")
+  })
+
+  test("no-bridge entries in the report are expected, never missing", async () => {
+    const report = [
+      { key: "get_projects", integrationId: "vscode-power-user", reason: "no-bridge" },
+      { key: "run_model", integrationId: "vscode-power-user", reason: "no-bridge" },
+    ]
+    const h = install({ meta: { [UNFULFILLED_META_KEY]: report } })
+    await beforeTurn("s1")
+    expect(settledOutcome("s1")).toEqual({
+      kind: "attached",
+      available: 2,
+      declared: 3,
+      missing: [],
+      unfulfilled: report,
+    })
+    expect(h.toasts[0].message).toBe("2 of 3 declared integration tools available.")
+    expect(h.toasts[0].variant).toBe("info")
+  })
+
+  test("an engine that sends no report is not read as having no gaps", async () => {
+    const h = install({ meta: null })
+    await beforeTurn("s1")
+    // Two of three declared keys are present; without the engine's report
+    // the third is neither claimed missing nor claimed served.
+    expect(settledOutcome("s1")).toEqual({ kind: "attached", available: 2, declared: 3 })
+    expect(h.toasts[0].message).toBe("2 of 3 declared integration tools available.")
+    expect(h.toasts[0].variant).toBe("info")
+  })
+
+  test("the report names gaps even when the allowlist lookup failed", async () => {
+    const report = [{ key: "jira_search_issues", integrationId: "jira", reason: "invalid-connection" }]
+    const h = install({ declared: null, meta: { [UNFULFILLED_META_KEY]: report } })
+    await beforeTurn("s1")
+    expect(settledOutcome("s1")).toEqual({
+      kind: "attached",
+      available: 2,
+      missing: ["jira_search_issues"],
+      unfulfilled: report,
+    })
+    expect(h.toasts[0].message).toBe(
+      "2 integration tools available. Declared but not available — no usable connection: jira_search_issues.",
+    )
+    expect(h.toasts[0].variant).toBe("warning")
+  })
+
+  test("a gap whose reason changed is announced again", async () => {
+    const h = install({
+      meta: { [UNFULFILLED_META_KEY]: [{ key: "gh_list_prs", integrationId: "github-mcp", reason: "spawn-failed" }] },
+    })
+    await beforeTurn("s1")
+    await beforeTurn("s1")
+    expect(h.toasts).toHaveLength(1)
+    h.meta = {
+      [UNFULFILLED_META_KEY]: [{ key: "gh_list_prs", integrationId: "github-mcp", reason: "invalid-connection" }],
+    }
+    await beforeTurn("s1")
+    expect(h.toasts).toHaveLength(2)
+    expect(h.toasts[1].message).toContain("no usable connection: gh_list_prs")
   })
 
   test("the inventory is announced per session, not per process", async () => {
@@ -801,7 +886,7 @@ describe("beforeTurn — what a turn boundary does", () => {
   test("a failed probe is repeated on its own after the TTL", async () => {
     const h = install({ version: "0.6.3" })
     await beforeTurn("s1")
-    h.version = "0.7.1"
+    h.version = "0.7.2"
     h.clock += FAILED_PROBE_TTL_MS
     await beforeTurn("s1")
     expect(h.added).toHaveLength(1)

--- a/packages/opencode/test/altimate/workspace/engine-types.test.ts
+++ b/packages/opencode/test/altimate/workspace/engine-types.test.ts
@@ -201,6 +201,10 @@ describe("messages", () => {
       { key: "c", integrationId: "pu", reason: "no-bridge" },
     ])
     expect(parseUnfulfilled({ [UNFULFILLED_META_KEY]: [] })).toEqual([])
+    // A custom integration's id arrives as a number from the engine; it is a string here.
+    expect(
+      parseUnfulfilled({ [UNFULFILLED_META_KEY]: [{ key: "demo_tool", integrationId: 7, reason: "spawn-failed" }] }),
+    ).toEqual([{ key: "demo_tool", integrationId: "7", reason: "spawn-failed" }])
     expect(parseUnfulfilled(undefined)).toBeUndefined()
     expect(parseUnfulfilled({})).toBeUndefined()
     expect(parseUnfulfilled({ [UNFULFILLED_META_KEY]: "nope" })).toBeUndefined()

--- a/packages/opencode/test/altimate/workspace/engine-types.test.ts
+++ b/packages/opencode/test/altimate/workspace/engine-types.test.ts
@@ -13,6 +13,9 @@ import {
   clearsFloor,
   compareVersions,
   describeMissing,
+  parseUnfulfilled,
+  reportedMissing,
+  UNFULFILLED_META_KEY,
   describeRefusal,
   engineEntry,
   engineToolKeys,
@@ -53,10 +56,11 @@ describe("clearsFloor", () => {
     expect(clearsFloor(null)).toBe(false)
     expect(clearsFloor("")).toBe(false)
     expect(clearsFloor(MIN_ENGINE_VERSION)).toBe(true)
-    expect(clearsFloor("0.7.1")).toBe(true)
+    expect(clearsFloor("0.7.2")).toBe(true)
     expect(clearsFloor("1.0.0")).toBe(true)
     expect(clearsFloor("0.6.9")).toBe(false)
-    expect(clearsFloor("0.7.0")).toBe(false) // the previous floor no longer clears
+    expect(clearsFloor("0.7.1")).toBe(false) // the previous floor no longer clears: no unfulfilled report
+    expect(clearsFloor("0.7.0")).toBe(false)
     expect(clearsFloor(`${MIN_ENGINE_VERSION}-beta.1`)).toBe(false)
     expect(clearsFloor("0.7rc.0")).toBe(false)
   })
@@ -153,11 +157,62 @@ describe("messages", () => {
       "Update with: npm i -g @altimateai/datamate@next",
     )
   })
-  test("the missing list is truncated after five", () => {
+  test("the missing line groups by reason, carries the engine's detail, and truncates after five", () => {
+    const u = (key: string, reason: string, detail?: string) => ({
+      key,
+      integrationId: "i",
+      reason,
+      ...(detail ? { detail } : {}),
+    })
     expect(describeMissing([])).toBe("")
-    expect(describeMissing(["a", "b"])).toBe(" Declared but not available: a, b.")
-    expect(describeMissing(["a", "b", "c", "d", "e", "f", "g"])).toBe(
-      " Declared but not available: a, b, c, d, e (+2 more).",
+    expect(describeMissing([u("a", "invalid-connection"), u("b", "invalid-connection")])).toBe(
+      " Declared but not available — no usable connection: a, b.",
     )
+    expect(
+      describeMissing([
+        u("a", "spawn-failed", "spawn docker ENOENT"),
+        u("b", "spawn-failed", "spawn docker ENOENT"),
+        u("c", "catalog-missing"),
+        u("d", "unknown-key"),
+        u("e", "exception", "boom"),
+      ]),
+    ).toBe(
+      " Declared but not available — server failed to start (spawn docker ENOENT): a, b; no longer in the catalog: c; " +
+        "not offered by the integration: d; failed to load (boom): e.",
+    )
+    expect(describeMissing(["a", "b", "c", "d", "e", "f", "g"].map((k) => u(k, "invalid-connection")))).toBe(
+      " Declared but not available — no usable connection: a, b, c, d, e (+2 more).",
+    )
+    // A reason this client does not know is shown verbatim rather than dropped.
+    expect(describeMissing([u("a", "quota-exceeded")])).toBe(" Declared but not available — quota-exceeded: a.")
+    // A long detail is cut so the toast stays a toast.
+    expect(describeMissing([u("a", "exception", "x".repeat(80))])).toContain(`(${"x".repeat(59)}…)`)
+  })
+
+  test("the engine's report is read out of tools/list _meta, and nothing is invented", () => {
+    const report = [
+      { key: "a", integrationId: "jira", reason: "invalid-connection" },
+      { key: "b", integrationId: "gh", reason: "spawn-failed", detail: "spawn docker ENOENT" },
+      { key: "c", integrationId: "pu", reason: "no-bridge", detail: "" },
+    ]
+    expect(parseUnfulfilled({ [UNFULFILLED_META_KEY]: report })).toEqual([
+      report[0],
+      report[1],
+      { key: "c", integrationId: "pu", reason: "no-bridge" },
+    ])
+    expect(parseUnfulfilled({ [UNFULFILLED_META_KEY]: [] })).toEqual([])
+    expect(parseUnfulfilled(undefined)).toBeUndefined()
+    expect(parseUnfulfilled({})).toBeUndefined()
+    expect(parseUnfulfilled({ [UNFULFILLED_META_KEY]: "nope" })).toBeUndefined()
+    expect(parseUnfulfilled({ [UNFULFILLED_META_KEY]: [{ key: "a" }] })).toBeUndefined()
+  })
+
+  test("no-bridge entries are the only ones kept out of the missing set", () => {
+    const report = [
+      { key: "a", integrationId: "jira", reason: "invalid-connection" },
+      { key: "b", integrationId: "pu", reason: "no-bridge" },
+      { key: "c", integrationId: "pu", reason: "unknown-key" },
+    ]
+    expect(reportedMissing(report).map((u) => u.key)).toEqual(["a", "c"])
   })
 })

--- a/packages/opencode/test/mcp/catalog-list-meta.test.ts
+++ b/packages/opencode/test/mcp/catalog-list-meta.test.ts
@@ -1,0 +1,74 @@
+// altimate_change - new file
+//
+// The MCP catalog keeps the `_meta` of a server's last tools/list page per
+// client (the workspace engine reports unserved allowlist keys there), even
+// though pagination keeps only the tools themselves.
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { Server } from "@modelcontextprotocol/sdk/server/index.js"
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js"
+import * as McpCatalog from "../../src/mcp/catalog"
+
+const KEY = "ai.altimate/unfulfilled"
+
+async function connected(listTools: () => Record<string, unknown>) {
+  const server = new Server({ name: "fake", version: "0" }, { capabilities: { tools: {} } })
+  server.setRequestHandler(ListToolsRequestSchema, async () => listTools() as never)
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  await server.connect(serverTransport)
+  const client = new Client({ name: "test", version: "0" })
+  await client.connect(clientTransport)
+  return { client, close: () => Promise.all([client.close(), server.close()]) }
+}
+
+const echo = { name: "echo", description: "", inputSchema: { type: "object", properties: {} } }
+
+describe("McpCatalog.listMeta", () => {
+  test("keeps the last tools/list page's _meta next to the listed tools", async () => {
+    const report = [{ key: "jira_search_issues", integrationId: "jira", reason: "invalid-connection" }]
+    const { client, close } = await connected(() => ({ tools: [echo], _meta: { [KEY]: report } }))
+    try {
+      expect(McpCatalog.listMeta(client)).toBeUndefined()
+      const defs = await Effect.runPromise(McpCatalog.defs(client))
+      expect(defs?.map((t) => t.name)).toEqual(["echo"])
+      expect(McpCatalog.listMeta(client)).toEqual({ [KEY]: report })
+    } finally {
+      await close()
+    }
+  })
+
+  test("a listing that carries no _meta clears what an earlier one left", async () => {
+    let withMeta = true
+    const { client, close } = await connected(() =>
+      withMeta ? { tools: [echo], _meta: { [KEY]: [] } } : { tools: [echo] },
+    )
+    try {
+      await Effect.runPromise(McpCatalog.defs(client))
+      expect(McpCatalog.listMeta(client)).toEqual({ [KEY]: [] })
+      withMeta = false
+      await Effect.runPromise(McpCatalog.defs(client))
+      expect(McpCatalog.listMeta(client)).toBeUndefined()
+    } finally {
+      await close()
+    }
+  })
+
+  test("_meta survives the multi-page path", async () => {
+    let page = 0
+    const { client, close } = await connected(() => {
+      page += 1
+      return page === 1
+        ? { tools: [echo], nextCursor: "p2" }
+        : { tools: [{ ...echo, name: "echo2" }], _meta: { [KEY]: [] } }
+    })
+    try {
+      const defs = await Effect.runPromise(McpCatalog.defs(client))
+      expect(defs?.map((t) => t.name)).toEqual(["echo", "echo2"])
+      expect(McpCatalog.listMeta(client)).toEqual({ [KEY]: [] })
+    } finally {
+      await close()
+    }
+  })
+})

--- a/packages/opencode/test/mcp/engine-unfulfilled.e2e.test.ts
+++ b/packages/opencode/test/mcp/engine-unfulfilled.e2e.test.ts
@@ -1,0 +1,245 @@
+// altimate_change - new file
+//
+// End to end through the real MCP service: a real `@altimateai/datamate`
+// engine (0.7.2+) is spawned over stdio the way the workspace overlay spawns
+// it, against a fake Altimate API, and its `ai.altimate/unfulfilled` report
+// arrives through the catalog as `MCP.listMeta(...)`, ready for the toast.
+//
+// Needs an engine checkout with a built `dist/cli.js`; skipped otherwise:
+//   ALTIMATE_ENGINE_E2E_ROOT=/path/to/altimate-mcp-engine bun test test/mcp/engine-unfulfilled.e2e.test.ts
+import http from "node:http"
+import path from "node:path"
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readdirSync, readFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import type { MCP as MCPNS } from "../../src/mcp/index"
+import { testEffect } from "../lib/effect"
+import { MCP } from "../../src/mcp/index"
+import {
+  describeMissing,
+  parseUnfulfilled,
+  reportedMissing,
+  UNFULFILLED_META_KEY,
+} from "../../src/altimate/workspace/engine-types"
+
+const root = process.env["ALTIMATE_ENGINE_E2E_ROOT"]
+// The engine ships as a node shebang script; under `bun test` the test runner's own
+// executable is bun, which the engine cannot run on.
+const node = Bun.which("node") ?? "node"
+const cli = root ? path.join(root, "dist/cli.js") : undefined
+const runnable = !!cli && existsSync(cli)
+const it = testEffect(MCP.defaultLayer)
+
+const DATAMATE_ID = "77"
+
+// The workspace declares five integrations; the engine can serve one of them.
+const catalog = [
+  {
+    id: "jira",
+    type: "tool",
+    name: "Jira",
+    description: "",
+    url: "",
+    supportsLocalConnectionTest: true,
+    supportsSaasConnectionTest: false,
+    config: [
+      { key: "url", name: "URL", type: "string", required: true },
+      { key: "email", name: "Email", type: "string", required: true },
+      { key: "token", name: "Token", type: "string", required: true },
+    ],
+    tools: [{ key: "jira_search_issues", name: "Search issues" }],
+  },
+  {
+    id: "vscode-power-user",
+    type: "extension",
+    name: "Power User for dbt",
+    description: "",
+    url: "",
+    supportsLocalConnectionTest: false,
+    supportsSaasConnectionTest: false,
+    config: [],
+    tools: [{ key: "pu_lineage", name: "Lineage" }],
+  },
+]
+const custom = [
+  {
+    id: "mcp-ok",
+    type: "mcp",
+    name: "Echo MCP",
+    description: "",
+    url: "",
+    config: [],
+    toolConfig: [
+      { key: "type", name: "type", type: "string", required: false, value: "stdio" },
+      { key: "command", name: "command", type: "string", required: true, value: node },
+      {
+        key: "arguments",
+        name: "arguments",
+        type: "array",
+        required: false,
+        value: [path.join(import.meta.dir, "fixtures/echo-mcp-server.mjs")],
+      },
+    ],
+    tools: [{ key: "echo" }, { key: "ghost" }],
+  },
+  {
+    id: "mcp-missing-binary",
+    type: "mcp",
+    name: "Missing MCP",
+    description: "",
+    url: "",
+    config: [],
+    toolConfig: [
+      { key: "type", name: "type", type: "string", required: false, value: "stdio" },
+      { key: "command", name: "command", type: "string", required: true, value: "altimate-e2e-missing-binary" },
+    ],
+    tools: [{ key: "whatever" }],
+  },
+]
+const datamate = {
+  id: DATAMATE_ID,
+  name: "e2e",
+  description: "",
+  privacy: "private",
+  memory_enabled: false,
+  knowledge_engine_enabled: false,
+  knowledge_bases: [],
+  integrations: [
+    { id: "jira", type: "tool", name: "Jira", description: "", url: "", tools: [{ key: "jira_search_issues" }] },
+    {
+      id: "vscode-power-user",
+      type: "extension",
+      name: "PU",
+      description: "",
+      url: "",
+      tools: [{ key: "pu_lineage" }],
+    },
+    {
+      id: "mcp-ok",
+      type: "mcp",
+      name: "Echo MCP",
+      description: "",
+      url: "",
+      tools: [{ key: "echo" }, { key: "ghost" }],
+    },
+    {
+      id: "mcp-missing-binary",
+      type: "mcp",
+      name: "Missing MCP",
+      description: "",
+      url: "",
+      tools: [{ key: "whatever" }],
+    },
+    {
+      id: "retired-integration",
+      type: "tool",
+      name: "Retired",
+      description: "",
+      url: "",
+      tools: [{ key: "retired_tool" }],
+    },
+  ],
+}
+
+async function fakeAltimateApi() {
+  const unhandled: string[] = []
+  const server = http.createServer((req, res) => {
+    const p = new URL(req.url ?? "/", "http://x").pathname
+    const json = (code: number, body?: unknown) => {
+      res.writeHead(code, { "content-type": "application/json" })
+      res.end(body === undefined ? "" : JSON.stringify(body))
+    }
+    if (p === "/dbt/v3/validate-credentials") return json(200, { ok: true })
+    if (p === "/datamates") return json(200, { datamates: [datamate] })
+    if (p === "/datamate_integrations") return json(200, catalog)
+    if (p === "/datamate_integrations/custom") return json(200, { items: custom })
+    if (p === "/mask") return json(200, { mask_data: [] })
+    if (p === "/connections") return json(200, { connections: [] })
+    if (p === `/datamates/${DATAMATE_ID}/knowledge_bases`) return json(200, { knowledge_bases: [] })
+    if (p === `/datamates/${DATAMATE_ID}/knowledge_engine_description`) return json(200, {})
+    if (p === "/datamates/audit/create_batch") return json(204)
+    unhandled.push(p)
+    return json(404, { detail: `unhandled ${p}` })
+  })
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r))
+  const address = server.address() as { port: number }
+  return { url: `http://127.0.0.1:${address.port}`, unhandled, close: () => server.close() }
+}
+
+function isolatedHome(apiUrl: string) {
+  const home = mkdtempSync(path.join(tmpdir(), "engine-unfulfilled-e2e-"))
+  mkdirSync(path.join(home, ".altimate"), { recursive: true })
+  writeFileSync(
+    path.join(home, ".altimate/altimate.json"),
+    JSON.stringify({ altimateUrl: apiUrl, altimateInstanceName: "e2e", altimateApiKey: "e2e-key" }),
+  )
+  writeFileSync(path.join(home, ".altimate/settings.json"), "{}")
+  writeFileSync(path.join(home, ".altimate/connections.json"), "[]")
+  return home
+}
+
+describe.skipIf(!runnable)("engine unfulfilled report through the MCP service", () => {
+  it.instance(
+    "the engine's report reaches MCP.listMeta and reads as the attach toast",
+    () =>
+      MCP.Service.use((mcp: MCPNS.Interface) =>
+        Effect.gen(function* () {
+          const api = yield* Effect.promise(fakeAltimateApi)
+          try {
+            const home = isolatedHome(api.url)
+            yield* mcp.add("datamate", {
+              type: "local",
+              command: [node, cli!, "start-stdio", "--datamate", DATAMATE_ID],
+              environment: { HOME: home },
+              cwd: root!,
+            })
+            const status = yield* mcp.status()
+            if (status["datamate"]?.status !== "connected") {
+              const logDir = path.join(home, ".altimate/logs")
+              const logs = existsSync(logDir) ? readdirSync(logDir) : []
+              const tail = logs.map((f) => readFileSync(path.join(logDir, f), "utf8").slice(-1500)).join("\n")
+              throw new Error(
+                `engine not connected: ${JSON.stringify(status["datamate"])}\n--- engine log tail ---\n${tail}`,
+              )
+            }
+
+            const tools = yield* mcp.tools()
+            expect(Object.keys(tools).filter((k) => k.startsWith("datamate_"))).toEqual(["datamate_echo"])
+
+            const meta = yield* mcp.listMeta("datamate")
+            const report = parseUnfulfilled(meta)
+            expect(report).toBeDefined()
+            const byKey = Object.fromEntries(report!.map((u) => [u.key, u]))
+            expect(byKey["jira_search_issues"]).toMatchObject({ integrationId: "jira", reason: "invalid-connection" })
+            expect(byKey["pu_lineage"]).toMatchObject({ integrationId: "vscode-power-user", reason: "no-bridge" })
+            expect(byKey["ghost"]).toMatchObject({ integrationId: "mcp-ok", reason: "unknown-key" })
+            expect(byKey["whatever"]).toMatchObject({ integrationId: "mcp-missing-binary", reason: "spawn-failed" })
+            expect(byKey["whatever"]?.detail).toMatch(/ENOENT/)
+            expect(byKey["retired_tool"]).toMatchObject({
+              integrationId: "retired-integration",
+              reason: "catalog-missing",
+            })
+            expect(report!.some((u) => `datamate_${u.key}` in tools)).toBe(false)
+
+            // What the user would read on attach: every gap but the IDE one, with reasons.
+            expect(describeMissing(reportedMissing(report!))).toBe(
+              " Declared but not available — no usable connection: jira_search_issues; " +
+                "not offered by the integration: ghost; " +
+                "server failed to start (spawn altimate-e2e-missing-binary ENOENT): whatever; " +
+                "no longer in the catalog: retired_tool.",
+            )
+            expect(api.unhandled).toEqual([])
+            yield* mcp.remove("datamate")
+            expect(yield* mcp.listMeta("datamate")).toBeUndefined()
+          } finally {
+            api.close()
+          }
+        }),
+      ),
+    60_000,
+  )
+})
+
+// Referenced so the key is visibly the contract this test exercises.
+void UNFULFILLED_META_KEY

--- a/packages/opencode/test/mcp/fixtures/echo-mcp-server.mjs
+++ b/packages/opencode/test/mcp/fixtures/echo-mcp-server.mjs
@@ -1,0 +1,9 @@
+// A real MCP server over stdio offering exactly one tool, "echo" (test fixture).
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { z } from "zod"
+const server = new McpServer({ name: "e2e-echo", version: "0.0.1" })
+server.tool("echo", "Echoes its input", { text: z.string() }, async ({ text }) => ({
+  content: [{ type: "text", text }],
+}))
+await server.connect(new StdioServerTransport())

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -125,6 +125,7 @@ const mcp = Layer.succeed(
     status: () => Effect.succeed({}),
     clients: () => Effect.succeed({}),
     tools: () => Effect.succeed({}),
+    listMeta: () => Effect.succeed(undefined),
     prompts: () => Effect.succeed({}),
     resources: () => Effect.succeed({}),
     add: () => Effect.succeed({ status: { status: "disabled" as const } }),

--- a/packages/opencode/test/session/snapshot-tool-race.test.ts
+++ b/packages/opencode/test/session/snapshot-tool-race.test.ts
@@ -38,6 +38,7 @@ const mcp = Layer.succeed(
     status: () => Effect.succeed({}),
     clients: () => Effect.succeed({}),
     tools: () => Effect.succeed({}),
+    listMeta: () => Effect.succeed(undefined),
     prompts: () => Effect.succeed({}),
     resources: () => Effect.succeed({}),
     add: () => Effect.succeed({ status: { status: "disabled" as const } }),


### PR DESCRIPTION
### Issue for this PR

Closes #1307

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a workspace is bound, the attach toast says "N of M declared integration tools available" and lists what is declared but absent. Until now that list came from a client-side diff: fetch the workspace's allowlist from the API, subtract the tool names the engine served. A diff can name keys, never reasons — an expired Jira token, an MCP server whose binary is not installed, an integration the tenant removed from the catalog, an extension tool with no VS Code window, and a key the provider does not offer all read the same.

`@altimateai/datamate` 0.7.2 (AltimateAI/altimate-mcp-engine#248) reports every declared-but-unserved key with a reason under `_meta["ai.altimate/unfulfilled"]` on each `tools/list` response. This PR reads it:

- **MCP catalog** keeps the `_meta` of a server's last `tools/list` page per client. `paginate` keeps only each page's items, so the result object — the only carrier of `_meta` — was dropped. A listing starts with none; any page that carries one sets it; a listing without one clears it. Exposed as `MCP.listMeta(name)` (undefined while not connected).
- **Attach** takes the gaps from the report instead of the diff. `no-bridge` entries stay out of the "missing" line, as absent extension tools without an IDE were already treated as expected; every other reason is named, grouped, with the engine's detail (e.g. `spawn docker ENOENT`) — `Declared but not available — no usable connection: jira_search_issues; server failed to start (spawn docker ENOENT): gh_list_prs, gh_create_pr.` The "N of M" headline still counts declared keys that are present. The attached outcome carries the full report for later surfaces.
- **No report means no claim.** An engine that sends no `_meta` (nothing at or above the floor does) yields an outcome with neither `missing` nor `unfulfilled`, and a toast with no gap line — not "all served".
- **Floor** moves to 0.7.2 (`MIN_ENGINE_VERSION`), the first engine that emits the report. **Do not merge before `@altimateai/datamate@0.7.2` is on npm** (AltimateAI/altimate-mcp-engine#249 is the bump); until then every attach would refuse with "needs 0.7.2 or newer".

The client no longer reads what it cannot know: the allowlist lookup (`declared()`) is kept only for the headline's denominator and the extension-tool count, and a report without a reachable allowlist still names the gaps.

#### Claims

- **C1 — Nothing is invented.** `missing` and `unfulfilled` exist on the outcome only when the engine sent a well-formed report; a malformed or absent `_meta` yields neither (test: "an engine that sends no report is not read as having no gaps"; `parseUnfulfilled` cases).
- **C2 — `no-bridge` never counts as missing**, and every other reason does — including `unknown-key` on an extension key while a bridge is connected (`reportedMissing`; test "no-bridge entries in the report are expected, never missing").
- **C3 — The catalog keeps the report across the paths that list tools**: initial connect, the `tools/list_changed` refresh, the post-OAuth reconnect all go through `McpCatalog.defs` → `listTools`, which is the only writer (`catalog-list-meta.test.ts` covers first page, multi-page, and clearing).
- **C4 — A gap whose reason changes is announced again**; an identical report is not (signature carries `key=reason`; test "a gap whose reason changed is announced again").
- **C5 — Servers other than the engine are unaffected**: `_meta` is retained per client but read only for `datamate`; tool conversion and the stored `defs` are unchanged.

#### Residuals

- **R1** — Reasons outside the engine's current set are shown verbatim (a newer engine may add one) rather than dropped.
- **R2** — The toast shows at most five keys across groups and truncates a detail at 60 characters; the full report is on the outcome.
- **R3** — The floor bump refuses 0.7.1 engines; that is the intended contract, and the reason is in the `MIN_ENGINE_VERSION` comment.

### How did you verify your code works?

- `bun run typecheck` clean; prettier clean on the files this PR touches (the files that were already non-conforming on `main` are left as they were).
- `test/altimate/workspace` (all), `test/mcp/catalog-list-meta.test.ts`, `test/altimate/precedence-guard-order.test.ts`: 460 pass. `test/mcp` and the two session suites whose MCP stubs gained `listMeta`: 279 pass; the 5 `mcp.headers` failures and 1 `oauth-auto-connect` failure reproduce identically on an untouched `main` checkout (environmental, not this change).
- New tests: 6 attach cases (reasons in the toast, no-bridge exclusion, no-report, report-without-allowlist, reason-change re-announce, the existing inventory case now stating the engine's report), `describeMissing`/`parseUnfulfilled`/`reportedMissing` unit cases, 3 catalog cases over a real in-memory MCP server.
- **End to end through the real MCP service** (`test/mcp/engine-unfulfilled.e2e.test.ts`, env-guarded, skipped in CI): the engine at `AltimateAI/altimate-mcp-engine#248`'s head built as 0.7.2 is spawned over stdio by `MCP.add` exactly as the overlay spawns it, against a fake Altimate API, a real second MCP server and a missing binary; `MCP.listMeta("datamate")` returns the five-entry report with the expected reasons and the toast text reads `Declared but not available — no usable connection: jira_search_issues; not offered by the integration: ghost; server failed to start (spawn altimate-e2e-missing-binary ENOENT): whatever; no longer in the catalog: retired_tool.` — 1 pass. Run it with `ALTIMATE_ENGINE_E2E_ROOT=<engine checkout with dist/> bun test test/mcp/engine-unfulfilled.e2e.test.ts` from `packages/opencode`.

- **Engine → CLI through the real attach path** ([evidence](https://github.com/AltimateAI/altimate-code/pull/1308#issuecomment-5642662482)): `bootstrap` + `beforeTurn` on a bound directory against the 0.7.2 release candidate (engine PRs 250 + 248 merged, built locally, on PATH as `datamate`). Settled outcome `attached` with `declared: 5`, `missing: [jira_search_issues, ghost, whatever, retired_tool]`, the full report incl. the `no-bridge` entry, and the exact toast text; 8/8 checks. A 0.7.1 build is refused as `engine-too-old` with the install line; 2/2.

### Screenshots / recordings

Not a UI change beyond toast text; the exact strings are asserted in the tests above.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHBUvb843k1R7UAGi8Ya9b

### Appendix — complexity delta (altimate-code: engine unfulfilled report)

`e8c21c2af7` → `93c879af8` · only functions this diff touches · advisory, not a gate.

✅ No touched function changed in complexity (12 touched, 4 new, all under 10).

<details><summary>ℹ️ How to read these numbers</summary>

**Cognitive** (Sonar spec) counts breaks in linear reading flow — each `if`/loop/`catch`/ternary/boolean-operator switch adds 1, and nesting makes every further break cost more. It approximates how much you must hold in your head to follow the function: **0–5 trivial · 6–10 easy · 11–15 moderate (15 = Sonar's recommended per-function cap) · 16–25 hard to follow · >25 needs decomposition**.

**CCN** (cyclomatic) counts independent paths — also the minimum number of test cases for full branch coverage of the function.

Only functions this diff touches are measured, as deltas — pre-existing complexity is not counted against this change. Rising numbers aren't automatically wrong; they're where review attention should go. Test files excluded.
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #1307. Workspace attach now reads the engine’s `ai.altimate/unfulfilled` report instead of diffing declared and delivered tools, so missing-tool notices include actionable reasons and details rather than only tool names.

**Attach behavior**

- Excludes `no-bridge` entries; every other valid reason is reported.
- Groups missing tools by reason and integration, preserving the engine’s detail.
- Leaves `missing` and `unfulfilled` unset when the report is absent or malformed.
- Re-announces a gap when its reason changes, but not when the report is identical.
- Counts distinct sanitized catalog entries, including collisions across ordinary and extension tools.
- Accepts numeric integration IDs and stores them as strings.

**MCP catalog**

- Preserves each client’s `tools/list` `_meta` and exposes it through `MCP.listMeta(name)`.
- Commits tools and their report together through `MCP.snapshot(name)` to prevent mismatched refreshes.
- Keeps the previous report for pending or failed listings; a completed listing without `_meta` clears it.
- Raises `MIN_ENGINE_VERSION` to 0.7.2, which requires `@altimateai/datamate` 0.7.2 or newer.

<sup>Written for commit 0087205ce1cd32ef4a0edf5cd19daac499cf702a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/1308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

