### PR TITLE
feat(workspace): post a sanitized session attach report when the outcome settles

### DIFF
--- a/packages/opencode/src/altimate/api/client.ts
+++ b/packages/opencode/src/altimate/api/client.ts
@@ -319,6 +319,12 @@ export namespace AltimateApi {
     await request(creds, "DELETE", `/datamates/${id}`)
   }
 
+  /** Post this session's attach report for a workspace (session attach report store). */
+  export async function postAttachReport(datamateId: string, report: unknown): Promise<void> {
+    const creds = await getCredentials()
+    await request(creds, "POST", `/datamates/${datamateId}/attach-reports`, report)
+  }
+
   export async function listIntegrations() {
     const creds = await getCredentials()
     const data = await request(creds, "GET", "/datamate_integrations/")

--- a/packages/opencode/src/altimate/workspace/attach-report.ts
+++ b/packages/opencode/src/altimate/workspace/attach-report.ts
@@ -1,0 +1,143 @@
+// altimate_change - new file
+//
+// The session attach report: what this session actually received from its
+// workspace, posted to the backend when the outcome settles so the workspace
+// page can show it. Pure shaping here; the one I/O function at the bottom
+// goes through the API client and never throws.
+import { AltimateApi } from "@/altimate/api/client"
+import { log, syncInternals } from "./engine-seams"
+import type { Declared, Outcome, Unfulfilled } from "./engine-types"
+
+/** What the backend accepts as an unserved key's detail: a code and, for
+ * spawn failures, the basename of the command. Never the engine's raw error
+ * text, which can name paths and hosts. */
+export type AttachReportDetail = { code: string; command?: string }
+
+export type AttachReportUnfulfilled = {
+  key: string
+  integration_id: string
+  reason: string
+  detail?: AttachReportDetail
+}
+
+export type AttachReportOutcome = "attached" | "engine-missing" | "engine-too-old" | "connect-failed"
+
+export type AttachReport = {
+  binding_key: string
+  outcome: AttachReportOutcome
+  cli_version: string
+  engine_version: string | null
+  bridge_connected: boolean
+  declared_keys: string[]
+  delivered_keys: string[]
+  unfulfilled: AttachReportUnfulfilled[]
+  reported_at: string
+}
+
+/** The identity the server binding row already carries: the git remote when
+ * the project has one, else its absolute path. Nothing new about the machine
+ * leaves it. */
+export function bindingKey(binding: { repoRemote: string | null; projectPath: string | null }): string | null {
+  return binding.repoRemote || binding.projectPath || null
+}
+
+const CODES: Array<[RegExp, string]> = [
+  [/\bENOENT\b/, "ENOENT"],
+  [/\bEACCES\b|\bEPERM\b/, "EACCES"],
+  [/\bETIMEDOUT\b|timed? ?out/i, "ETIMEDOUT"],
+  [/\bECONNREFUSED\b/, "ECONNREFUSED"],
+  [/invalid url/i, "invalid-url"],
+]
+
+/** A code for an error string, never the string. */
+export function errorCode(text: string): string {
+  return CODES.find(([re]) => re.test(text))?.[1] ?? "other"
+}
+
+/** Reduce an engine detail to what may leave the machine. For a spawn
+ * failure the spawned command's basename is kept (`spawn /Users/x/bin/docker
+ * ENOENT` → `docker`); the directory, and everything else, is dropped. */
+export function sanitizeDetail(detail: string | undefined, reason: string): AttachReportDetail | undefined {
+  if (!detail) return undefined
+  const code = errorCode(detail)
+  if (reason !== "spawn-failed") return { code }
+  const match = /\bspawn\s+(\S+)/.exec(detail)
+  const command = match ? match[1].split(/[\\/]/).pop() : undefined
+  return command ? { code, command } : { code }
+}
+
+function sanitizeUnfulfilled(entries: Unfulfilled[]): AttachReportUnfulfilled[] {
+  return entries.map((u) => {
+    const detail = sanitizeDetail(u.detail, u.reason)
+    return { key: u.key, integration_id: u.integrationId, reason: u.reason, ...(detail ? { detail } : {}) }
+  })
+}
+
+export type AttachReportInput = {
+  outcome: Outcome
+  bindingKey: string
+  cliVersion: string
+  /** The probed engine version, when the engine ran at all. */
+  engineVersion: string | null
+  declared: Declared | null
+  /** Keys the engine served under the workspace key (attached only). */
+  present?: Set<string>
+  bridgeConnected: boolean
+  reportedAt: string
+}
+
+/** The report for a settled outcome, or null for outcomes that are not about
+ * the engine at all (disabled, unbound). */
+export function buildAttachReport(input: AttachReportInput): AttachReport | null {
+  const { outcome, declared } = input
+  const declaredKeys = declared ? [...declared.keys, ...declared.extensionKeys] : []
+  const base = {
+    binding_key: input.bindingKey,
+    cli_version: input.cliVersion,
+    bridge_connected: input.bridgeConnected,
+    declared_keys: declaredKeys,
+    delivered_keys: [] as string[],
+    unfulfilled: [] as AttachReportUnfulfilled[],
+    reported_at: input.reportedAt,
+  }
+  switch (outcome.kind) {
+    case "attached": {
+      const present = input.present ?? new Set<string>()
+      const delivered = declared ? declaredKeys.filter((k) => present.has(k)) : [...present]
+      return {
+        ...base,
+        outcome: "attached",
+        engine_version: input.engineVersion,
+        delivered_keys: delivered,
+        unfulfilled: sanitizeUnfulfilled(outcome.unfulfilled ?? []),
+      }
+    }
+    case "engine-missing":
+      return { ...base, outcome: "engine-missing", engine_version: null }
+    case "engine-too-old":
+      return { ...base, outcome: "engine-too-old", engine_version: outcome.found }
+    case "connect-failed":
+      return { ...base, outcome: "connect-failed", engine_version: input.engineVersion }
+    default:
+      return null
+  }
+}
+
+/** Everything that would make the backend row different — so an identical
+ * re-attach does not post again, and a changed reason or version does. */
+export function attachReportSignature(report: AttachReport): string {
+  const { reported_at: _at, ...rest } = report
+  return JSON.stringify(rest)
+}
+
+/** Post a report; fire-and-forget by contract. A failure is logged once at
+ * debug and never reaches the user or the turn. */
+export async function postAttachReport(datamateId: string, report: AttachReport): Promise<void> {
+  try {
+    if (syncInternals.reportAttach) return await syncInternals.reportAttach(datamateId, report)
+    if (!(await AltimateApi.isConfigured())) return
+    await AltimateApi.postAttachReport(datamateId, report)
+  } catch (err) {
+    log.debug("attach report not posted", { datamateId, err: String(err) })
+  }
+}

--- a/packages/opencode/src/altimate/workspace/engine-overlay.ts
+++ b/packages/opencode/src/altimate/workspace/engine-overlay.ts
@@ -35,7 +35,18 @@ import {
   syncInternals,
   type ScopedBinding,
 } from "./engine-seams"
-import { declaredBounded, fingerprint, notify, printLine, resolveBinding, versionOf, which } from "./engine-probes"
+import {
+  declaredBounded,
+  fingerprint,
+  liveBridge,
+  notify,
+  printLine,
+  resolveBinding,
+  versionOf,
+  which,
+} from "./engine-probes"
+import { attachReportSignature, bindingKey, buildAttachReport, postAttachReport } from "./attach-report"
+import { Installation } from "@/installation"
 import { OFFER_RECHECK_MS, OFFER_SKIP_TTL_MS, installCommand, offerOrNotify, type EngineOffer } from "./engine-offer"
 import {
   ENGINE_BINARY,
@@ -136,6 +147,8 @@ type Overlay = {
   /** The derived entry, or null when the engine is unusable. */
   entry: LocalMcpConfig | null
   refusal: Extract<Outcome, { kind: "engine-missing" | "engine-too-old" }> | null
+  /** The probed engine version when the engine ran; null when it is missing. */
+  version: string | null
 }
 
 /** Per-directory state. Config and MCP state are per project instance, and one
@@ -247,7 +260,7 @@ export async function overlay(
       const entry = engineEntry(workspace.id)
       config.mcp ??= {}
       config.mcp[DATAMATE_KEY] = entry
-      state.current = { directory, workspace, entry, refusal: null }
+      state.current = { directory, workspace, entry, refusal: null, version: probe.version }
       log.info("workspace engine overlay applied", { workspaceId: workspace.id, version: probe.version })
       return
     }
@@ -261,6 +274,7 @@ export async function overlay(
       workspace,
       entry: null,
       refusal: probe.kind === "missing" ? { kind: "engine-missing" } : { kind: "engine-too-old", found: probe.found },
+      version: probe.kind === "missing" ? null : probe.found,
     }
     log.info("workspace engine overlay refused", { workspaceId: workspace.id, reason: probe.kind })
   } catch (err) {
@@ -303,7 +317,14 @@ export async function managedWorkspaceLoaded(
 
 /** `retried`: this session already spent its one re-add on a failed handshake.
  * Per session, so "start a new session to try again" is true. */
-type SessionRecord = { outcome: Outcome; announced?: string; announcedAt?: number; retried?: boolean }
+type SessionRecord = {
+  outcome: Outcome
+  announced?: string
+  announcedAt?: number
+  retried?: boolean
+  /** Signature of the last attach report posted for this session. */
+  reported?: string
+}
 const sessions = new Map<string, SessionRecord>()
 const declaredCache = new Map<string, { value: Declared | null; at: number }>()
 /** Verdict signatures a headless process has already printed to stderr. */
@@ -317,6 +338,7 @@ function record(sessionID: string, outcome: Outcome): SessionRecord {
     announced: previous?.announced,
     announcedAt: previous?.announcedAt,
     retried: previous?.retried,
+    reported: previous?.reported,
   }
   sessions.set(sessionID, next)
   while (sessions.size > MAX_TRACKED_SESSIONS) {
@@ -329,6 +351,34 @@ function record(sessionID: string, outcome: Outcome): SessionRecord {
 
 /** The outcome a session settled at its last turn boundary. A pure read;
  * `undefined` before the first `beforeTurn` for that session. */
+/** Post the settled outcome as this session's attach report, once per
+ * distinct report. Never awaited by the turn: the post is fire-and-forget and
+ * swallows its own failures. */
+function reportOutcome(
+  sessionID: string,
+  binding: ScopedBinding,
+  extras: { engineVersion: string | null; declared: Declared | null; present?: Set<string>; bridgeConnected: boolean },
+): void {
+  const rec = sessions.get(sessionID)
+  const key = bindingKey(binding)
+  if (!rec || !key) return
+  const report = buildAttachReport({
+    outcome: rec.outcome,
+    bindingKey: key,
+    cliVersion: Installation.VERSION,
+    engineVersion: extras.engineVersion,
+    declared: extras.declared,
+    present: extras.present,
+    bridgeConnected: extras.bridgeConnected,
+    reportedAt: new Date(now()).toISOString(),
+  })
+  if (!report) return
+  const signature = attachReportSignature(report)
+  if (rec.reported === signature) return
+  rec.reported = signature
+  void postAttachReport(String(binding.datamateId), report)
+}
+
 export function settledOutcome(sessionID: string): Outcome | undefined {
   return sessions.get(sessionID)?.outcome
 }
@@ -369,7 +419,9 @@ async function refuseUnreadableLink(sessionID: string, state: DirectoryState, er
   record(sessionID, outcome)
   const kept = state.applied?.entry ? "the running engine is kept and " : ""
   await announceRefusal(sessionID, outcome, {
-    title: state.applied ? `Workspace "${state.applied.workspace.name}": link could not be read` : "Workspace link could not be read",
+    title: state.applied
+      ? `Workspace "${state.applied.workspace.name}": link could not be read`
+      : "Workspace link could not be read",
     message: `${outcome.error} (${error}); ${kept}it is read again next turn.`,
     variant: "warning",
   })
@@ -505,7 +557,9 @@ async function reconcile(sessionID: string, directory: string, state: DirectoryS
   // probe memo bounds how often that is asked).
   let reload = state.current
     ? state.current.workspace.key !== boundKey
-    : state.linkUnreadable !== undefined || state.failedAt === undefined || now() - state.failedAt >= FAILED_PROBE_TTL_MS
+    : state.linkUnreadable !== undefined ||
+      state.failedAt === undefined ||
+      now() - state.failedAt >= FAILED_PROBE_TTL_MS
   if (!reload && state.current && !state.current.entry) {
     const probe = await probeEngine()
     reload = probe.kind === "ok"
@@ -517,7 +571,8 @@ async function reconcile(sessionID: string, directory: string, state: DirectoryS
   }
   // The boundary read the binding but the reload could not: the link is
   // flapping, and the reload's verdict is the one the config now reflects.
-  if (!state.current && state.linkUnreadable !== undefined) return refuseUnreadableLink(sessionID, state, state.linkUnreadable)
+  if (!state.current && state.linkUnreadable !== undefined)
+    return refuseUnreadableLink(sessionID, state, state.linkUnreadable)
 
   // A transient overlay failure (its retry is throttled above) keeps what was
   // last applied for this same workspace: a running engine is not released
@@ -540,6 +595,7 @@ async function reconcile(sessionID: string, directory: string, state: DirectoryS
     // Say so, once, rather than settling a bound directory as unbound in silence.
     const outcome: Outcome = { kind: "connect-failed", error: "the workspace engine could not be checked" }
     record(sessionID, outcome)
+    reportOutcome(sessionID, binding, { engineVersion: null, declared: null, bridgeConnected: false })
     await announceRefusal(sessionID, outcome, {
       title: `Workspace "${binding.datamateName}": engine unavailable`,
       message: `${outcome.error}; it is checked again shortly.`,
@@ -575,6 +631,7 @@ async function reconcile(sessionID: string, directory: string, state: DirectoryS
       const outcome: Outcome =
         count === undefined ? { kind: "engine-missing" } : { kind: "engine-missing", declared: count }
       record(sessionID, outcome)
+      reportOutcome(sessionID, binding, { engineVersion: null, declared, bridgeConnected: false })
       const what =
         count === undefined
           ? `Workspace "${workspace.name}" has integration tools that run on the local engine, which is not installed.`
@@ -598,7 +655,13 @@ async function reconcile(sessionID: string, directory: string, state: DirectoryS
       return
     }
     record(sessionID, refusal)
-    const declared = (await declaredFor(workspace))?.keys.length
+    const declaredAll = await declaredFor(workspace)
+    const declared = declaredAll?.keys.length
+    reportOutcome(sessionID, binding, {
+      engineVersion: overlayNow.version,
+      declared: declaredAll,
+      bridgeConnected: false,
+    })
     await announceRefusal(
       sessionID,
       refusal,
@@ -640,6 +703,7 @@ async function reconcile(sessionID: string, directory: string, state: DirectoryS
       error: status?.error ?? `engine status: ${status?.status ?? "unknown"}`,
     }
     record(sessionID, outcome)
+    reportOutcome(sessionID, binding, { engineVersion: overlayNow.version, declared, bridgeConnected: false })
     await announceRefusal(sessionID, outcome, {
       title: `Workspace "${workspace.name}": engine failed to start`,
       message: `${outcome.error}. Start a new session to try again.`,
@@ -672,6 +736,12 @@ async function reconcile(sessionID: string, directory: string, state: DirectoryS
     ...(unfulfilled === undefined ? {} : { unfulfilled }),
   }
   const rec = record(sessionID, outcome)
+  reportOutcome(sessionID, binding, {
+    engineVersion: overlayNow.version,
+    declared,
+    present,
+    bridgeConnected: extServed > 0 || liveBridge(directory),
+  })
   // Keyed on the workspace too: a re-link with an identical inventory is still
   // a new verdict the user should hear.
   // extServed is part of what the user hears, so it is part of the signature:

--- a/packages/opencode/src/altimate/workspace/engine-seams.ts
+++ b/packages/opencode/src/altimate/workspace/engine-seams.ts
@@ -7,6 +7,7 @@ import { Instance } from "@/project/instance"
 import { Log } from "@/altimate/util/log"
 import type { CachedBinding } from "./state"
 import type { Declared, LocalMcpConfig, McpEntry, McpStatus, Toast } from "./engine-types"
+import type { AttachReport } from "./attach-report"
 import type { EngineOffer, InstallResult } from "./engine-offer"
 
 export const log = Log.create({ service: "workspace-engine" })
@@ -19,7 +20,10 @@ export type ScopedBinding = CachedBinding & { scope?: string }
 /** What a binding read established. `failed` is not `unbound`: the link may
  * well exist, it could not be read, and nothing may be handed the key on the
  * strength of that. */
-export type BindingRead = { kind: "bound"; binding: ScopedBinding } | { kind: "unbound" } | { kind: "failed"; error: string }
+export type BindingRead =
+  | { kind: "bound"; binding: ScopedBinding }
+  | { kind: "unbound" }
+  | { kind: "failed"; error: string }
 
 export const syncInternals: {
   resolveBinding?: (directory: string) => Promise<ScopedBinding | null>
@@ -29,6 +33,8 @@ export const syncInternals: {
   declared?: (workspaceId: string) => Promise<Declared | null>
   liveBridge?: (cwd: string) => boolean
   notify?: (toast: Toast) => Promise<void>
+  /** Attach-report sink (see attach-report.ts); production posts through the API client. */
+  reportAttach?: (datamateId: string, report: AttachReport) => Promise<void>
   printLine?: (line: string) => void
   /** Install-offer seams (see engine-offer.ts). */
   offer?: (offer: EngineOffer) => boolean

--- a/packages/opencode/test/altimate/workspace/attach-report.test.ts
+++ b/packages/opencode/test/altimate/workspace/attach-report.test.ts
@@ -1,0 +1,141 @@
+// altimate_change - new file
+import { describe, expect, test } from "bun:test"
+import {
+  attachReportSignature,
+  bindingKey,
+  buildAttachReport,
+  errorCode,
+  sanitizeDetail,
+} from "../../../src/altimate/workspace/attach-report"
+
+const declared = { keys: ["jira_search_issues", "echo", "ghost"], extensionKeys: ["pu_lineage"] }
+const base = {
+  bindingKey: "ssh://git@github.com/acme/jaffle-shop",
+  cliVersion: "0.11.2",
+  engineVersion: "0.7.2",
+  declared,
+  bridgeConnected: false,
+  reportedAt: "2026-09-12T13:50:00.000Z",
+}
+
+describe("bindingKey", () => {
+  test("prefers the git remote, falls back to the path, and is null with neither", () => {
+    expect(bindingKey({ repoRemote: "ssh://a", projectPath: "/p" })).toBe("ssh://a")
+    expect(bindingKey({ repoRemote: null, projectPath: "/p" })).toBe("/p")
+    expect(bindingKey({ repoRemote: "", projectPath: null })).toBeNull()
+  })
+})
+
+describe("sanitizeDetail", () => {
+  test("keeps only a code and, for spawn failures, the command basename", () => {
+    expect(sanitizeDetail("spawn /Users/x/bin/docker ENOENT", "spawn-failed")).toEqual({
+      code: "ENOENT",
+      command: "docker",
+    })
+    expect(sanitizeDetail("spawn C:\\Users\\x\\tools\\gh.exe ENOENT", "spawn-failed")).toEqual({
+      code: "ENOENT",
+      command: "gh.exe",
+    })
+    expect(sanitizeDetail("spawn altimate-e2e-missing-binary ENOENT", "spawn-failed")).toEqual({
+      code: "ENOENT",
+      command: "altimate-e2e-missing-binary",
+    })
+  })
+  test("never forwards free text: paths, hosts and messages collapse to a code", () => {
+    expect(sanitizeDetail("connect ECONNREFUSED 10.0.0.7:8443", "exception")).toEqual({ code: "ECONNREFUSED" })
+    expect(sanitizeDetail("Invalid URL: http://[bad", "spawn-failed")).toEqual({ code: "invalid-url" })
+    expect(sanitizeDetail("token expired for user@corp.example", "invalid-connection")).toEqual({ code: "other" })
+    expect(sanitizeDetail(undefined, "spawn-failed")).toBeUndefined()
+    expect(sanitizeDetail("", "spawn-failed")).toBeUndefined()
+  })
+  test("errorCode maps the recognised patterns", () => {
+    expect(errorCode("Request timed out")).toBe("ETIMEDOUT")
+    expect(errorCode("EACCES: permission denied")).toBe("EACCES")
+    expect(errorCode("boom")).toBe("other")
+  })
+})
+
+describe("buildAttachReport", () => {
+  test("attached: declared vs delivered from the served set, unfulfilled sanitized", () => {
+    const report = buildAttachReport({
+      ...base,
+      outcome: {
+        kind: "attached",
+        available: 1,
+        declared: 3,
+        missing: ["jira_search_issues", "ghost"],
+        unfulfilled: [
+          { key: "jira_search_issues", integrationId: "jira", reason: "invalid-connection" },
+          { key: "ghost", integrationId: "mcp-ok", reason: "unknown-key" },
+          { key: "pu_lineage", integrationId: "vscode-power-user", reason: "no-bridge" },
+          {
+            key: "whatever",
+            integrationId: "mcp-missing-binary",
+            reason: "spawn-failed",
+            detail: "spawn /opt/tools/altimate-e2e-missing-binary ENOENT",
+          },
+        ],
+      },
+      present: new Set(["echo", "altimate_knowledge_search"]),
+    })
+    expect(report).toEqual({
+      binding_key: base.bindingKey,
+      outcome: "attached",
+      cli_version: "0.11.2",
+      engine_version: "0.7.2",
+      bridge_connected: false,
+      declared_keys: ["jira_search_issues", "echo", "ghost", "pu_lineage"],
+      delivered_keys: ["echo"],
+      unfulfilled: [
+        { key: "jira_search_issues", integration_id: "jira", reason: "invalid-connection" },
+        { key: "ghost", integration_id: "mcp-ok", reason: "unknown-key" },
+        { key: "pu_lineage", integration_id: "vscode-power-user", reason: "no-bridge" },
+        {
+          key: "whatever",
+          integration_id: "mcp-missing-binary",
+          reason: "spawn-failed",
+          detail: { code: "ENOENT", command: "altimate-e2e-missing-binary" },
+        },
+      ],
+      reported_at: base.reportedAt,
+    })
+    expect(JSON.stringify(report)).not.toContain("/opt/tools")
+  })
+  test("attached without an allowlist reports what was served as delivered", () => {
+    const report = buildAttachReport({
+      ...base,
+      declared: null,
+      outcome: { kind: "attached", available: 2 },
+      present: new Set(["echo", "dbt_build_model"]),
+    })
+    expect(report?.declared_keys).toEqual([])
+    expect(report?.delivered_keys).toEqual(["echo", "dbt_build_model"])
+  })
+  test("failed outcomes carry the version the CLI saw, or null when the engine is missing", () => {
+    expect(buildAttachReport({ ...base, outcome: { kind: "engine-missing", declared: 3 } })).toMatchObject({
+      outcome: "engine-missing",
+      engine_version: null,
+      declared_keys: declared.keys.concat(declared.extensionKeys),
+      delivered_keys: [],
+    })
+    expect(buildAttachReport({ ...base, outcome: { kind: "engine-too-old", found: "0.7.1" } })).toMatchObject({
+      outcome: "engine-too-old",
+      engine_version: "0.7.1",
+    })
+    expect(buildAttachReport({ ...base, outcome: { kind: "connect-failed", error: "x" } })).toMatchObject({
+      outcome: "connect-failed",
+      engine_version: "0.7.2",
+    })
+  })
+  test("outcomes that are not about the engine produce no report", () => {
+    expect(buildAttachReport({ ...base, outcome: { kind: "disabled" } })).toBeNull()
+    expect(buildAttachReport({ ...base, outcome: { kind: "unbound" } })).toBeNull()
+  })
+  test("the signature ignores the timestamp and changes with the content", () => {
+    const a = buildAttachReport({ ...base, outcome: { kind: "engine-too-old", found: "0.7.1" } })!
+    const b = { ...a, reported_at: "2026-09-12T14:00:00.000Z" }
+    const c = { ...a, engine_version: "0.7.0" }
+    expect(attachReportSignature(a)).toBe(attachReportSignature(b))
+    expect(attachReportSignature(a)).not.toBe(attachReportSignature(c))
+  })
+})

--- a/packages/opencode/test/altimate/workspace/engine-overlay.test.ts
+++ b/packages/opencode/test/altimate/workspace/engine-overlay.test.ts
@@ -28,6 +28,7 @@ import {
   type Toast,
 } from "../../../src/altimate/workspace/engine-overlay"
 import type { ScopedBinding } from "../../../src/altimate/workspace/engine-seams"
+import type { AttachReport } from "../../../src/altimate/workspace/attach-report"
 import { DATAMATE_KEY } from "../../../src/altimate/datamate-transport"
 
 const DIR = "/tmp/analytics"
@@ -52,6 +53,7 @@ type Harness = {
   invalidates: number
   probes: number
   toasts: Toast[]
+  reports: { datamateId: string; report: AttachReport }[]
   lines: string[]
   clock: number
   /** Whether MCP holds a client under the key — set when MCP "bootstraps" from
@@ -94,6 +96,7 @@ function install(opts: {
     invalidates: 0,
     probes: 0,
     toasts: [],
+    reports: [],
     lines: [],
     clock: 1_000_000,
     fingerprint: "bin-1",
@@ -114,6 +117,9 @@ function install(opts: {
       : opts.declared
   syncInternals.notify = async (toast) => {
     h.toasts.push(toast)
+  }
+  syncInternals.reportAttach = async (datamateId, report) => {
+    h.reports.push({ datamateId, report })
   }
   syncInternals.printLine = (line) => {
     h.lines.push(line)
@@ -1014,5 +1020,97 @@ describe("beforeTurn — what a turn boundary does", () => {
     install({ which: null })
     await beforeTurn("s1")
     expect(managedWorkspace()).toEqual({ id: "42", name: "analytics" })
+  })
+})
+
+describe("attach reports — what the session posts when an outcome settles", () => {
+  test("an attached session posts one sanitized report for its binding", async () => {
+    const report = [
+      { key: "dbt_execute_sql", integrationId: "dbt", reason: "invalid-connection" },
+      {
+        key: "gh_list_prs",
+        integrationId: "github-mcp",
+        reason: "spawn-failed",
+        detail: "spawn /Users/ralph/.local/bin/docker ENOENT",
+      },
+    ]
+    const h = install({ meta: { [UNFULFILLED_META_KEY]: report } })
+    await beforeTurn("s1")
+    expect(h.reports).toHaveLength(1)
+    expect(h.reports[0].datamateId).toBe("42")
+    expect(h.reports[0].report).toMatchObject({
+      binding_key: DIR,
+      outcome: "attached",
+      engine_version: "0.7.2",
+      bridge_connected: false,
+      declared_keys: ["dbt_build_model", "dbt_compile_model", "dbt_execute_sql"],
+      delivered_keys: ["dbt_build_model", "dbt_compile_model"],
+      unfulfilled: [
+        { key: "dbt_execute_sql", integration_id: "dbt", reason: "invalid-connection" },
+        {
+          key: "gh_list_prs",
+          integration_id: "github-mcp",
+          reason: "spawn-failed",
+          detail: { code: "ENOENT", command: "docker" },
+        },
+      ],
+    })
+    expect(JSON.stringify(h.reports[0].report)).not.toContain("/Users/ralph")
+    expect(typeof h.reports[0].report.cli_version).toBe("string")
+    expect(h.reports[0].report.reported_at).toBe(new Date(h.clock).toISOString())
+  })
+
+  test("an unchanged outcome does not post again; a changed reason does", async () => {
+    const h = install({
+      meta: { [UNFULFILLED_META_KEY]: [{ key: "gh_list_prs", integrationId: "github-mcp", reason: "spawn-failed" }] },
+    })
+    await beforeTurn("s1")
+    await beforeTurn("s1")
+    expect(h.reports).toHaveLength(1)
+    h.meta = {
+      [UNFULFILLED_META_KEY]: [{ key: "gh_list_prs", integrationId: "github-mcp", reason: "invalid-connection" }],
+    }
+    await beforeTurn("s1")
+    expect(h.reports).toHaveLength(2)
+    expect(h.reports[1].report.unfulfilled[0].reason).toBe("invalid-connection")
+  })
+
+  test("failed attaches post too: too old carries the found version, missing carries null", async () => {
+    const old = install({ version: "0.6.3" })
+    await beforeTurn("s1")
+    expect(old.reports.map((r) => r.report)).toMatchObject([
+      {
+        outcome: "engine-too-old",
+        engine_version: "0.6.3",
+        declared_keys: ["dbt_build_model", "dbt_compile_model", "dbt_execute_sql"],
+        delivered_keys: [],
+      },
+    ])
+    const missing = install({ which: null })
+    await beforeTurn("s2")
+    expect(missing.reports.map((r) => r.report)).toMatchObject([{ outcome: "engine-missing", engine_version: null }])
+  })
+
+  test("an engine that fails to start posts connect-failed", async () => {
+    const h = install({ status: "failed", statusError: "spawn datamate ENOENT" })
+    await beforeTurn("s1")
+    expect(settledOutcome("s1")?.kind).toBe("connect-failed")
+    expect(h.reports.map((r) => r.report.outcome)).toEqual(["connect-failed"])
+  })
+
+  test("nothing is posted for an unbound directory", async () => {
+    const h = install({ binding: null })
+    await beforeTurn("s1")
+    expect(h.reports).toHaveLength(0)
+  })
+
+  test("a failing sink never reaches the turn or the outcome", async () => {
+    const h = install({})
+    syncInternals.reportAttach = async () => {
+      throw new Error("backend down")
+    }
+    await beforeTurn("s1")
+    expect(settledOutcome("s1")?.kind).toBe("attached")
+    expect(h.toasts).toHaveLength(1)
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #1309

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Stacked on the client half of the unfulfilled-keys work (base branch `feat/unfulfilled-keys-meta`); merge that first, then retarget this to `main`.

When a workspace attach settles, the CLI is the only place that knows what the session actually received. This PR posts that as a **session attach report** to the backend's `POST /datamates/{id}/attach-reports` (a new endpoint, not yet deployed anywhere — see verification), so the workspace page can show "your last session received …" and whether a linked project is ready.

- `attach-report.ts` (new): the report shape, `buildAttachReport` (one report per settled outcome: `attached`, `engine-missing`, `engine-too-old`, `connect-failed`; nothing for `disabled`/`unbound`), `attachReportSignature`, and `postAttachReport` (through `AltimateApi.postAttachReport`, guarded: a failure logs once at debug and never throws).
- **Sanitized by construction.** Engine `detail` strings are raw error text and can name paths and hosts. They never leave the machine: `sanitizeDetail` reduces each to `{code}` (`ENOENT`, `EACCES`, `ETIMEDOUT`, `ECONNREFUSED`, `invalid-url`, else `other`) plus, for spawn failures only, the basename of the spawned command (`spawn /Users/x/bin/docker ENOENT` → `{code: "ENOENT", command: "docker"}`). The binding is identified by the git remote or project path the server binding row already holds.
- `engine-overlay.ts`: the probed engine version now rides on the overlay state; `reportOutcome` builds and posts the report at the four terminal sites, once per distinct report per session (signature excludes the timestamp), fire-and-forget — never awaited by the turn. `bridge_connected` is true when a live IDE bridge served extension keys.
- `engine-seams.ts`: `reportAttach` seam so tests capture posts; `api/client.ts`: `postAttachReport`.

#### Claims

- **C1 — Nothing free-text leaves the machine.** Every `detail` is `{code, command?}`; unit tests feed representative engine strings with paths, Windows paths and hosts and assert only the code and a basename survive; the E2E asserts the stored row contains no `spawn ` text.
- **C2 — One post per distinct report.** Same outcome twice → one post; a changed reason or version → another (test).
- **C3 — Failed attaches post too**, with the version the CLI saw (`engine-too-old` carries `found`; `engine-missing` carries null) (tests).
- **C4 — Never on the turn's path.** The post is `void`ed; a sink that throws leaves the outcome and the toast untouched (test).
- **C5 — No post without a binding, the workspace flag, or credentials.** `bindingKey` null → no report; unbound → no report (test); production path checks `AltimateApi.isConfigured()`.

#### Residuals

- **R1** — `connect-failed` posts the outcome but not an error code: the backend row has no field for it yet.
- **R2** — The report is per session signature; a second session on the same project posts its own report, which the backend upserts into the same row (by design).

### How did you verify your code works?

- `bun run typecheck` clean; prettier clean; Marker Guard: no upstream-shared files touched.
- Unit: `test/altimate/workspace/attach-report.test.ts` (11) and six new attach-report cases in `engine-overlay.test.ts`; `test/altimate/workspace` — 81 pass.
- **Real chain, locally.** The backend endpoint exists only on a local `altimate-backend` branch, so per the ticket every E2E runs against that local stack: `uvicorn` on `:5001` with the new migration applied, SuperTokens local, a demo workspace declaring six integrations chosen to produce every reason (an in-house integration served, Jira and a GitHub MCP without connections, an extension integration with no VS Code, an integration removed from the catalog, and a custom MCP pointing at a missing binary). The probe drives the CLI's production attach path (`bootstrap` + `beforeTurn`) with the 0.7.2 release-candidate engine on PATH, then reads the row back through `GET …/attach-reports/latest`. **14/14 checks**, 8063 ms:
  - toast: `2 of 7 declared integration tools available. Declared but not available — no usable connection: jira_get_issue, jira_create_issue, create_branch; no longer in the catalog: retired_tool; server failed to start (spawn altimate-demo-missing-mcp ENOENT): demo_tool.`
  - stored: outcome `attached`, engine `0.7.2`, delivered `['altimate_analyze_snowflake_query', 'altimate_analyze_snowflake_table']`, unfulfilled 7 entries incl. `demo_tool` → `spawn-failed` with detail `{"code": "ENOENT", "command": "altimate-demo-missing-mcp"}` and no raw text; one row per binding.
- This run found and fixed a real defect on both sides: a custom integration's id arrives from the engine as a **number**, and the client parser rejected the whole report as malformed (the attach then announced no gaps at all). The engine now stringifies ids (AltimateAI/altimate-mcp-engine#248, `64e5bb4`) and the client parser accepts a number (`82531540c` on the base branch).

### Screenshots / recordings

Not a UI change; the toast text and the stored row are asserted above.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHBUvb843k1R7UAGi8Ya9b

### Appendix — complexity delta (altimate-code: attach report post)

`82531540c7` → `2cd250d2fe` · only functions this diff touches · advisory, not a gate.

| Function | File | Cognitive | CCN | Status |
|---|---|---|---|---|
| `overlay` L213 | `packages/opencode/src/altimate/workspace/engine-overlay.ts` | 9 → 10 ▲ | 13 → 14 ▲ | easy |
| `buildAttachReport` L91 | `packages/opencode/src/altimate/workspace/attach-report.ts` | new → 4 | new → 11 | new — trivial |
| `reconcile` L516 | `packages/opencode/src/altimate/workspace/engine-overlay.ts` | 64 = | 47 → 50 ▲ | needs decomposition |

**Summary:** 5 touched · 2 rose · 0 improved · 10 new (max cognitive 4) · net cognitive Δ +16

<details><summary>ℹ️ How to read these numbers</summary>

**Cognitive** (Sonar spec) counts breaks in linear reading flow — each `if`/loop/`catch`/ternary/boolean-operator switch adds 1, and nesting makes every further break cost more. It approximates how much you must hold in your head to follow the function: **0–5 trivial · 6–10 easy · 11–15 moderate (15 = Sonar's recommended per-function cap) · 16–25 hard to follow · >25 needs decomposition**.

**CCN** (cyclomatic) counts independent paths — also the minimum number of test cases for full branch coverage of the function.

Only functions this diff touches are measured, as deltas — pre-existing complexity is not counted against this change. Rising numbers aren't automatically wrong; they're where review attention should go. Test files excluded.
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The CLI now posts a sanitized session attach report to `POST /datamates/{id}/attach-reports` when an attach settles; previously, attach details stayed local. This lets the workspace page show what the session received without exposing raw engine errors or changing attach behavior.

- Reports cover `attached`, `engine-missing`, `engine-too-old`, and `connect-failed`; `disabled` and `unbound` produce no report.
- Reports include binding identity, CLI and engine versions, bridge status, declared and delivered keys, and sanitized unfulfilled entries.
- Engine errors become codes, with only the command basename retained for spawn failures.
- Identical reports post once per session; failures log at debug level without affecting the outcome or toast.

**Rollout**

- Merge `feat/unfulfilled-keys-meta` first, then retarget this branch to `main`; verify against the local backend until the endpoint is deployed.
- Closes #1309.

<sup>Written for commit 3d5a784fea79bfd6c60556bedcaac78a2d750fb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AltimateAI/altimate-code/pull/1310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

